### PR TITLE
fix etcd health check bug

### DIFF
--- a/roles/vault/tasks/shared/check_etcd.yml
+++ b/roles/vault/tasks/shared/check_etcd.yml
@@ -4,6 +4,7 @@
   uri:
     url: "{{ vault_etcd_url }}/health"
     validate_certs: no
+    return_content: yes
   until: vault_etcd_health_check.status == 200 or vault_etcd_health_check.status == 401
   retries: 10
   delay: 2
@@ -14,7 +15,9 @@
 
 - name: check_etcd | Set fact based off the etcd_health_check response
   set_fact:
-    vault_etcd_available: "{{ vault_etcd_health_check.get('json', {}).get('health')|bool  }}"
+    vault_etcd_available: "{{ vault_etcd_health_check.content  }}"
+- set_fact:
+    vault_etcd_available: "{{ vault_etcd_available.health|d()|bool }}"
 
 - name: check_etcd | Fail if etcd is not available and needed
   fail:


### PR DESCRIPTION
I checked etcd v3.0.17 as REDEME said and the response's content type was `text/plain` so there is no `json` attribute in `vault_etcd_health_check` fact.