### PR TITLE
Enhance support for environments behind proxies

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -54,3 +54,7 @@ export AWS_SECRET_ACCESS_KEY="yyyyy"
 export REGION="us-east-2"
 ```
 - We will now create our cluster. There will be either one or two small changes. The first is that we will specify `-i inventory/kubespray-aws-inventory.py` as our inventory script. The other is conditional. If your AWS instances are public facing, you can set the `VPC_VISIBILITY` variable to `public` and that will result in public IP and DNS names being passed into the inventory. This causes your cluster.yml command to look like `VPC_VISIBILITY="public" ansible-playbook ... cluster.yml`
+
+### AWS deployments with proxies ###
+
+If the cluster is deployed in a VPC with `http_proxy` set, make sure to add the ec2 metadata IP to the `no_proxy` variable.

--- a/roles/bootstrap-os/handlers/main.yml
+++ b/roles/bootstrap-os/handlers/main.yml
@@ -1,0 +1,8 @@
+---
+- name: reload systemd
+  shell: systemctl daemon-reload
+
+- name: reload update-engine
+  service:
+    name: update-engine
+    state: restarted

--- a/roles/bootstrap-os/tasks/bootstrap-centos.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-centos.yml
@@ -16,3 +16,4 @@
 
 - name: Install packages requirements for bootstrap
   raw: yum -y install libselinux-python
+  environment: "{{ proxy_env }}"

--- a/roles/bootstrap-os/tasks/bootstrap-coreos.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-coreos.yml
@@ -8,6 +8,7 @@
 - name: Bootstrap | Run bootstrap.sh
   script: bootstrap.sh
   when: (need_bootstrap | failed)
+  environment: "{{ proxy_env }}"
 
 - set_fact:
     ansible_python_interpreter: "/opt/bin/python"
@@ -27,10 +28,12 @@
     src: get-pip.py
     dest: ~/get-pip.py
   when: (need_pip | failed)
+  environment: "{{ proxy_env }}"
 
 - name: Bootstrap | Install pip
   shell: "{{ansible_python_interpreter}} ~/get-pip.py"
   when: (need_pip | failed)
+  environment: "{{ proxy_env }}"
 
 - name: Bootstrap | Remove get-pip.py
   file:
@@ -49,4 +52,17 @@
   pip:
     name: "{{ item }}"
   with_items: "{{pip_python_modules}}"
+  environment: "{{ proxy_env }}"
 
+- name: Create update-engine service systemd drop-in directory
+  file:
+    path: /etc/systemd/system/update-engine.service.d
+    state: directory
+
+- name: Configure proxy for ContainerLinux update-engine
+  template:
+    src: update-engine-proxy.conf.j2
+    dest: "/etc/systemd/system/update-engine.service.d/10-proxy.conf"
+  notify:
+    - reload systemd
+    - reload update-engine

--- a/roles/bootstrap-os/tasks/bootstrap-ubuntu.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-ubuntu.yml
@@ -16,6 +16,7 @@
     DEBIAN_FRONTEND=noninteractive apt-get install -y python-minimal python-pip
   when:
     "{{ need_bootstrap.results | map(attribute='rc') | sort | last | bool }}"
+  environment: "{{ proxy_env }}"
 
 - set_fact:
     ansible_python_interpreter: "/usr/bin/python"

--- a/roles/bootstrap-os/templates/update-engine-proxy.conf.j2
+++ b/roles/bootstrap-os/templates/update-engine-proxy.conf.j2
@@ -1,0 +1,4 @@
+[Service]
+{% for key, value in proxy_env.items() %}
+Environment={{ key }}={{ value }}
+{% endfor %}

--- a/roles/kubernetes-apps/helm/tasks/main.yml
+++ b/roles/kubernetes-apps/helm/tasks/main.yml
@@ -13,6 +13,7 @@
 - name: Helm | Install/upgrade helm
   command: "{{ bin_dir }}/helm init --upgrade --tiller-image={{ tiller_image_repo }}:{{ tiller_image_tag }}"
   when: helm_container.changed
+  environment: "{{ proxy_env }}"
 
 - name: Helm | Set up bash completion
   shell: "umask 022 && {{ bin_dir }}/helm completion bash >/etc/bash_completion.d/helm.sh"

--- a/roles/kubernetes-apps/helm/templates/helm-container.j2
+++ b/roles/kubernetes-apps/helm/templates/helm-container.j2
@@ -2,6 +2,9 @@
 {{ docker_bin_dir }}/docker run --rm \
   --net=host \
   --name=helm \
+{% for key, value in proxy_env.items() %}
+  -e "{{key}}={{value}}" \
+{% endfor %}
   -v /etc/ssl:/etc/ssl:ro \
   -v {{ helm_home_dir }}:{{ helm_home_dir }}:rw \
   {% for dir in ssl_ca_dirs -%}

--- a/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
@@ -110,6 +110,11 @@ spec:
       name: rhel-ca-bundle
       readOnly: true
 {% endif %}
+    env:
+{% for key, value in proxy_env.items() %}
+    - name: {{ key }}
+      value: "{{ value }}"
+{% endfor %}
   volumes:
   - hostPath:
       path: {{ kube_config_dir }}

--- a/roles/kubernetes/master/templates/manifests/kube-controller-manager.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-controller-manager.manifest.j2
@@ -69,6 +69,11 @@ spec:
       name: cloudconfig
       readOnly: true
 {% endif %}
+    env:
+{% for key, value in proxy_env.items() %}
+    - name: {{ key }}
+      value: "{{ value }}"
+{% endfor %}
   volumes:
   - hostPath:
       path: {{ kube_cert_dir }}

--- a/roles/kubernetes/node/templates/kubelet-container.j2
+++ b/roles/kubernetes/node/templates/kubelet-container.j2
@@ -7,6 +7,9 @@
   --restart=on-failure:5 \
   --memory={{ kubelet_memory_limit|regex_replace('Mi', 'M') }} \
   --cpu-shares={{ kubelet_cpu_limit|regex_replace('m', '')  }} \
+{% for key, value in proxy_env.items() %}
+  -e "{{key}}={{value}}" \
+{% endfor %}
   -v /dev:/dev:rw \
   -v /etc/cni:/etc/cni:ro \
   -v /opt/cni:/opt/cni:ro \

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -124,7 +124,7 @@ default_no_proxy_list: |
 proxy_env: "{
 {% if bypass_proxy_for_cluster_hosts %}
 {% set default_no_proxy_list = default_no_proxy_list + ',' + groups['all']|\
-                                                             map('extract', hostvars, ['ip'])|\ ## ansible_default_ipv4.address ?!?
+                                                             map('extract', hostvars, ['ip'])|\
                                                              join(,) %}
 {% endif %}
 {% if http_proxy|d(None) %}

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -116,16 +116,16 @@ efk_enabled: false
 enable_network_policy: false
 
 # Configure proxy environment variable map
-default_no_proxy_list: |
-  127.0.0.1,127.0.1.1,127.1.1.1,localhost,
-  {{kube_service_addresses}},{{kube_pods_subnet}},
-  {{apiserver_loadbalancer_domain_name|default('lb-apiserver.kubernetes.local')}},
-  .{{cluster_name}}
+default_no_proxy_list: "
+  127.0.0.1,127.0.1.1,127.1.1.1,localhost,\
+  {{kube_service_addresses}},{{kube_pods_subnet}},\
+  {{apiserver_loadbalancer_domain_name|default('lb-apiserver.kubernetes.local')}},\
+  .{{cluster_name}}\
+"
+bypass_proxy_for_cluster_hosts: true
 proxy_env: "{
 {% if bypass_proxy_for_cluster_hosts %}
-{% set default_no_proxy_list = default_no_proxy_list + ',' + groups['all']|\
-                                                             map('extract', hostvars, ['ip'])|\
-                                                             join(,) %}
+{% set default_no_proxy_list = default_no_proxy_list+','+groups['all']|map('extract',hostvars,['ip'])|join(',') %}
 {% endif %}
 {% if http_proxy|d(None) %}
 {% for key in ('http_proxy', 'HTTP_PROXY') %}

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -116,12 +116,12 @@ efk_enabled: false
 enable_network_policy: false
 
 # Configure proxy environment variable map
-default_no_proxy_list: "
+default_no_proxy_list: "\
   127.0.0.1,127.0.1.1,127.1.1.1,localhost,\
   {{kube_service_addresses}},{{kube_pods_subnet}},\
   {{apiserver_loadbalancer_domain_name|default('lb-apiserver.kubernetes.local')}},\
-  .{{cluster_name}}\
-"
+  .{{cluster_name}}"
+
 bypass_proxy_for_cluster_hosts: true
 proxy_env: "{
 {% if bypass_proxy_for_cluster_hosts %}

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -116,7 +116,17 @@ efk_enabled: false
 enable_network_policy: false
 
 # Configure proxy environment variable map
+default_no_proxy_list: |
+  127.0.0.1,127.0.1.1,127.1.1.1,localhost,
+  {{kube_service_addresses}},{{kube_pods_subnet}},
+  {{apiserver_loadbalancer_domain_name|default('lb-apiserver.kubernetes.local')}},
+  .{{cluster_name}}
 proxy_env: "{
+{% if bypass_proxy_for_cluster_hosts %}
+{% set default_no_proxy_list = default_no_proxy_list + ',' + groups['all']|\
+                                                             map('extract', hostvars, ['ip'])|\ ## ansible_default_ipv4.address ?!?
+                                                             join(,) %}
+{% endif %}
 {% if http_proxy|d(None) %}
 {% for key in ('http_proxy', 'HTTP_PROXY') %}
   '{{ key }}': '{{ http_proxy }}',
@@ -132,9 +142,9 @@ proxy_env: "{
   '{{ key }}': '{{ https_proxy|default(None) }}',
 {% endfor %}
 {% endif %}
-{% if no_proxy|d(None) %}
+{% if http_proxy|d(None) or https_proxy|d(None) %}
 {% for key in ('no_proxy', 'NO_PROXY') %}
-  '{{ key }}': '{{ no_proxy }}',
+  '{{ key }}': '{{ default_no_proxy_list }},{{ no_proxy }}',
 {% endfor %}
 {% endif %}
 }"

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -114,3 +114,27 @@ vault_deployment_type: docker
 k8s_image_pull_policy: IfNotPresent
 efk_enabled: false
 enable_network_policy: false
+
+# Configure proxy environment variable map
+proxy_env: "{
+{% if http_proxy|d(None) %}
+{% for key in ('http_proxy', 'HTTP_PROXY') %}
+  '{{ key }}': '{{ http_proxy }}',
+{% endfor %}
+{% endif %}
+{% if https_proxy|d(None) %}
+{% for key in ('https_proxy', 'HTTPS_PROXY') %}
+  '{{ key }}': '{{ https_proxy }}',
+{% endfor %}
+{% endif %}
+{% if http_proxy|d(None) and https_proxy|d(None) and http_proxy == https_proxy  %}
+{% for key in ('all_proxy', 'ALL_PROXY') %}
+  '{{ key }}': '{{ https_proxy|default(None) }}',
+{% endfor %}
+{% endif %}
+{% if no_proxy|d(None) %}
+{% for key in ('no_proxy', 'NO_PROXY') %}
+  '{{ key }}': '{{ no_proxy }}',
+{% endfor %}
+{% endif %}
+}"


### PR DESCRIPTION
It's generally safe to assume that if the k8s cluster is configured to use HTTP(s) proxies, then the provisioning environment must use them as well. This PR will make sure that any tasks requiring internet access will be provided the correct proxy configuration via environment variables.

