### PR TITLE
CI Fixes: turn off coreos updates

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -90,6 +90,7 @@ before_script:
     - pwd
     - ls
     - echo ${PWD}
+    - echo "${STARTUP_SCRIPT}"
     - >
       ansible-playbook tests/cloud_playbooks/create-gce.yml -i tests/local_inventory/hosts.cfg -c local 
       ${LOG_LEVEL}
@@ -103,6 +104,7 @@ before_script:
       -e kube_network_plugin=${KUBE_NETWORK_PLUGIN}
       -e mode=${CLUSTER_MODE}
       -e test_id=${TEST_ID}
+      -e startup_script="'${STARTUP_SCRIPT}'"
 
     # Check out latest tag if testing upgrade
     # Uncomment when gitlab kargo repo has tags
@@ -261,6 +263,8 @@ before_script:
   CLUSTER_MODE: separate
   BOOTSTRAP_OS: coreos
   RESOLVCONF_MODE: host_resolvconf # This is required as long as the CoreOS stable channel uses docker < 1.12
+  ##User-data to simply turn off coreos upgrades
+  STARTUP_SCRIPT: 'systemctl disable locksmithd && systemctl stop locksmithd'
 
 .ubuntu_canal_ha_variables: &ubuntu_canal_ha_variables
 # stage: deploy-gce-part1
@@ -271,6 +275,7 @@ before_script:
   UPGRADE_TEST: "basic"
   CLUSTER_MODE: ha
   UPGRADE_TEST: "graceful"
+  STARTUP_SCRIPT: ""
 
 .rhel7_weave_variables: &rhel7_weave_variables
 # stage: deploy-gce-part1
@@ -278,6 +283,7 @@ before_script:
   CLOUD_IMAGE: rhel-7
   CLOUD_REGION: europe-west1-b
   CLUSTER_MODE: default
+  STARTUP_SCRIPT: ""
 
 .centos7_flannel_variables: &centos7_flannel_variables
 # stage: deploy-gce-part2
@@ -285,13 +291,15 @@ before_script:
   CLOUD_IMAGE: centos-7
   CLOUD_REGION: us-west1-a
   CLUSTER_MODE: default
-
+  STARTUP_SCRIPT: ""
+  
 .debian8_calico_variables: &debian8_calico_variables
 # stage: deploy-gce-part2
   KUBE_NETWORK_PLUGIN: calico
   CLOUD_IMAGE: debian-8-kubespray
   CLOUD_REGION: us-central1-b
   CLUSTER_MODE: default
+  STARTUP_SCRIPT: ""
 
 .coreos_canal_variables: &coreos_canal_variables
 # stage: deploy-gce-part2
@@ -302,6 +310,7 @@ before_script:
   BOOTSTRAP_OS: coreos
   IDEMPOT_CHECK: "true"
   RESOLVCONF_MODE: host_resolvconf # This is required as long as the CoreOS stable channel uses docker < 1.12
+  STARTUP_SCRIPT: 'systemctl disable locksmithd && systemctl stop locksmithd'
 
 .rhel7_canal_sep_variables: &rhel7_canal_sep_variables
 # stage: deploy-gce-special
@@ -309,6 +318,7 @@ before_script:
   CLOUD_IMAGE: rhel-7
   CLOUD_REGION: us-east1-b
   CLUSTER_MODE: separate
+  STARTUP_SCRIPT: ""
 
 .ubuntu_weave_sep_variables: &ubuntu_weave_sep_variables
 # stage: deploy-gce-special
@@ -317,6 +327,7 @@ before_script:
   CLOUD_REGION: us-central1-b
   CLUSTER_MODE: separate
   IDEMPOT_CHECK: "false"
+  STARTUP_SCRIPT: ""
 
 .centos7_calico_ha_variables: &centos7_calico_ha_variables
 # stage: deploy-gce-special
@@ -327,6 +338,7 @@ before_script:
   CLOUD_REGION: europe-west1-b
   CLUSTER_MODE: ha-scale
   IDEMPOT_CHECK: "true"
+  STARTUP_SCRIPT: ""
 
 .coreos_alpha_weave_ha_variables: &coreos_alpha_weave_ha_variables
 # stage: deploy-gce-special
@@ -336,6 +348,7 @@ before_script:
   CLUSTER_MODE: ha-scale
   BOOTSTRAP_OS: coreos
   RESOLVCONF_MODE: host_resolvconf # This is required as long as the CoreOS stable channel uses docker < 1.12
+  STARTUP_SCRIPT: 'systemctl disable locksmithd && systemctl stop locksmithd'
 
 .ubuntu_rkt_sep_variables: &ubuntu_rkt_sep_variables
 # stage: deploy-gce-part1
@@ -345,6 +358,7 @@ before_script:
   CLUSTER_MODE: separate
   ETCD_DEPLOYMENT: rkt
   KUBELET_DEPLOYMENT: rkt
+  STARTUP_SCRIPT: ""
 
 .ubuntu_vault_sep_variables: &ubuntu_vault_sep_variables
 # stage: deploy-gce-part1
@@ -353,6 +367,7 @@ before_script:
   CLOUD_IMAGE: ubuntu-1604-xenial
   CLOUD_REGION: us-central1-b
   CLUSTER_MODE: separate
+  STARTUP_SCRIPT: ""
 
 # Builds for PRs only (premoderated by unit-tests step) and triggers (auto)
 coreos-calico-sep:

--- a/tests/cloud_playbooks/create-gce.yml
+++ b/tests/cloud_playbooks/create-gce.yml
@@ -30,7 +30,7 @@
         credentials_file: "{{gce_credentials_file | default(omit)}}"
         project_id: "{{ gce_project_id }}"
         zone: "{{cloud_region}}"
-        metadata: '{"test_id": "{{test_id}}", "network": "{{kube_network_plugin}}"}'
+        metadata: '{"test_id": "{{test_id}}", "network": "{{kube_network_plugin}}", "startup-script": "{{startup_script}}"}'
         tags: "build-{{test_name}},{{kube_network_plugin}}"
       register: gce
 
@@ -52,5 +52,5 @@
       when: mode in ['scale', 'separate-scale', 'ha-scale']
 
     - name: Wait for SSH to come up
-      wait_for: host={{item.public_ip}} port=22 delay=10 timeout=180 state=started
+      wait_for: host={{item.public_ip}} port=22 delay=30 timeout=180 state=started
       with_items: "{{gce.instance_data}}"


### PR DESCRIPTION
This PR will resolve some of the CI flakiness we've been seeing in our test environment. We were seeing a couple of things:

- CoreOS nodes were rebooting to upgrade. We are now disabling the upgrade daemon with a startup script.
- The 3rd node booted during testing was highly unreliable. Although Ansible was reporting port 22 was open, the box was not yet ready to receive SSH traffic and failed immediately during bootstrap. I've increased the delay before attempting check for SSH to allow some time for the box to be fully online.
