### PR TITLE
Fixing a condition that cause upgrade failure. 

### DIFF
--- a/roles/upgrade/pre-upgrade/tasks/main.yml
+++ b/roles/upgrade/pre-upgrade/tasks/main.yml
@@ -7,11 +7,11 @@
 
 - set_fact:
     needs_cordoning: >-
-      {% if " Ready" in kubectl_nodes.stdout %}
+      {% if " Ready" in kubectl_nodes.stdout -%}
       true
-      {% else %}
+      {%- else -%}
       false
-      {% endif %}
+      {%- endif %}
 
 - name: Cordon node
   command: "{{ bin_dir }}/kubectl cordon {{ inventory_hostname }}"


### PR DESCRIPTION
An error would occur every time ansible pass by this task as "needs_cordoning" is treated as a string " true " which is not boolean! and so next 2 tasks in the same file fail and shows an error