### PR TITLE
Update supported component versions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,13 @@ Versions of supported components
 --------------------------------
 
 
-[kubernetes](https://github.com/kubernetes/kubernetes/releases) v1.6.7 <br>
-[etcd](https://github.com/coreos/etcd/releases) v3.0.17 <br>
+[kubernetes](https://github.com/kubernetes/kubernetes/releases) v1.7.3 <br>
+[etcd](https://github.com/coreos/etcd/releases) v3.2.4 <br>
 [flanneld](https://github.com/coreos/flannel/releases) v0.8.0 <br>
-[calicoctl](https://github.com/projectcalico/calico-docker/releases) v0.23.0 <br>
+[calicoctl](https://github.com/projectcalico/calico-docker/releases) v1.1.3 <br>
 [canal](https://github.com/projectcalico/canal) (given calico/flannel versions) <br>
 [weave](http://weave.works/) v2.0.1 <br>
-[docker](https://www.docker.com/) v1.13.1 (see note)<br>
+[docker](https://www.docker.com/) v1.13 (see note)<br>
 [rkt](https://coreos.com/rkt/docs/latest/) v1.21.0 (see Note 2)<br>
 
 Note: kubernetes doesn't support newer docker versions. Among other things kubelet currently breaks on docker's non-standard version numbering (it no longer uses semantic versioning). To ensure auto-updates don't break your cluster look into e.g. yum versionlock plugin or apt pin).


### PR DESCRIPTION
The list of supported component versions in README.md had become outdated during the recent version bumps. Here is an updated list based on Kubespray's default version settings.