### PR TITLE
Add calico variable that enables ignoring Kernel's RPF Setting

### DIFF
--- a/docs/calico.md
+++ b/docs/calico.md
@@ -161,3 +161,11 @@ Cloud providers configuration
 =============================
 
 Please refer to the official documentation, for example [GCE configuration](http://docs.projectcalico.org/v1.5/getting-started/docker/installation/gce) requires a security rule for calico ip-ip tunnels. Note, calico is always configured with ``ipip: true`` if the cloud provider was defined.
+
+##### Optional : Ignore kernel's RPF check setting
+
+By default the felix agent(calico-node) will abort if the Kernel RPF setting is not 'strict'. If you want Calico to ignore the Kernel setting:
+
+```
+calico_node_ignorelooserpf: true
+```

--- a/roles/network_plugin/calico/defaults/main.yml
+++ b/roles/network_plugin/calico/defaults/main.yml
@@ -30,3 +30,7 @@ calicoctl_memory_limit: 170M
 calicoctl_cpu_limit: 100m
 calicoctl_memory_requests: 32M
 calicoctl_cpu_requests: 50m
+
+# Should calico ignore kernel's RPF check setting,
+# see https://github.com/projectcalico/felix/blob/ab8799eaea66627e5db7717e62fca61fd9c08646/python/calico/felix/config.py#L198
+calico_node_ignorelooserpf: false

--- a/roles/network_plugin/calico/templates/calico-node.service.j2
+++ b/roles/network_plugin/calico/templates/calico-node.service.j2
@@ -20,6 +20,9 @@ ExecStart={{ docker_bin_dir }}/docker run --net=host --privileged \
  -e ETCD_CA_CERT_FILE=${ETCD_CA_CERT_FILE} \
  -e ETCD_CERT_FILE=${ETCD_CERT_FILE} \
  -e ETCD_KEY_FILE=${ETCD_KEY_FILE} \
+{% if calico_node_ignorelooserpf %}
+ -e FELIX_IGNORELOOSERPF=true \
+{% endif %}
  -v /var/log/calico:/var/log/calico \
  -v /run/docker/plugins:/run/docker/plugins \
  -v /lib/modules:/lib/modules \


### PR DESCRIPTION
Adds a var `calico_node_ignorelooserpf` with default behavior same as existing.

Fixes https://github.com/kubernetes-incubator/kubespray/issues/1498