### PR TITLE
Bump tag for upgrade CI, fix netchecker upgrade

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -110,7 +110,7 @@ before_script:
     # Check out latest tag if testing upgrade
     # Uncomment when gitlab kargo repo has tags
     #- test "${UPGRADE_TEST}" != "false" && git fetch --all && git checkout $(git describe --tags $(git rev-list --tags --max-count=1))
-    - test "${UPGRADE_TEST}" != "false" && git checkout 031cf565ec3ccd3ebbe80eeef3454c3780e5c598 && pip install ansible==2.2.0
+    - test "${UPGRADE_TEST}" != "false" && git checkout acae0fe4a36bd1d3cd267e72ad01126a72d1458a
 
 
     # Create cluster
@@ -142,7 +142,6 @@ before_script:
       if [ "${UPGRADE_TEST}" != "false" ]; then
       test "${UPGRADE_TEST}" == "basic" && PLAYBOOK="cluster.yml";
       test "${UPGRADE_TEST}" == "graceful" && PLAYBOOK="upgrade-cluster.yml";
-      pip install ansible==2.3.0;
       git checkout "${CI_BUILD_REF}";
       ansible-playbook -i inventory/inventory.ini -b --become-user=root --private-key=${HOME}/.ssh/id_rsa -u $SSH_USER
       ${SSH_ARGS}

--- a/roles/kubernetes-apps/ansible/tasks/netchecker.yml
+++ b/roles/kubernetes-apps/ansible/tasks/netchecker.yml
@@ -15,6 +15,16 @@
     - inventory_hostname == groups['kube-master'][0]
     - rbac_enabled or item.type not in rbac_resources
 
+- name: Kubernetes Apps | Purge old Netchecker server
+  kube:
+    name: "netchecker-server"
+    namespace: "{{ netcheck_namespace }}"
+    kubectl: "{{bin_dir}}/kubectl"
+    resource: "po"
+    filename: "{{kube_config_dir}}/{{item.item.file}}"
+    state: absent
+  when: inventory_hostname == groups['kube-master'][0]
+
 #FIXME: remove if kubernetes/features#124 is implemented
 - name: Kubernetes Apps | Purge old Netchecker daemonsets
   kube:


### PR DESCRIPTION
netchecker-server was changed from pod to deployment, so
we need an upgrade hook for it.

CI now uses v2.1.1 as a basis for upgrade.