### PR TITLE
"failed_when: false" and "|succeeded" checks for registered vars

### DIFF
--- a/roles/etcd/tasks/configure.yml
+++ b/roles/etcd/tasks/configure.yml
@@ -2,7 +2,7 @@
 - name: Configure | Check if member is in cluster
   shell: "{{ bin_dir }}/etcdctl --no-sync --peers={{ etcd_access_addresses }} member list | grep -q {{ etcd_access_address }}"
   register: etcd_member_in_cluster
-  failed_when: false
+  ignore_errors: true
   changed_when: false
   check_mode: no
   when: is_etcd_master

--- a/roles/etcd/tasks/set_cluster_health.yml
+++ b/roles/etcd/tasks/set_cluster_health.yml
@@ -2,7 +2,7 @@
 - name: Configure | Check if cluster is healthy
   shell: "{{ bin_dir }}/etcdctl --peers={{ etcd_access_addresses }} cluster-health | grep -q 'cluster is healthy'"
   register: etcd_cluster_is_healthy
-  failed_when: false
+  ignore_errors: true
   changed_when: false
   check_mode: no
   when: is_etcd_master

--- a/roles/vault/tasks/shared/check_vault.yml
+++ b/roles/vault/tasks/shared/check_vault.yml
@@ -14,7 +14,7 @@
     headers: "{{ vault_client_headers }}"
     status_code: 200,429,500,501
     validate_certs: no
-  failed_when: false
+  ignore_errors: true
   register: vault_local_service_health
 
 - name: check_vault | Set facts about local Vault health


### PR DESCRIPTION
<!-- Thanks for filing an issue! Before hitting the button, please answer these questions.-->

**Is this a BUG REPORT or FEATURE REQUEST?** (choose one):
BUG
<!--
If this is a BUG REPORT, please:
  - Fill in as much of the template below as you can.  If you leave out
    information, we can't help you as well.

If this is a FEATURE REQUEST, please:
  - Describe *in detail* the feature/behavior/change you'd like to see.

In both cases, be ready for followup questions, and please respond in a timely
manner.  If we can't reproduce a bug or think a feature already exists, we
might close your issue.  If we're wrong, PLEASE feel free to reopen it and
explain why.
-->
Discovered this case in vault role. It maybe also in other roles.
When `failed_when: false` set for task registered variable will be **always** succeeded.
In vault role this caused variable vault_is_running to be always true.
It is better to use ignore_errors for such tasks.