### PR TITLE
Fix problems when setting up vault

### DIFF
--- a/roles/etcd/tasks/gen_certs_vault.yml
+++ b/roles/etcd/tasks/gen_certs_vault.yml
@@ -10,12 +10,12 @@
 - name: gen_certs_vault | Read in the local credentials
   command: cat /etc/vault/roles/etcd/userpass
   register: etcd_vault_creds_cat
-  delegate_to: "{{ groups['vault'][0] }}"
+  delegate_to: "{{ groups['etcd'][0] }}"
 
 - name: gen_certs_vault | Set facts for read Vault Creds
   set_fact:
     etcd_vault_creds: "{{ etcd_vault_creds_cat.stdout|from_json }}"
-  delegate_to: "{{ groups['vault'][0] }}"
+  delegate_to: "{{ groups['etcd'][0] }}"
 
 - name: gen_certs_vault | Log into Vault and obtain an token
   uri:

--- a/roles/vault/tasks/bootstrap/gen_vault_certs.yml
+++ b/roles/vault/tasks/bootstrap/gen_vault_certs.yml
@@ -24,5 +24,5 @@
     issue_cert_path: "{{ vault_cert_dir }}/api.pem"
     issue_cert_headers: "{{ hostvars[groups.vault|first]['vault_headers'] }}"
     issue_cert_role: vault
-    issue_cert_url: "{{ vault_leader_url }}"
+    issue_cert_url: "{{ hostvars[groups.vault|first]['vault_leader_url'] }}"
   when: vault_api_cert_needed

--- a/roles/vault/tasks/bootstrap/main.yml
+++ b/roles/vault/tasks/bootstrap/main.yml
@@ -6,6 +6,9 @@
 - include: sync_secrets.yml
   when: inventory_hostname in groups.vault
 
+- include: ../cluster/unseal.yml
+  when: inventory_hostname in groups.vault and vault_is_sealed and vault_cluster_is_initialized|d()
+
 - include: ../shared/find_leader.yml
   when: inventory_hostname in groups.vault and vault_cluster_is_initialized|d()
 

--- a/roles/vault/tasks/shared/check_vault.yml
+++ b/roles/vault/tasks/shared/check_vault.yml
@@ -28,4 +28,3 @@
   set_fact:
     vault_cluster_is_initialized: "{{ vault_is_initialized or hostvars[item]['vault_is_initialized'] }}"
   with_items: "{{ groups.vault }}"
-  run_once: true


### PR DESCRIPTION
I tried to setup kubernetes together with vault but ran into a couple of problems which I would like to push back:

roles/vault/tasks/bootstrap/main.yml: If the setup somehow was broken and the vault is still unsealed a restart will fail forever
roles/vault/tasks/shared/check_vault.yml: run_once delegates to the first host that is running. But the hosts are restricted before with inventory_hostname in groups.vault. So if the first host is not in the vault group this fails