### PR TITLE
Added role dependencies

### DIFF
--- a/roles/docker/meta/main.yml
+++ b/roles/docker/meta/main.yml
@@ -1,0 +1,5 @@
+---
+
+dependencies:
+  - role: bootstrap-os
+

--- a/roles/download/meta/main.yml
+++ b/roles/download/meta/main.yml
@@ -1,0 +1,5 @@
+---
+
+dependencies:
+  - role: docker
+


### PR DESCRIPTION
Other roles (for example vault) could be called using tags (-t flag).
Without roles dependencies they will fail.