### PR TITLE
Update to Kubernetes v1.7.3

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -59,7 +59,7 @@ before_script:
   RESOLVCONF_MODE: docker_dns
   LOG_LEVEL: "-vv"
   ETCD_DEPLOYMENT: "docker"
-  KUBELET_DEPLOYMENT: "docker"
+  KUBELET_DEPLOYMENT: "host"
   VAULT_DEPLOYMENT: "docker"
   WEAVE_CPU_LIMIT: "100m"
   AUTHORIZATION_MODES: "{ 'authorization_modes': [] }"
@@ -110,7 +110,7 @@ before_script:
     # Check out latest tag if testing upgrade
     # Uncomment when gitlab kargo repo has tags
     #- test "${UPGRADE_TEST}" != "false" && git fetch --all && git checkout $(git describe --tags $(git rev-list --tags --max-count=1))
-    - test "${UPGRADE_TEST}" != "false" && git checkout acae0fe4a36bd1d3cd267e72ad01126a72d1458a
+    - test "${UPGRADE_TEST}" != "false" && git checkout 72ae7638bcc94c66afa8620dfa4ad9a9249327ea
 
 
     # Create cluster
@@ -266,8 +266,9 @@ before_script:
 .coreos_calico_sep_variables: &coreos_calico_sep_variables
 # stage: deploy-gce-part1
   KUBE_NETWORK_PLUGIN: calico
-  CLOUD_IMAGE: coreos-stable
+  CLOUD_IMAGE: coreos-stable-1465-6-0-v20170817
   CLOUD_REGION: us-west1-b
+  CLOUD_MACHINE_TYPE: "n1-standard-2"
   CLUSTER_MODE: separate
   BOOTSTRAP_OS: coreos
   RESOLVCONF_MODE: host_resolvconf # This is required as long as the CoreOS stable channel uses docker < 1.12
@@ -279,7 +280,6 @@ before_script:
   KUBE_NETWORK_PLUGIN: canal
   CLOUD_IMAGE: ubuntu-1604-xenial
   CLOUD_REGION: europe-west1-b
-  CLOUD_MACHINE_TYPE: "n1-standard-2"
   CLUSTER_MODE: ha
   UPGRADE_TEST: "graceful"
   STARTUP_SCRIPT: ""
@@ -297,6 +297,7 @@ before_script:
   KUBE_NETWORK_PLUGIN: flannel
   CLOUD_IMAGE: centos-7
   CLOUD_REGION: us-west1-a
+  CLOUD_MACHINE_TYPE: "n1-standard-2"
   CLUSTER_MODE: default
   STARTUP_SCRIPT: ""
   
@@ -311,7 +312,7 @@ before_script:
 .coreos_canal_variables: &coreos_canal_variables
 # stage: deploy-gce-part2
   KUBE_NETWORK_PLUGIN: canal
-  CLOUD_IMAGE: coreos-stable
+  CLOUD_IMAGE: coreos-stable-1465-6-0-v20170817
   CLOUD_REGION: us-east1-b
   CLUSTER_MODE: default
   BOOTSTRAP_OS: coreos
@@ -350,7 +351,7 @@ before_script:
 .coreos_alpha_weave_ha_variables: &coreos_alpha_weave_ha_variables
 # stage: deploy-gce-special
   KUBE_NETWORK_PLUGIN: weave
-  CLOUD_IMAGE: coreos-alpha-1325-0-0-v20170216
+  CLOUD_IMAGE: coreos-alpha-1506-0-0-v20170817
   CLOUD_REGION: us-west1-a
   CLUSTER_MODE: ha-scale
   BOOTSTRAP_OS: coreos

--- a/inventory/group_vars/k8s-cluster.yml
+++ b/inventory/group_vars/k8s-cluster.yml
@@ -23,7 +23,7 @@ kube_users_dir: "{{ kube_config_dir }}/users"
 kube_api_anonymous_auth: false
 
 ## Change this to use another Kubernetes version, e.g. a current beta release
-kube_version: v1.6.7
+kube_version: v1.7.3
 
 # Where the binaries will be downloaded.
 # Note: ensure that you've enough disk space (about 1G)
@@ -141,7 +141,7 @@ docker_bin_dir: "/usr/bin"
 
 # Settings for containerized control plane (etcd/kubelet/secrets)
 etcd_deployment_type: docker
-kubelet_deployment_type: docker
+kubelet_deployment_type: host
 cert_management: script
 vault_deployment_type: docker
 

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -18,7 +18,7 @@ download_localhost: False
 download_always_pull: False
 
 # Versions
-kube_version: v1.6.7
+kube_version: v1.7.3
 etcd_version: v3.2.4
 #TODO(mattymo): Move calico versions to roles/network_plugins/calico/defaults
 # after migration to container download

--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -1,5 +1,5 @@
 # Valid options: docker (default), rkt, or host
-kubelet_deployment_type: docker
+kubelet_deployment_type: host
 
 # change to 0.0.0.0 to enable insecure access from anywhere (not recommended)
 kube_apiserver_insecure_bind_address: 127.0.0.1
@@ -15,8 +15,8 @@ kube_proxy_masquerade_all: false
 
 # These options reflect limitations of running kubelet in a container.
 # Modify at your own risk
-kubelet_enable_cri: false
-kubelet_cgroups_per_qos: false
+kubelet_enable_cri: true
+kubelet_cgroups_per_qos: true
 # Set to empty to avoid cgroup creation
 kubelet_enforce_node_allocatable: "\"\""
 

--- a/roles/kubernetes/node/tasks/pre_upgrade.yml
+++ b/roles/kubernetes/node/tasks/pre_upgrade.yml
@@ -4,3 +4,8 @@
   args:
     creates: "/var/lib/cni"
   failed_when: false
+
+- name: "Pre-upgrade | ensure kubelet container is stopped if using host deployment"
+  command: docker stop kubelet
+  failed_when: false
+  when: kubelet_deployment_type == "host"


### PR DESCRIPTION
Change kubelet deploy mode to host
Enable cri and qos per cgroup for kubelet
Update CoreOS images
Add upgrade hook for switching from kubelet deployment from docker to host.