### PR TITLE
Make etcd_backup_prefix configurable. 

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -4,9 +4,6 @@ bootstrap_os: none
 #Directory where etcd data stored
 etcd_data_dir: /var/lib/etcd
 
-#Directory where etcd backups are stored on the host
-etcd_backup_prefix: /var/backups
-
 # Directory where the binaries will be installed
 bin_dir: /usr/local/bin
 

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -4,6 +4,9 @@ bootstrap_os: none
 #Directory where etcd data stored
 etcd_data_dir: /var/lib/etcd
 
+#Directory where etcd backups are stored on the host
+etcd_backup_prefix: /var/backups
+
 # Directory where the binaries will be installed
 bin_dir: /usr/local/bin
 

--- a/roles/etcd/defaults/main.yml
+++ b/roles/etcd/defaults/main.yml
@@ -2,6 +2,7 @@
 # Set to false to only do certificate management
 etcd_cluster_setup: true
 
+etcd_backup_prefix: "/var/backups"
 etcd_bin_dir: "{{ local_release_dir }}/etcd/etcd-{{ etcd_version }}-linux-amd64/"
 etcd_data_dir: "/var/lib/etcd"
 

--- a/roles/etcd/handlers/backup.yml
+++ b/roles/etcd/handlers/backup.yml
@@ -3,7 +3,6 @@
   command: /bin/true
   notify:
     - Refresh Time Fact
-    - Set etcd Backup Directory Prefix
     - Set Backup Directory
     - Create Backup Directory
     - Backup etcd v2 data
@@ -12,10 +11,6 @@
 
 - name: Refresh Time Fact
   setup: filter=ansible_date_time
-
-- name: Set etcd Backup Directory Prefix
-  set_fact:
-    etcd_backup_prefix: '/var/backups'
 
 - name: Set Backup Directory
   set_fact:


### PR DESCRIPTION
Ensures that backups can be stored on a different location other than ${HOST}/var/backups, say an EBS volume on AWS.

Addresses this [issue](https://github.com/kubernetes-incubator/kubespray/issues/1375)