### PR TITLE
Explicitly defines the --kubelet-preferred-address-types parameter.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,8 +30,6 @@ $os = "ubuntu"
 $etcd_instances = $num_instances
 # The first two nodes are masters
 $kube_master_instances = $num_instances == 1 ? $num_instances : ($num_instances - 1)
-# All nodes are kube nodes
-$kube_node_instances = $num_instances
 $local_release_dir = "/vagrant/temp"
 
 host_vars = {}
@@ -39,6 +37,9 @@ host_vars = {}
 if File.exist?(CONFIG)
   require CONFIG
 end
+
+# All nodes are kube nodes
+$kube_node_instances = $num_instances
 
 $box = SUPPORTED_OS[$os][:box]
 # if $inventory is not set, try to use example

--- a/roles/kubernetes/master/defaults/main.yml
+++ b/roles/kubernetes/master/defaults/main.yml
@@ -62,6 +62,9 @@ kube_oidc_auth: false
 ##Variables for custom flags
 apiserver_custom_flags: []
 
+# List of the preferred NodeAddressTypes to use for kubelet connections.
+kubelet_preferred_address_types: 'InternalDNS,InternalIP,Hostname,ExternalDNS,ExternalIP'
+
 controller_mgr_custom_flags: []
 
 scheduler_custom_flags: []

--- a/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
@@ -37,6 +37,7 @@ spec:
     - --service-cluster-ip-range={{ kube_service_addresses }}
     - --service-node-port-range={{ kube_apiserver_node_port_range }}
     - --client-ca-file={{ kube_cert_dir }}/ca.pem
+    - --kubelet-preferred-address-types={{ kubelet_preferred_address_types }}
 {% if kube_basic_auth|default(true) %}
     - --basic-auth-file={{ kube_users_dir }}/known_users.csv
 {% endif %}

--- a/roles/kubernetes/node/templates/kubelet.j2
+++ b/roles/kubernetes/node/templates/kubelet.j2
@@ -16,7 +16,6 @@ KUBELET_HOSTNAME="--hostname-override={{ ansible_hostname }}"
 {% if kube_version | version_compare('v1.6', '>=') %}
 {# flag got removed with 1.7.0 #}
 {% if kube_version | version_compare('v1.7', '<') %}
---enable-cri={{ kubelet_enable_cri }} {% endif %}
 --enable-cri={{ kubelet_enable_cri }} --cgroups-per-qos={{ kubelet_cgroups_per_qos }} \
 --enforce-node-allocatable='{{ kubelet_enforce_node_allocatable }}' {% endif %}{% endset %}
 

--- a/roles/kubernetes/node/templates/kubelet.j2
+++ b/roles/kubernetes/node/templates/kubelet.j2
@@ -13,7 +13,7 @@ KUBELET_HOSTNAME="--hostname-override={{ ansible_hostname }}"
 --pod-infra-container-image={{ pod_infra_image_repo }}:{{ pod_infra_image_tag }} \
 --kube-reserved cpu={{ kubelet_cpu_limit }},memory={{ kubelet_memory_limit|regex_replace('Mi', 'M') }} \
 --node-status-update-frequency={{ kubelet_status_update_frequency }} \
-{% if kube_version | version_compare('v1.6', '>=') %}
+{% if kube_version | version_compare('v1.7', '>=') %}
 --enable-cri={{ kubelet_enable_cri }} --cgroups-per-qos={{ kubelet_cgroups_per_qos }} \
 --enforce-node-allocatable='{{ kubelet_enforce_node_allocatable }}' {% endif %}{% endset %}
 

--- a/roles/kubernetes/node/templates/kubelet.j2
+++ b/roles/kubernetes/node/templates/kubelet.j2
@@ -16,7 +16,9 @@ KUBELET_HOSTNAME="--hostname-override={{ ansible_hostname }}"
 {% if kube_version | version_compare('v1.6', '>=') %}
 {# flag got removed with 1.7.0 #}
 {% if kube_version | version_compare('v1.7', '<') %}
---enable-cri={{ kubelet_enable_cri }} --cgroups-per-qos={{ kubelet_cgroups_per_qos }} \
+--enable-cri={{ kubelet_enable_cri }} \
+{% endif %}
+--cgroups-per-qos={{ kubelet_cgroups_per_qos }} \
 --enforce-node-allocatable='{{ kubelet_enforce_node_allocatable }}' {% endif %}{% endset %}
 
 {# DNS settings for kubelet #}

--- a/roles/kubernetes/node/templates/kubelet.j2
+++ b/roles/kubernetes/node/templates/kubelet.j2
@@ -13,7 +13,10 @@ KUBELET_HOSTNAME="--hostname-override={{ ansible_hostname }}"
 --pod-infra-container-image={{ pod_infra_image_repo }}:{{ pod_infra_image_tag }} \
 --kube-reserved cpu={{ kubelet_cpu_limit }},memory={{ kubelet_memory_limit|regex_replace('Mi', 'M') }} \
 --node-status-update-frequency={{ kubelet_status_update_frequency }} \
-{% if kube_version | version_compare('v1.7', '>=') %}
+{% if kube_version | version_compare('v1.6', '>=') %}
+{# flag got removed with 1.7.0 #}
+{% if kube_version | version_compare('v1.7', '<') %}
+--enable-cri={{ kubelet_enable_cri }} {% endif %}
 --enable-cri={{ kubelet_enable_cri }} --cgroups-per-qos={{ kubelet_cgroups_per_qos }} \
 --enforce-node-allocatable='{{ kubelet_enforce_node_allocatable }}' {% endif %}{% endset %}
 


### PR DESCRIPTION
If publicly non-resolvable node names are used, then using the scale.yml playbook to scale the cluster to add new nodes causes a problem where kubectl stops working for newly added nodes. It attempts to contact the nodes by resolving their node names against whatever public DNS is set up (for example, Google's DNS), and then fails. By explicitly defining the kubelet-preferred-address-types parameter to define an order of mechanisms by which to determine the address of nodes, this problem can be solved easily. 