### PR TITLE
Bump Calico CNI Plugin to 1.8.0

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -23,7 +23,7 @@ etcd_version: v3.0.17
 #TODO(mattymo): Move calico versions to roles/network_plugins/calico/defaults
 # after migration to container download
 calico_version: "v1.1.3"
-calico_cni_version: "v1.7.0"
+calico_cni_version: "v1.8.0"
 calico_policy_version: "v0.5.4"
 weave_version: 1.8.2
 flannel_version: v0.6.2


### PR DESCRIPTION
This aligns calico component versions with Calico release 2.1.5 and
fixes an issue with nodes being unable to schedule existing workloads
as per [#349](https://github.com/projectcalico/cni-plugin/issues/349)