### PR TITLE
Add to network plugins documentation - README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ in order to avoid any issue during deployment you should disable your firewall.
 
 
 ## Network plugins
-You can choose between 4 network plugins. (default: `calico`)
+
+You can choose between 4 network plugins. (default: `calico`, except Vagrant uses `flannel`)
 
 * [**flannel**](docs/flannel.md): gre/vxlan (layer 2) networking.
 


### PR DESCRIPTION
Tiny fix for README.md, is a little confusing when you try to look for calico on the vagrant and nothing is there. 