### PR TITLE
Allow calico ipPool to be created with mode "cross-subnet"

### DIFF
--- a/roles/network_plugin/calico/defaults/main.yml
+++ b/roles/network_plugin/calico/defaults/main.yml
@@ -4,6 +4,7 @@ nat_outgoing: true
 
 # Use IP-over-IP encapsulation across hosts
 ipip: false
+ipip_mode: always  # change to "cross-subnet" if you only want ipip encapsulation on traffic going across subnets
 
 # Set to true if you want your calico cni binaries to overwrite the
 # ones from hyperkube while leaving other cni plugins intact.

--- a/roles/network_plugin/calico/tasks/main.yml
+++ b/roles/network_plugin/calico/tasks/main.yml
@@ -94,7 +94,7 @@
   shell: >
     echo '{
     "kind": "ipPool",
-    "spec": {"disabled": false, "ipip": {"enabled": {{ cloud_provider is defined or ipip }}},
+    "spec": {"disabled": false, "ipip": {"enabled": {{ cloud_provider is defined or ipip }}, "mode": "{{ ipip_mode }}"},
              "nat-outgoing": {{ nat_outgoing|default(false) and not peer_with_router|default(false) }}},
     "apiVersion": "v1",
     "metadata": {"cidr": "{{ kube_pods_subnet }}"}


### PR DESCRIPTION
Allow this option so we don't have to pay the penalty of ipip encapsulation when traffic does not go across subnets.

See http://docs.projectcalico.org/v2.3/reference/public-cloud/aws