### PR TITLE
Add six package install in bootstrap

### DIFF
--- a/roles/bootstrap-os/defaults/main.yml
+++ b/roles/bootstrap-os/defaults/main.yml
@@ -2,3 +2,4 @@
 pypy_version: 2.4.0
 pip_python_modules:
   - httplib2
+  - six


### PR DESCRIPTION
CoreOS installation (and maybe more ?) requires the six package to be installed for dependencies