### PR TITLE
Compatibility with Ansible 2.2.0.0

### DIFF
--- a/roles/etcd/tasks/pre_upgrade.yml
+++ b/roles/etcd/tasks/pre_upgrade.yml
@@ -33,7 +33,7 @@
 
 - name: "Pre-upgrade | remove etcd-proxy if it exists"
   command: "{{ docker_bin_dir }}/docker rm -f {{item}}"
-  with_items: "{{etcd_proxy_container.stdout_lines}}"
+  with_items: "{{etcd_proxy_container.stdout_lines | default([]) }}"
 
 - name: "Pre-upgrade | see if etcdctl is installed"
   stat:

--- a/roles/vault/tasks/bootstrap/sync_secrets.yml
+++ b/roles/vault/tasks/bootstrap/sync_secrets.yml
@@ -4,7 +4,7 @@
   vars:
     sync_file: "{{ item }}"
     sync_file_dir: "{{ vault_secrets_dir }}"
-    sync_file_hosts: "{{ groups.vault }}"
+    sync_file_hosts: "{{ groups.vault | default([]) }}"
   with_items:
     - root_token
     - unseal_keys

--- a/roles/vault/tasks/bootstrap/sync_vault_certs.yml
+++ b/roles/vault/tasks/bootstrap/sync_vault_certs.yml
@@ -4,7 +4,7 @@
   vars:
     sync_file: "ca.pem"
     sync_file_dir: "{{ vault_cert_dir }}"
-    sync_file_hosts: "{{ groups.vault }}"
+    sync_file_hosts: "{{ groups.vault | default([]) }}"
     sync_file_is_cert: true
 
 - name: bootstrap/sync_vault_certs | Set facts for vault sync_file results
@@ -19,7 +19,7 @@
   vars:
     sync_file: "api.pem"
     sync_file_dir: "{{ vault_cert_dir }}"
-    sync_file_hosts: "{{ groups.vault }}"
+    sync_file_hosts: "{{ groups.vault | default([]) }}"
     sync_file_is_cert: true
 
 - name: bootstrap/sync_vault_certs | Set fact if Vault's API cert is needed
@@ -29,4 +29,3 @@
 - name: bootstrap/sync_vault_certs | Unset sync_file_results after api.pem sync
   set_fact:
     sync_file_results: []
-

--- a/roles/vault/tasks/shared/check_vault.yml
+++ b/roles/vault/tasks/shared/check_vault.yml
@@ -28,4 +28,4 @@
 - name: check_vault | Set fact about the Vault cluster's initialization state
   set_fact:
     vault_cluster_is_initialized: "{{ vault_is_initialized or hostvars[item]['vault_is_initialized'] }}"
-  with_items: "{{ groups.vault }}"
+  with_items: "{{ groups.vault | default([])  }}"

--- a/roles/vault/tasks/shared/find_leader.yml
+++ b/roles/vault/tasks/shared/find_leader.yml
@@ -13,5 +13,5 @@
 - name: find_leader | Set fact for current http leader
   set_fact:
     vault_leader_url: "{{ vault_config.listener.tcp.tls_disable|d()|ternary('http', 'https') }}://{{ item }}:{{ vault_port }}"
-  with_items: "{{ groups.vault }}"
+  with_items: "{{ groups.vault | default([])  }}"
   when: "hostvars[item]['vault_leader_check'].get('status') == 200"

--- a/roles/vault/tasks/shared/sync_auth_certs.yml
+++ b/roles/vault/tasks/shared/sync_auth_certs.yml
@@ -4,7 +4,7 @@
   vars:
     sync_file: "auth-ca.pem"
     sync_file_dir: "{{ vault_cert_dir }}"
-    sync_file_hosts: "{{ groups.vault }}"
+    sync_file_hosts: "{{ groups.vault | default([]) }}"
     sync_file_is_cert: true
 
 - name: shared/sync_auth_certs | Set facts for vault sync_file results


### PR DESCRIPTION
When it is executed with Ansible 2.2.0.0 fails caused by undefined groups or variables. 
```release-note
NONE
```