### PR TITLE
Fixed kubelet can't run kube-apiserver when docker stable version

### DIFF
--- a/roles/kubernetes/node/templates/kubelet.j2
+++ b/roles/kubernetes/node/templates/kubelet.j2
@@ -16,9 +16,15 @@ KUBELET_HOSTNAME="--hostname-override={{ ansible_hostname }}"
 {% if kube_version | version_compare('v1.6', '>=') %}
 {# flag got removed with 1.7.0 #}
 {% if kube_version | version_compare('v1.7', '<') %}
+{% if (ansible_os_family not in ["CoreOS", "Container Linux by CoreOS"] and docker_version.stdout | version_compare('17.03.0-ce', '<')) or 
+      (docker_version | version_compare('17.03.0-ce', '<')) %}
 --enable-cri={{ kubelet_enable_cri }} \
 {% endif %}
+{% endif %}
+{% if (ansible_os_family not in ["CoreOS", "Container Linux by CoreOS"] and docker_version.stdout | version_compare('17.03.0-ce', '<')) or 
+      (docker_version | version_compare('17.03.0-ce', '<')) %}
 --cgroups-per-qos={{ kubelet_cgroups_per_qos }} \
+{% endif %}
 --enforce-node-allocatable='{{ kubelet_enforce_node_allocatable }}' {% endif %}{% endset %}
 
 {# DNS settings for kubelet #}


### PR DESCRIPTION
When using docker stable version, kubelet can not run kube-apiserver.