### PR TITLE
Correct etcd data mount path

### DIFF
--- a/roles/etcd/templates/etcd.j2
+++ b/roles/etcd/templates/etcd.j2
@@ -5,7 +5,7 @@
   --net=host \
   -v /etc/ssl/certs:/etc/ssl/certs:ro \
   -v {{ etcd_cert_dir }}:{{ etcd_cert_dir }}:ro \
-  -v {{ etcd_data_dir }}:/var/lib/etcd:rw \
+  -v {{ etcd_data_dir }}:{{ etcd_data_dir }}:rw \
   {% if etcd_memory_limit is defined %}
   --memory={{ etcd_memory_limit|regex_replace('Mi', 'M') }} \
   {% endif %}


### PR DESCRIPTION
If the etcd data path is set to anything other that `/var/lib/etcd`, this mount path is not used, and the etcd data is not persisted. The env file sets `ETCD_DATA_DIR={{ etcd_data_dir }}` so etcd will use the configured path within the container.