### PR TITLE
add newline after expanding user information

### DIFF
--- a/roles/kubernetes/secrets/templates/known_users.csv.j2
+++ b/roles/kubernetes/secrets/templates/known_users.csv.j2
@@ -1,3 +1,4 @@
 {% for user in kube_users %}
 {{kube_users[user].pass}},{{user}},{{kube_users[user].role}}{% if kube_users[user].groups is defined %},{% set groups_csv = kube_users[user].groups|join(',') -%}"{{groups_csv}}"{% endif %}
+
 {% endfor %}


### PR DESCRIPTION
in PR 1447, when using multiple users a newline was not put in. 