### PR TITLE
Custom `etcd_data_dir` saves etcd data to host, not container

### DIFF
--- a/roles/etcd/templates/etcd-rkt.service.j2
+++ b/roles/etcd/templates/etcd-rkt.service.j2
@@ -15,8 +15,8 @@ ExecStart=/usr/bin/rkt run \
 --mount=volume=etc-ssl-certs,target=/etc/ssl/certs \
 --volume=etcd-cert-dir,kind=host,source={{ etcd_cert_dir }},readOnly=true \
 --mount=volume=etcd-cert-dir,target={{ etcd_cert_dir }} \
---volume=var-lib-etcd,kind=host,source={{ etcd_data_dir }},readOnly=false \
---mount=volume=var-lib-etcd,target=/var/lib/etcd \
+--volume=etcd-data-dir,kind=host,source={{ etcd_data_dir }},readOnly=false \
+--mount=volume=etcd-data-dir,target={{ etcd_data_dir }} \
 --set-env-file=/etc/etcd.env \
 --stage1-from-dir=stage1-fly.aci \
 {{ etcd_image_repo }}:{{ etcd_image_tag }} \

--- a/roles/etcd/templates/etcd.env.yml
+++ b/roles/etcd/templates/etcd.env.yml
@@ -1,4 +1,4 @@
-ETCD_DATA_DIR=/var/lib/etcd
+ETCD_DATA_DIR={{ etcd_data_dir }}
 ETCD_ADVERTISE_CLIENT_URLS={{ etcd_client_url }}
 ETCD_INITIAL_ADVERTISE_PEER_URLS={{ etcd_peer_url }}
 ETCD_INITIAL_CLUSTER_STATE={% if etcd_cluster_is_healthy.rc != 0 | bool %}new{% else %}existing{% endif %}

--- a/roles/etcd/templates/etcd.env.yml
+++ b/roles/etcd/templates/etcd.env.yml
@@ -1,4 +1,4 @@
-ETCD_DATA_DIR={{ etcd_data_dir }}
+ETCD_DATA_DIR=/var/lib/etcd
 ETCD_ADVERTISE_CLIENT_URLS={{ etcd_client_url }}
 ETCD_INITIAL_ADVERTISE_PEER_URLS={{ etcd_peer_url }}
 ETCD_INITIAL_CLUSTER_STATE={% if etcd_cluster_is_healthy.rc != 0 | bool %}new{% else %}existing{% endif %}

--- a/roles/etcd/templates/etcd.j2
+++ b/roles/etcd/templates/etcd.j2
@@ -5,7 +5,7 @@
   --net=host \
   -v /etc/ssl/certs:/etc/ssl/certs:ro \
   -v {{ etcd_cert_dir }}:{{ etcd_cert_dir }}:ro \
-  -v {{ etcd_data_dir }}:/var/lib/etcd:rw \
+  -v {{ etcd_data_dir }}:{{ etcd_data_dir }}:rw \
   {% if etcd_memory_limit is defined %}
   --memory={{ etcd_memory_limit|regex_replace('Mi', 'M') }} \
   {% endif %}


### PR DESCRIPTION
In the etcd container, the etcd data directory is always /var/lib/etcd. Reverting to this value, since `etcd_data_dir` on the host maps to `/var/lib/etcd` in the container.

See https://github.com/kubernetes-incubator/kubespray/issues/1376 for details.