### PR TITLE
 no need to set Flannel etcd configuration when we add a node

### DIFF
--- a/roles/network_plugin/canal/tasks/main.yml
+++ b/roles/network_plugin/canal/tasks/main.yml
@@ -29,8 +29,7 @@
     {{ bin_dir }}/etcdctl --peers={{ etcd_access_addresses }} \
     set /{{ cluster_name }}/network/config \
     '{ "Network": "{{ kube_pods_subnet }}", "SubnetLen": {{ kube_network_node_prefix }}, "Backend": { "Type": "{{ flannel_backend_type }}" } }'
-  delegate_to: "{{groups['etcd'][0]}}"
-  run_once: true
+  when: inventory_hostname == groups['etcd'][0]
 
 - name: Canal | Write canal configmap
   template:

--- a/roles/network_plugin/flannel/tasks/main.yml
+++ b/roles/network_plugin/flannel/tasks/main.yml
@@ -4,8 +4,7 @@
     {{ bin_dir }}/etcdctl --peers={{ etcd_access_addresses }} \
     set /{{ cluster_name }}/network/config \
     '{ "Network": "{{ kube_pods_subnet }}", "SubnetLen": {{ kube_network_node_prefix }}, "Backend": { "Type": "{{ flannel_backend_type }}" } }'
-  delegate_to: "{{groups['etcd'][0]}}"
-  run_once: true
+  when: inventory_hostname == groups['etcd'][0]
 
 - name: Flannel | Create flannel certs directory
   file:


### PR DESCRIPTION
when we add a node  by --limit  to a cluster , this task is redundant , so I use `when: inventory_hostname == groups['etcd'][0]` to skip it. 