### PR TITLE
Added default value for weave_mode_seed in weave role

### DIFF
--- a/roles/network_plugin/weave/defaults/main.yml
+++ b/roles/network_plugin/weave/defaults/main.yml
@@ -5,6 +5,11 @@ weave_cpu_limit: 30m
 weave_memory_requests: 64M
 weave_cpu_requests: 10m
 
+# Weave uses consensus mode by default
+# Enabling seed mode allow to dynamically add or remove hosts
+# https://www.weave.works/docs/net/latest/ipam/
+weave_mode_seed: false
+
 # This two variable are automatically changed by the weave's role, do not manually change these values
 # To reset values :
 # weave_seed: unset


### PR DESCRIPTION
When running the playbook with weave enabled the 'weave_mode_seed' is not defined which makes it default to seed mode for some reason. 

`roles/network_plugin/weave/tasks/main.yml` uses this variable, without setting weave_mode_seed it runs the `seed.yml` file. 
```
- include: seed.yml
  when: weave_mode_seed 
```

I added the default to the role defaults file. I think this only happens when running the playbook through ansible, and not with kubespray-cli. 