### PR TITLE
fix curl get calico status error ( error in tls version, centos 7.3 1611)  

### DIFF
--- a/roles/kubernetes/preinstall/defaults/main.yml
+++ b/roles/kubernetes/preinstall/defaults/main.yml
@@ -11,6 +11,7 @@ common_required_pkgs:
   - bash-completion
   - socat
   - unzip
+  - nss
 
 # Set to true if your network does not support IPv6
 # This maybe necessary for pulling Docker images from


### PR DESCRIPTION
curl use nss package to auto negotiate the tls version, but early nss package have issue with tls1.2 protocol.
this can cause curl report following error in kargo install process.

curl: (35) Peer reports incompatible or unsupported protocol version.

how to fix? ensure nss is the latest package.  after install latest nss package, above error disappear.

https://bugzilla.redhat.com/show_bug.cgi?id=1272504

Fixes #2116 