### PR TITLE
Configurable docker yum repos, systemd fix

### DIFF
--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -10,3 +10,6 @@ docker_repo_info:
   repos:
 
 docker_dns_servers_strict: yes
+
+docker_rh_repo_base_url: 'https://yum.dockerproject.org/repo/main/centos/7'
+docker_rh_repo_gpgkey: 'https://yum.dockerproject.org/gpg'

--- a/roles/docker/tasks/systemd.yml
+++ b/roles/docker/tasks/systemd.yml
@@ -10,11 +10,17 @@
     dest: /etc/systemd/system/docker.service.d/http-proxy.conf
   when: http_proxy is defined or https_proxy is defined or no_proxy is defined
 
+- name: get systemd version
+  command: rpm -q --qf '%{V}\n' systemd
+  register: systemd_version
+  when: not (ansible_os_family in ["CoreOS", "Container Linux by CoreOS"] or is_atomic)
+
 - name: Write docker.service systemd file
   template:
     src: docker.service.j2
     dest: /etc/systemd/system/docker.service
   register: docker_service_file
+  notify: restart docker
   when: not (ansible_os_family in ["CoreOS", "Container Linux by CoreOS"] or is_atomic)
 
 - name: Write docker.service systemd file for atomic

--- a/roles/docker/tasks/systemd.yml
+++ b/roles/docker/tasks/systemd.yml
@@ -13,7 +13,7 @@
 - name: get systemd version
   command: rpm -q --qf '%{V}\n' systemd
   register: systemd_version
-  when: not (ansible_os_family in ["CoreOS", "Container Linux by CoreOS"] or is_atomic)
+  when: ansible_os_family == "RedHat" and not is_atomic
 
 - name: Write docker.service systemd file
   template:

--- a/roles/docker/tasks/systemd.yml
+++ b/roles/docker/tasks/systemd.yml
@@ -14,6 +14,7 @@
   command: rpm -q --qf '%{V}\n' systemd
   register: systemd_version
   when: ansible_os_family == "RedHat" and not is_atomic
+  changed_when: false
 
 - name: Write docker.service systemd file
   template:

--- a/roles/docker/templates/docker.service.j2
+++ b/roles/docker/templates/docker.service.j2
@@ -24,7 +24,9 @@ ExecStart={{ docker_bin_dir }}/docker daemon \
           $DOCKER_NETWORK_OPTIONS \
           $DOCKER_DNS_OPTIONS \
           $INSECURE_REGISTRY
+{% if systemd_version.stdout|int >= 226 %}
 TasksMax=infinity
+{% endif %}
 LimitNOFILE=1048576
 LimitNPROC=1048576
 LimitCORE=infinity

--- a/roles/docker/templates/docker.service.j2
+++ b/roles/docker/templates/docker.service.j2
@@ -24,7 +24,7 @@ ExecStart={{ docker_bin_dir }}/docker daemon \
           $DOCKER_NETWORK_OPTIONS \
           $DOCKER_DNS_OPTIONS \
           $INSECURE_REGISTRY
-{% if systemd_version.stdout|int >= 226 %}
+{% if ansible_os_family == "RedHat" and systemd_version.stdout|int >= 226 %}
 TasksMax=infinity
 {% endif %}
 LimitNOFILE=1048576

--- a/roles/docker/templates/rh_docker.repo.j2
+++ b/roles/docker/templates/rh_docker.repo.j2
@@ -1,7 +1,7 @@
 [dockerrepo]
 name=Docker Repository
-baseurl=https://yum.dockerproject.org/repo/main/centos/7
+baseurl={{ docker_rh_repo_base_url }}
 enabled=1
 gpgcheck=1
-gpgkey=https://yum.dockerproject.org/gpg
+gpgkey={{ docker_rh_repo_gpgkey }}
 {% if http_proxy is defined %}proxy={{ http_proxy }}{% endif %}


### PR DESCRIPTION
* Make yum repos used for installing docker rpms configurable
* TasksMax is only supported in systemd version >= 226
* Change to systemd file should restart docker

Fixes: https://github.com/kubernetes-incubator/kubespray/issues/1513