### PR TITLE
docker_dns_servers_strict to control docker_dns_servers rtrim

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -83,6 +83,9 @@ bin_dir: /usr/local/bin
 ## Please note that overlay2 is only supported on newer kernels
 #docker_storage_options: -s overlay2
 
+# Uncomment this if you have more than 3 nameservers, then we'll only use the first 3.
+#docker_dns_servers_strict: false
+
 ## Default packages to install within the cluster, f.e:
 #kpm_packages:
 #  - name: kube-system/grafana

--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -8,3 +8,5 @@ docker_repo_key_info:
 
 docker_repo_info:
   repos:
+
+docker_dns_servers_strict: yes

--- a/roles/docker/tasks/set_facts_dns.yml
+++ b/roles/docker/tasks/set_facts_dns.yml
@@ -52,8 +52,13 @@
 
 - name: check number of nameservers
   fail:
-    msg: "Too many nameservers"
-  when: docker_dns_servers|length > 3
+    msg: "Too many nameservers. You can relax this check by set docker_dns_servers_strict=no and we will only use the first 3."
+  when: docker_dns_servers|length > 3 and docker_dns_servers_strict|bool
+
+- name: rtrim number of nameservers to 3
+  set_fact:
+    docker_dns_servers: "{{ docker_dns_servers[0:3] }}"
+  when: docker_dns_servers|length > 3 and not docker_dns_servers_strict|bool
 
 - name: check number of search domains
   fail:


### PR DESCRIPTION
i have 3 nameserver in my /etc/resolv.conf, the max nameservers check will always fail in this case.

add a *docker_dns_servers_strict* to control whether to rtrim docker_dns_servers to 3