### PR TITLE
Updates to calico rr

### DIFF
--- a/cluster.yml
+++ b/cluster.yml
@@ -57,6 +57,12 @@
     - { role: kargo-defaults}
     - { role: vault, tags: vault, when: "cert_management == 'vault'"}
 
+- hosts: calico-rr
+  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  roles:
+    - { role: kargo-defaults}
+    - { role: network_plugin/calico/rr, tags: network }
+
 - hosts: k8s-cluster
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   roles:
@@ -71,12 +77,6 @@
     - { role: kubernetes/master, tags: master }
     - { role: kubernetes-apps/network_plugin, tags: network }
     - { role: kubernetes-apps/policy_controller, tags: policy-controller }
-
-- hosts: calico-rr
-  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
-  roles:
-    - { role: kargo-defaults}
-    - { role: network_plugin/calico/rr, tags: network }
 
 - hosts: k8s-cluster
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"

--- a/cluster.yml
+++ b/cluster.yml
@@ -45,7 +45,7 @@
     - { role: kargo-defaults}
     - { role: etcd, tags: etcd, etcd_cluster_setup: true }
 
-- hosts: k8s-cluster
+- hosts: etcd:calico-rr:k8s-cluster
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   roles:
     - { role: kargo-defaults}

--- a/roles/etcd/tasks/sync_etcd_master_certs.yml
+++ b/roles/etcd/tasks/sync_etcd_master_certs.yml
@@ -16,6 +16,7 @@
     sync_file_hosts: "{{ groups.etcd }}"
     sync_file_is_cert: true
   with_items: "{{ etcd_master_cert_list|d([]) }}"
+  when: inventory_hostname in groups.etcd
 
 - name: sync_etcd_certs | Set facts for etcd sync_file results
   set_fact:

--- a/roles/network_plugin/calico/rr/meta/main.yml
+++ b/roles/network_plugin/calico/rr/meta/main.yml
@@ -1,6 +1,3 @@
 dependencies:
-  - role: etcd
-  - role: docker
-    when: not ansible_os_family in ["CoreOS", "Container Linux by CoreOS"]
   - role: download
     file: "{{ downloads.calico_rr }}"

--- a/roles/network_plugin/calico/tasks/main.yml
+++ b/roles/network_plugin/calico/tasks/main.yml
@@ -233,7 +233,7 @@
    "metadata": {
      "node": "{{ inventory_hostname.split(".")[0] }}",
      "scope": "node",
-     "peerIP": "{{ hostvars[item]["calico_rr_ip"] | default(hostvars[item]["ip"]) | default(hostvars[item]["ansible_default_ipv4"]["address"]) }}"
+     "peerIP": "{{ hostvars[item]["rr_ip"] }}"
      }
    }'
    | {{ bin_dir }}/calicoctl create --skip-exists -f -
@@ -256,7 +256,7 @@
          peer_with_router|default(false) and inventory_hostname in groups['k8s-cluster'])
 
 - name: Calico (old) | Configure peering with route reflectors
-  shell: "{{ bin_dir }}/calicoctl node bgp peer add {{ hostvars[item]['calico_rr_ip'] | default(hostvars[item]['ip']) | default(hostvars[item]['ansible_default_ipv4']['address'])  }} as {{ local_as | default(global_as_num) }}"
+  shell: "{{ bin_dir }}/calicoctl node bgp peer add {{ hostvars[item]['rr_ip'] }} as {{ local_as | default(global_as_num) }}"
   with_items: "{{ groups['calico-rr'] | default([]) }}"
   when: (legacy_calicoctl and
          peer_with_calico_rr|default(false) and inventory_hostname in groups['k8s-cluster']

--- a/roles/network_plugin/calico/tasks/main.yml
+++ b/roles/network_plugin/calico/tasks/main.yml
@@ -217,7 +217,7 @@
    "kind": "bgpPeer",
    "spec": {"asNumber": "{{ item.as }}"},
    "apiVersion": "v1",
-   "metadata": {"node": "{{ inventory_hostname }}", "scope": "node", "peerIP": "{{ item.router_id }}"}
+   "metadata": {"node": "{{ inventory_hostname.split(".")[0] }}", "scope": "node", "peerIP": "{{ item.router_id }}"}
    }'
    | {{ bin_dir }}/calicoctl create -f -
   with_items: "{{ peers|default([]) }}"
@@ -230,9 +230,11 @@
    "kind": "bgpPeer",
    "spec": {"asNumber": "{{ local_as | default(global_as_num)}}"},
    "apiVersion": "v1",
-   "metadata": {"node": "{{ inventory_hostname }}",
+   "metadata": {
+     "node": "{{ inventory_hostname.split(".")[0] }}",
      "scope": "node",
-     "peerIP": "{{ hostvars[item]["calico_rr_ip"]|default(hostvars[item]["ip"])|default(hostvars[item]["ansible_default_ipv4.address"]) }}"}
+     "peerIP": "{{ hostvars[item]["calico_rr_ip"] | default(hostvars[item]["ip"]) | default(hostvars[item]["ansible_default_ipv4"]["address"]) }}"
+     }
    }'
    | {{ bin_dir }}/calicoctl create --skip-exists -f -
   with_items: "{{ groups['calico-rr'] | default([]) }}"
@@ -254,7 +256,7 @@
          peer_with_router|default(false) and inventory_hostname in groups['k8s-cluster'])
 
 - name: Calico (old) | Configure peering with route reflectors
-  shell: "{{ bin_dir }}/calicoctl node bgp peer add {{ hostvars[item]['calico_rr_ip']|default(hostvars[item]['ip'])|default(hostvars[item]['ansible_default_ipv4.address']) }} as {{ local_as | default(global_as_num) }}"
+  shell: "{{ bin_dir }}/calicoctl node bgp peer add {{ hostvars[item]['calico_rr_ip'] | default(hostvars[item]['ip']) | default(hostvars[item]['ansible_default_ipv4']['address'])  }} as {{ local_as | default(global_as_num) }}"
   with_items: "{{ groups['calico-rr'] | default([]) }}"
   when: (legacy_calicoctl and
          peer_with_calico_rr|default(false) and inventory_hostname in groups['k8s-cluster']

--- a/roles/vault/tasks/shared/sync_file.yml
+++ b/roles/vault/tasks/shared/sync_file.yml
@@ -30,13 +30,14 @@
   register: sync_file_key_stat
   when: sync_file_is_cert|d()
 
+# .get() is used for situations where not all nodes in sync_file_srcs are included in current play
 - name: "sync_file | Combine all possible file sync sources"
   set_fact:
     sync_file_srcs: "{{ sync_file_srcs|default([]) + [host_item] }}"
   with_items: "{{ sync_file_hosts | unique }}"
   loop_control:
     loop_var: host_item
-  when: hostvars[host_item]["sync_file_stat"]["stat"]["exists"]|bool
+  when: hostvars[host_item].get("sync_file_stat", {}).get("stat", {}).get("exists")
 
 - name: "sync_file | Combine all possible key file sync sources"
   set_fact:
@@ -44,22 +45,22 @@
   with_items: "{{ sync_file_hosts | unique }}"
   loop_control:
     loop_var: host_item
-  when: sync_file_is_cert|d() and hostvars[host_item]["sync_file_key_stat"]["stat"]["exists"]|bool
+  when: sync_file_is_cert|d() and hostvars[host_item].get("sync_file_key_stat", {}).get("stat", {}).get("exists")
 
 - name: "sync_file | Remove sync sources with files that do not match sync_file_srcs|first"
   set_fact:
-    _: "{% if inventory_hostname in sync_file_srcs %}{{ sync_file_srcs.remove(inventory_hostname) }}{% endif %}"
+    _: "{{ sync_file_srcs.remove(inventory_hostname) }}"
   when: >-
-        sync_file_srcs|d([])|length > 1 and
+        inventory_hostname in sync_file_srcs|d([]) and
         inventory_hostname != sync_file_srcs|first and
         sync_file_stat.stat.get("checksum") != hostvars[sync_file_srcs|first]["sync_file_stat"]["stat"]["checksum"]
 
 - name: "sync_file | Remove sync sources with keys that do not match sync_file_srcs|first"
   set_fact:
-    _: "{% if inventory_hostname in sync_file_srcs %}{{ sync_file_srcs.remove(inventory_hostname) }}{% endif %}"
+    _: "{{ sync_file_srcs.remove(inventory_hostname) }}"
   when: >-
         sync_file_is_cert|d() and
-        sync_file_key_srcs|d([])|length > 1 and
+        inventory_hostname in sync_file_srcs|d([]) and
         inventory_hostname != sync_file_key_srcs|first and
         sync_file_key_stat.stat.checksum != hostvars[sync_file_srcs|first]["sync_file_key_stat"]["stat"]["checksum"]
 


### PR DESCRIPTION
- Allows calico-rr to be installed on an independent node (one that is not part of k8s-cluster)
- Minor fixes to valut cert generation
- Change the ordering of when RR are installed. This is to allow peering to happen as soon as calico is installed/configured instead of waiting for the RR to be deployed at a later state.
- Consolidated lookups of RR ips, this now happens through `rr_ip` fact