### PR TITLE
make sure every instance is a node if user changed defaults

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,8 +30,6 @@ $os = "ubuntu"
 $etcd_instances = $num_instances
 # The first two nodes are masters
 $kube_master_instances = $num_instances == 1 ? $num_instances : ($num_instances - 1)
-# All nodes are kube nodes
-$kube_node_instances = $num_instances
 $local_release_dir = "/vagrant/temp"
 
 host_vars = {}
@@ -39,6 +37,9 @@ host_vars = {}
 if File.exist?(CONFIG)
   require CONFIG
 end
+
+# All nodes are kube nodes
+$kube_node_instances = $num_instances
 
 $box = SUPPORTED_OS[$os][:box]
 # if $inventory is not set, try to use example


### PR DESCRIPTION
If user added for exmaple $num_instances=4 to config.rb , number of nodes will stay 3 as per default, with this update it will make sure it assign kube_node_instances after looking at config.rb. 