### PR TITLE
add possibility to ignore the hostname override

### DIFF
--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -57,3 +57,6 @@ kubelet_custom_flags: []
 ## Empty vaule for quay.io containers
 ## docker for docker registry containers
 kube_hyperkube_image_repo: ""
+
+# If non-empty, will use this string as identification instead of the actual hostname
+kube_override_hostname: "{{ ansible_hostname }}"

--- a/roles/kubernetes/node/templates/kubelet.j2
+++ b/roles/kubernetes/node/templates/kubelet.j2
@@ -6,8 +6,9 @@ KUBELET_ADDRESS="--address={{ ip | default("0.0.0.0") }}"
 # The port for the info server to serve on
 # KUBELET_PORT="--port=10250"
 # You may leave this blank to use the actual hostname
-KUBELET_HOSTNAME="--hostname-override={{ ansible_hostname }}"
-
+{% if kube_override_hostname %}
+KUBELET_HOSTNAME="--hostname-override={{ kube_override_hostname }}"
+{% endif %}
 {# Base kubelet args #}
 {% set kubelet_args_base %}--pod-manifest-path={{ kube_manifest_dir }} \
 --pod-infra-container-image={{ pod_infra_image_repo }}:{{ pod_infra_image_tag }} \


### PR DESCRIPTION
Background: the vsphere cloud plugin changes the hostname in kubelet to the system hostname. When upgrading a cluster this means that the node will not register itself to the cluster again since the name has changed now. 
I do not see a good way to change directly the vpshere cloud provider behaviour, so I introduce this flag which can be used to set the name to whatever is wanted. In case it's empty, the system hostname will be taken from kubelet (default).
Default in the role is still ansible_hostname to be backward compatible.