### PR TITLE
Add etcd metrics flag

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -101,3 +101,6 @@ kernel_upgrade: false
 
 ## Etcd auto compaction retention for mvcc key value store in hour
 #etcd_compaction_retention: 0
+
+## Set level of detail for etcd exported metrics, specify 'extensive' to include histogram metrics.
+#etcd_metrics: basic

--- a/roles/etcd/defaults/main.yml
+++ b/roles/etcd/defaults/main.yml
@@ -15,6 +15,8 @@ etcd_script_dir: "{{ bin_dir }}/etcd-scripts"
 etcd_heartbeat_interval: "250"
 etcd_election_timeout: "5000"
 
+etcd_metrics: "basic"
+
 # Limits
 etcd_memory_limit: 512M
 

--- a/roles/etcd/templates/etcd.env.yml
+++ b/roles/etcd/templates/etcd.env.yml
@@ -3,6 +3,7 @@ ETCD_ADVERTISE_CLIENT_URLS={{ etcd_client_url }}
 ETCD_INITIAL_ADVERTISE_PEER_URLS={{ etcd_peer_url }}
 ETCD_INITIAL_CLUSTER_STATE={% if etcd_cluster_is_healthy.rc != 0 | bool %}new{% else %}existing{% endif %}
 
+ETCD_METRICS={{ etcd_metrics }}
 ETCD_LISTEN_CLIENT_URLS=https://{{ etcd_address }}:2379,https://127.0.0.1:2379
 ETCD_ELECTION_TIMEOUT={{ etcd_election_timeout }}
 ETCD_HEARTBEAT_INTERVAL={{ etcd_heartbeat_interval }}


### PR DESCRIPTION
This allows users to set etcd metrics flag to `extensive` to include histogram metrics which are required for monitoring etcd performance.