### PR TITLE
Unneded (extra) cycles in some tasks

### DIFF
--- a/roles/etcd/tasks/sync_etcd_master_certs.yml
+++ b/roles/etcd/tasks/sync_etcd_master_certs.yml
@@ -8,6 +8,7 @@
         "member-" + item + ".pem"
         ] }}
   with_items: "{{ groups.etcd }}"
+  run_once: true
 
 - include: ../../vault/tasks/shared/sync_file.yml
   vars: 
@@ -16,6 +17,7 @@
     sync_file_hosts: "{{ groups.etcd }}"
     sync_file_is_cert: true
   with_items: "{{ etcd_master_cert_list|d([]) }}"
+  run_once: true
 
 - name: sync_etcd_certs | Set facts for etcd sync_file results
   set_fact:
@@ -32,6 +34,7 @@
     sync_file: ca.pem
     sync_file_dir: "{{ etcd_cert_dir }}"
     sync_file_hosts: "{{ groups.etcd }}"
+  run_once: true
 
 - name: sync_etcd_certs | Unset sync_file_results after ca.pem sync
   set_fact:

--- a/roles/etcd/tasks/sync_etcd_node_certs.yml
+++ b/roles/etcd/tasks/sync_etcd_node_certs.yml
@@ -4,6 +4,7 @@
   set_fact: 
     etcd_node_cert_list: "{{ etcd_node_cert_list|default([]) +  ['node-' + item + '.pem'] }}"
   with_items: "{{ etcd_node_cert_hosts }}"
+  run_once: true
 
 - include: ../../vault/tasks/shared/sync_file.yml
   vars: 
@@ -12,12 +13,14 @@
     sync_file_hosts: "{{ etcd_node_cert_hosts }}"
     sync_file_is_cert: true
   with_items: "{{ etcd_node_cert_list|d([]) }}"
+  run_once: true
 
 - name: sync_etcd_node_certs | Set facts for etcd sync_file results
   set_fact:
     etcd_node_certs_needed: "{{ etcd_node_certs_needed|default([]) + [item.path] }}"
   with_items: "{{ sync_file_results|d([]) }}"
   when: item.no_srcs|bool
+  run_once: true
 
 - name: sync_etcd_node_certs | Unset sync_file_results after etcd node certs
   set_fact:
@@ -28,6 +31,7 @@
     sync_file: ca.pem
     sync_file_dir: "{{ etcd_cert_dir }}"
     sync_file_hosts: "{{ etcd_node_cert_hosts }}"
+  run_once: true
 
 - name: sync_etcd_node_certs | Unset sync_file_results after ca.pem
   set_fact:

--- a/roles/kubernetes/master/tasks/post-upgrade.yml
+++ b/roles/kubernetes/master/tasks/post-upgrade.yml
@@ -6,6 +6,7 @@
   delegate_to: "{{item}}"
   with_items: "{{groups['kube-master']}}"
   when: needs_etcd_migration|bool
+  run_once: true
 
 - name: "Post-upgrade | Pause for kubelet stop"
   pause:
@@ -19,6 +20,7 @@
   delegate_to: "{{item}}"
   with_items: "{{groups['kube-master']}}"
   when: needs_etcd_migration|bool
+  run_once: true
 
 - name: "Post-upgrade | etcd3 upgrade | purge etcd2 k8s data"
   command: "{{ bin_dir }}/etcdctl --endpoints={{ etcd_access_addresses }} rm -r /registry"

--- a/roles/kubernetes/master/tasks/pre-upgrade.yml
+++ b/roles/kubernetes/master/tasks/pre-upgrade.yml
@@ -79,6 +79,7 @@
     - ["kube-apiserver", "kube-controller-manager", "kube-scheduler"]
   register: kube_apiserver_manifest_replaced
   when: (secret_changed|default(false) or etcd_secret_changed|default(false) or needs_etcd_migration|bool) and kube_apiserver_manifest.stat.exists
+  run_once: true
 
 - name: "Pre-upgrade | etcd3 upgrade | stop etcd"
   service:
@@ -87,6 +88,7 @@
   delegate_to: "{{item}}"
   with_items: "{{groups['etcd']}}"
   when: needs_etcd_migration|bool
+  run_once: true
 
 - name: "Pre-upgrade | etcd3 upgrade | migrate data"
   command: "{{ bin_dir }}/etcdctl migrate --data-dir=\"{{ etcd_data_dir }}\" --wal-dir=\"{{ etcd_data_dir }}/member/wal\""
@@ -96,6 +98,7 @@
   with_items: "{{groups['etcd']}}"
   register: etcd_migrated
   when: needs_etcd_migration|bool
+  run_once: true
 
 - name: "Pre-upgrade | etcd3 upgrade | start etcd"
   service:
@@ -104,3 +107,4 @@
   delegate_to: "{{item}}"
   with_items: "{{groups['etcd']}}"
   when: needs_etcd_migration|bool
+  run_once: true

--- a/roles/vault/tasks/shared/check_vault.yml
+++ b/roles/vault/tasks/shared/check_vault.yml
@@ -29,3 +29,4 @@
   set_fact:
     vault_cluster_is_initialized: "{{ vault_is_initialized or hostvars[item]['vault_is_initialized'] }}"
   with_items: "{{ groups.vault }}"
+  run_once: true

--- a/roles/vault/tasks/shared/find_leader.yml
+++ b/roles/vault/tasks/shared/find_leader.yml
@@ -15,3 +15,6 @@
     vault_leader_url: "{{ vault_config.listener.tcp.tls_disable|d()|ternary('http', 'https') }}://{{ item }}:{{ vault_port }}"
   with_items: "{{ groups.vault }}"
   when: "hostvars[item]['vault_leader_check'].get('status') == 200"
+  run_once: true
+
+- debug: var=vault_leader_url verbosity=2


### PR DESCRIPTION
<!-- Thanks for filing an issue! Before hitting the button, please answer these questions.-->

**Is this a BUG REPORT or FEATURE REQUEST?** (choose one):
BUG

<!--
If this is a BUG REPORT, please:
  - Fill in as much of the template below as you can.  If you leave out
    information, we can't help you as well.

If this is a FEATURE REQUEST, please:
  - Describe *in detail* the feature/behavior/change you'd like to see.

In both cases, be ready for followup questions, and please respond in a timely
manner.  If we can't reproduce a bug or think a feature already exists, we
might close your issue.  If we're wrong, PLEASE feel free to reopen it and
explain why.
-->
There are tasks in kubespray which use iteration via with_items with targets like groups.etcd, groups.vault etc. Such tasks will be run for every target by **every** member of the group doing the same job.
Solution: use run_once for task or rewrite task using add_host for in-memory inventory.
I'm creating this issue as consolidation point for such bugs. PR for already fixed tasks will be provided.