### PR TITLE
Support CentOS 7 through Vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,6 +14,7 @@ SUPPORTED_OS = {
   "coreos-alpha"  => {box: "coreos-alpha",       bootstrap_os: "coreos", user: "core", box_url: COREOS_URL_TEMPLATE % ["alpha"]},
   "coreos-beta"   => {box: "coreos-beta",        bootstrap_os: "coreos", user: "core", box_url: COREOS_URL_TEMPLATE % ["beta"]},
   "ubuntu"        => {box: "bento/ubuntu-16.04", bootstrap_os: "ubuntu", user: "vagrant"},
+  "centos"        => {box: "bento/centos-7.3",   bootstrap_os: "centos", user: "vagrant"},
 }
 
 # Defaults for config options defined in CONFIG


### PR DESCRIPTION
Feature request from #1532 , I have tested this change, the installation process can be performed successfully:
```sh
....
PLAY RECAP *********************************************************************
k8s-01                     : ok=390  changed=108  unreachable=0    failed=0
k8s-02                     : ok=363  changed=102  unreachable=0    failed=0
k8s-03                     : ok=330  changed=90   unreachable=0    failed=0

Friday 18 August 2017  10:53:15 +0800 (0:00:00.019)       0:10:19.855 *********
===============================================================================
download : Download containers if pull is required or told to always pull - 147.25s
kubernetes/preinstall : Install packages requirements ------------------ 56.24s
download : Download containers if pull is required or told to always pull -- 19.53s
docker : ensure docker packages are installed -------------------------- 18.58s
download : Download containers if pull is required or told to always pull -- 17.31s
download : Download containers if pull is required or told to always pull -- 14.36s
bootstrap-os : Install packages requirements for bootstrap ------------- 14.19s
network_plugin/flannel : Flannel | reload docker ----------------------- 12.80s
kubernetes/preinstall : Update package management cache (YUM) ---------- 12.08s
network_plugin/flannel : Flannel | pause while Docker restarts --------- 10.05s
docker : Docker | pause while Docker restarts -------------------------- 10.03s
download : Download containers if pull is required or told to always pull --- 9.94s
download : Download containers if pull is required or told to always pull --- 9.48s
download : Download containers if pull is required or told to always pull --- 8.30s
kubernetes/master : Master | wait for the apiserver to be running ------- 6.43s
download : Download containers if pull is required or told to always pull --- 5.79s
download : Download containers if pull is required or told to always pull --- 5.65s
network_plugin/flannel : Flannel | Wait for flannel subnet.env file presence --- 5.60s
kubernetes-apps/ansible : Kubernetes Apps | Start Resources ------------- 3.71s
etcd : wait for etcd up ------------------------------------------------- 3.34s
```

ssh into `k8s-01` node to check cluster:
```sh
$ vagrant ssh k8s-01
Last login: Fri Aug 18 02:48:59 2017 from 10.0.2.2
[vagrant@k8s-01 ~]$ kubectl get no
NAME      STATUS    AGE       VERSION
k8s-01    Ready     14m       v1.6.7+coreos.0
k8s-02    Ready     14m       v1.6.7+coreos.0
k8s-03    Ready     14m       v1.6.7+coreos.0
[vagrant@k8s-01 ~]$ kubectl get po --all-namespaces
NAMESPACE     NAME                                  READY     STATUS    RESTARTS   AGE
kube-system   flannel-k8s-01                        1/1       Running   1          13m
kube-system   flannel-k8s-02                        1/1       Running   1          13m
kube-system   flannel-k8s-03                        1/1       Running   1          13m
kube-system   kube-apiserver-k8s-01                 1/1       Running   0          14m
kube-system   kube-apiserver-k8s-02                 1/1       Running   0          14m
kube-system   kube-controller-manager-k8s-01        1/1       Running   0          14m
kube-system   kube-controller-manager-k8s-02        1/1       Running   0          14m
kube-system   kube-dns-3841192733-0lw6s             3/3       Running   0          13m
kube-system   kube-dns-3841192733-6j8w1             3/3       Running   0          13m
kube-system   kube-proxy-k8s-01                     1/1       Running   1          13m
kube-system   kube-proxy-k8s-02                     1/1       Running   1          13m
kube-system   kube-proxy-k8s-03                     1/1       Running   1          13m
kube-system   kube-scheduler-k8s-01                 1/1       Running   0          14m
kube-system   kube-scheduler-k8s-02                 1/1       Running   0          14m
kube-system   kubedns-autoscaler-1833630871-j8zfm   1/1       Running   0          13m
kube-system   nginx-proxy-k8s-03                    1/1       Running   1          13m
```

To check Linux distribution:
```sh
[vagrant@k8s-01 ~]$ cat /etc/os-release
NAME="CentOS Linux"
VERSION="7 (Core)"
ID="centos"
ID_LIKE="rhel fedora"
VERSION_ID="7"
PRETTY_NAME="CentOS Linux 7 (Core)"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:centos:centos:7"
HOME_URL="https://www.centos.org/"
BUG_REPORT_URL="https://bugs.centos.org/"

CENTOS_MANTISBT_PROJECT="CentOS-7"
CENTOS_MANTISBT_PROJECT_VERSION="7"
REDHAT_SUPPORT_PRODUCT="centos"
REDHAT_SUPPORT_PRODUCT_VERSION="7"
```