### PR TITLE
FIX: elrepo-release moved to v7.0.3

### DIFF
--- a/roles/kernel-upgrade/defaults/main.yml
+++ b/roles/kernel-upgrade/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 
 elrepo_key_url: 'https://www.elrepo.org/RPM-GPG-KEY-elrepo.org'
-elrepo_rpm : elrepo-release-7.0-2.el7.elrepo.noarch.rpm
+elrepo_rpm : elrepo-release-7.0-3.el7.elrepo.noarch.rpm
 elrepo_mirror : http://www.elrepo.org
 
 elrepo_url : '{{elrepo_mirror}}/{{elrepo_rpm}}'


### PR DESCRIPTION
7.0.2 version produces hard error `raise rpm.error(\"error reading package header\")\r\n_rpm.error: error reading package header\r\n", "msg": "MODULE FAILURE"` in ansible now.