### PR TITLE
Sync folders on the vagrant machine

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -100,6 +100,10 @@ Vagrant.configure("2") do |config|
         end
       end
 
+      $shared_folders.each do |src, dst|
+        config.vm.synced_folder src, dst
+      end
+
       config.vm.provider :virtualbox do |vb|
         vb.gui = $vm_gui
         vb.memory = $vm_memory


### PR DESCRIPTION
It doesn't look like `$shared_folders` were being used in the `Vagrantfile`:

```
$ ag shared_folders
Vagrantfile
25:$shared_folders = {}
```

Updated `Vagrantfile` so shared folders are being used to share folders between the host and the vagrant machines.