### PR TITLE
added flag for not populating inventory entries to etc hosts file

### DIFF
--- a/roles/kubernetes/preinstall/defaults/main.yml
+++ b/roles/kubernetes/preinstall/defaults/main.yml
@@ -32,7 +32,7 @@ openstack_domain_name: "{{ lookup('env','OS_USER_DOMAIN_NAME')  }}"
 
 # For the vsphere integration, kubelet will need credentials to access
 # vsphere apis
-# Documentation regarting these values can be found 
+# Documentation regarding these values can be found
 # https://github.com/kubernetes/kubernetes/blob/master/pkg/cloudprovider/providers/vsphere/vsphere.go#L105
 vsphere_vcenter_ip: "{{ lookup('env', 'VSPHERE_VCENTER') }}"
 vsphere_vcenter_port: "{{ lookup('env', 'VSPHERE_VCENTER_PORT') }}"
@@ -49,3 +49,6 @@ vsphere_public_network: "{{ lookup('env', 'VSPHERE_PUBLIC_NETWORK')|default('') 
 # Container Linux by CoreOS cloud init config file to define /etc/resolv.conf content
 # for hostnet pods and infra needs
 resolveconf_cloud_init_conf: /etc/resolveconf_cloud_init.conf
+
+# All inventory hostnames will be written into each /etc/hosts file.
+populate_inventory_to_hosts_file: true

--- a/roles/kubernetes/preinstall/tasks/etchosts.yml
+++ b/roles/kubernetes/preinstall/tasks/etchosts.yml
@@ -9,6 +9,7 @@
     create: yes
     backup: yes
     marker: "# Ansible inventory hosts {mark}"
+  when: populate_inventory_to_hosts_file
 
 - name: Hosts | populate kubernetes loadbalancer address into hosts file
   lineinfile:


### PR DESCRIPTION
Sometimes it's not needed or even a problem when the ips of all inventory hostnames got added into the etc hosts file. E.g. we are recreating a cluster in vsphere quite often and the ip addresses are changing then but the inventory file is static because we are using an internal dns for them. This can be solved by updating the ip addresses in the inventory file or with this flag now.