### PR TITLE
Ansible script to copy kubectl config to localhost 

### DIFF
--- a/scripts/copy-kubeconfig.yaml
+++ b/scripts/copy-kubeconfig.yaml
@@ -1,0 +1,61 @@
+---
+- hosts: kube-master[0]
+  gather_facts: no
+  become: yes
+  tasks:
+  - fetch:
+      src: "/etc/kubernetes/ssl/{{ item }}.pem"
+      dest: "{{ playbook_dir }}/kubectl/{{ item }}.pem"
+      flat: True
+    with_items:
+      - admin-{{ inventory_hostname }}-key
+      - admin-{{ inventory_hostname }}
+      - ca
+  - name: export hostname
+    set_fact:
+      kubectl_name: "{{ inventory_hostname }}"
+
+- hosts: localhost
+  connection: local
+  vars:
+    kubectl_name: "{{ hostvars[groups['kube-master'][0]].kubectl_name }}"
+    cluster_name: "{{ hostvars[groups['kube-master'][0]].cluster_name }}"
+    kube_apiserver_port: "{{ hostvars[groups['kube-master'][0]].kube_apiserver_port }}"
+    system_namespace: "{{ hostvars[groups['kube-master'][0]].system_namespace }}"
+  tasks:
+  - name: "check if context admin@{{ cluster_name }} exists"
+    command: kubectl config get-contexts admin@{{ cluster_name }}
+    register: kctl
+    failed_when: kctl.rc == 0
+
+  - block:
+    - name: "create cluster {{ cluster_name }}"
+      command: >
+        kubectl config set-cluster {{ cluster_name }}
+        --server=https://{{ kubectl_name }}:{{ kube_apiserver_port }}
+        --certificate-authority={{ playbook_dir }}/kubectl/ca.pem
+        --embed-certs
+
+    - name: "create credentials admin"
+      command: >
+        kubectl config set-credentials admin
+        --certificate-authority={{ playbook_dir }}/kubectl/ca.pem
+        --client-key={{ playbook_dir }}/kubectl/admin-{{ kubectl_name }}-key.pem
+        --client-certificate={{ playbook_dir }}/kubectl/admin-{{ kubectl_name }}.pem
+        --embed-certs
+
+    - name: "create context admin@{{ cluster_name }}"
+      command: >
+        kubectl config set-context admin@{{ cluster_name }}
+        --cluster={{ cluster_name }}
+        --namespace={{ system_namespace }}
+        --user=admin
+
+    - name: "use context admin@{{ cluster_name }}"
+      command: kubectl config use-context admin@{{ cluster_name }}
+    when: kctl.rc != 0
+
+  - name: "clean up fetched certificates"
+    file:
+      state: absent
+      path: "{{ playbook_dir }}/kubectl"


### PR DESCRIPTION
Here is a Ansible script (based on the work by @adamcstephens in #257) to copy certificates and config to Kubernetes apiserver to localhost.

**Run the script**

```
ansible-playbook-i inventory/inventory scripts/copy-kubeconfig.yaml
```

**Resulting kubectl config**

```
apiVersion: v1
clusters:
- cluster:
    certificate-authority-data: REDACTED
    server: https://{{ kube_master_hostname }}:{{ kube_apiserver_port }}
  name: 
contexts:
- context:
    cluster: {{ cluster_name }}
    namespace: {{ system_namespace }}
    user: admin
  name: admin@{{ cluster_name }}
current-context: admin@{{ cluster_name }}
kind: Config
preferences: {}
users:
- name: admin
  user:
    client-certificate-data: REDACTED
    client-key-data: REDACTED
```