### PR TITLE
Verify if br_netfilter module exists

### DIFF
--- a/roles/network_plugin/weave/tasks/main.yml
+++ b/roles/network_plugin/weave/tasks/main.yml
@@ -4,10 +4,17 @@
 - include: seed.yml
   when: weave_mode_seed
 
-- name: Weave | enable br_netfilter module
+- name: Weave | Verify if br_netfilter module exists
+  shell: "modinfo br_netfilter"
+  register: modinfo_br_netfilter
+  failed_when: modinfo_br_netfilter.rc not in [0, 1]
+  changed_when: false
+
+- name: Weave | Enable br_netfilter module
   modprobe:
     name: br_netfilter
     state: present
+  when: modinfo_br_netfilter.rc == 0
 
 - name: Weave | Copy cni plugins from hyperkube
   command: "{{ docker_bin_dir }}/docker run --rm -v /opt/cni/bin:/cnibindir {{ hyperkube_image_repo }}:{{ hyperkube_image_tag }} /bin/cp -r /opt/cni/bin/. /cnibindir/"


### PR DESCRIPTION
Fixed #1272

In the installation process of Weave network plugin, `br_netfilter` module is loaded unconditionally. (#1152)
When `br_netfilter` module is built-in to the kernel and not a loadable kernel module, the installation process fails.

I added a task to verify whether `br_netfilter` is a loadable kernel module.