### PR TITLE
set loadbalancer_apiserver_localhost default true

### DIFF
--- a/roles/kubernetes/preinstall/tasks/set_facts.yml
+++ b/roles/kubernetes/preinstall/tasks/set_facts.yml
@@ -20,7 +20,7 @@
 
 - set_fact:
     kube_apiserver_endpoint: |-
-      {% if not is_kube_master and loadbalancer_apiserver_localhost|default(false) -%}
+      {% if not is_kube_master and loadbalancer_apiserver_localhost|default(true) -%}
            https://localhost:{{ nginx_kube_apiserver_port|default(kube_apiserver_port) }}
       {%- elif is_kube_master -%}
            http://127.0.0.1:{{ kube_apiserver_insecure_port }}


### PR DESCRIPTION
to match this https://github.com/kubernetes-incubator/kubespray/blob/master/roles/kubernetes/node/tasks/main.yml#L20
and the documented behaviour in HA docs 
related to #1456
@rsmitty