### PR TITLE
Rename dns_server, add var for selinux.

### DIFF
--- a/docs/ansible.md
+++ b/docs/ansible.md
@@ -157,7 +157,7 @@ ansible-playbook -i inventory/inventory.ini cluster.yml  --tags preinstall,dnsma
 ```
 And this play only removes the K8s cluster DNS resolver IP from hosts' /etc/resolv.conf files:
 ```
-ansible-playbook -i inventory/inventory.ini -e dns_server='' cluster.yml --tags resolvconf
+ansible-playbook -i inventory/inventory.ini -e dnsmasq_dns_server='' cluster.yml --tags resolvconf
 ```
 And this prepares all container images localy (at the ansible runner node) without installing
 or upgrading related stuff or trying to upload container to K8s cluster nodes:

--- a/docs/vars.md
+++ b/docs/vars.md
@@ -28,6 +28,7 @@ Some variables of note include:
 * *kube_version* - Specify a given Kubernetes hyperkube version
 * *searchdomains* - Array of DNS domains to search when looking up hostnames
 * *nameservers* - Array of nameservers to use for DNS lookup
+* *preinstall_selinux_state* - Set selinux state, permitted values are permissive and disabled.
 
 #### Addressing variables
 
@@ -61,7 +62,7 @@ following default cluster paramters:
 * *kube_network_node_prefix* - Subnet allocated per-node for pod IPs. Remainin
   bits in kube_pods_subnet dictates how many kube-nodes can be in cluster.
 * *dns_setup* - Enables dnsmasq
-* *dns_server* - Cluster IP for dnsmasq (default is 10.233.0.2)
+* *dnsmasq_dns_server* - Cluster IP for dnsmasq (default is 10.233.0.2)
 * *skydns_server* - Cluster IP for KubeDNS (default is 10.233.0.3)
 * *cloud_provider* - Enable extra Kubelet option if operating inside GCE or
   OpenStack (default is unset)

--- a/inventory/group_vars/k8s-cluster.yml
+++ b/inventory/group_vars/k8s-cluster.yml
@@ -120,7 +120,7 @@ resolvconf_mode: docker_dns
 deploy_netchecker: false
 # Ip address of the kubernetes skydns service
 skydns_server: "{{ kube_service_addresses|ipaddr('net')|ipaddr(3)|ipaddr('address') }}"
-dns_server: "{{ kube_service_addresses|ipaddr('net')|ipaddr(2)|ipaddr('address') }}"
+dnsmasq_dns_server: "{{ kube_service_addresses|ipaddr('net')|ipaddr(2)|ipaddr('address') }}"
 dns_domain: "{{ cluster_name }}"
 
 # Path used to store Docker data

--- a/roles/dnsmasq/tasks/main.yml
+++ b/roles/dnsmasq/tasks/main.yml
@@ -100,7 +100,7 @@
 
 - name: Check for dnsmasq port (pulling image and running container)
   wait_for:
-    host: "{{dns_server}}"
+    host: "{{dnsmasq_dns_server}}"
     port: 53
     timeout: 180
   when: inventory_hostname == groups['kube-node'][0] and groups['kube-node'][0] in ansible_play_hosts

--- a/roles/dnsmasq/templates/dnsmasq-svc.yml
+++ b/roles/dnsmasq/templates/dnsmasq-svc.yml
@@ -18,6 +18,6 @@ spec:
       targetPort: 53
       protocol: UDP
   type: ClusterIP
-  clusterIP: {{dns_server}}
+  clusterIP: {{dnsmasq_dns_server}}
   selector:
     k8s-app: dnsmasq

--- a/roles/docker/tasks/set_facts_dns.yml
+++ b/roles/docker/tasks/set_facts_dns.yml
@@ -6,7 +6,7 @@
       {%- if dns_mode == 'kubedns' -%}
         {{ [ skydns_server ] }}
       {%- elif dns_mode == 'dnsmasq_kubedns' -%}
-        {{ [ dns_server ] }}
+        {{ [ dnsmasq_dns_server ] }}
       {%- endif -%}
 
 - name: set base docker dns facts

--- a/roles/kubernetes/node/templates/kubelet.standard.env.j2
+++ b/roles/kubernetes/node/templates/kubelet.standard.env.j2
@@ -27,7 +27,7 @@ KUBELET_HOSTNAME="--hostname-override={{ kube_override_hostname }}"
 {% if dns_mode == 'kubedns' %}
 {% set kubelet_args_cluster_dns %}--cluster-dns={{ skydns_server }}{% endset %}
 {% elif dns_mode == 'dnsmasq_kubedns' %}
-{% set kubelet_args_cluster_dns %}--cluster-dns={{ dns_server }}{% endset %}
+{% set kubelet_args_cluster_dns %}--cluster-dns={{ dnsmasq_dns_server }}{% endset %}
 {% else %}
 {% set kubelet_args_cluster_dns %}{% endset %}
 {% endif %}

--- a/roles/kubernetes/preinstall/defaults/main.yml
+++ b/roles/kubernetes/preinstall/defaults/main.yml
@@ -56,3 +56,5 @@ resolveconf_cloud_init_conf: /etc/resolveconf_cloud_init.conf
 
 # All inventory hostnames will be written into each /etc/hosts file.
 populate_inventory_to_hosts_file: true
+
+preinstall_selinux_state: permissive

--- a/roles/kubernetes/preinstall/tasks/main.yml
+++ b/roles/kubernetes/preinstall/tasks/main.yml
@@ -143,10 +143,10 @@
   when: ansible_os_family == "RedHat"
   register: slc
 
-- name: Set selinux policy to permissive
+- name: Set selinux policy
   selinux:
     policy: targeted
-    state: permissive
+    state: "{{ preinstall_selinux_state }}"
   when:
     - ansible_os_family == "RedHat"
     - slc.stat.exists == True

--- a/roles/kubernetes/preinstall/tasks/set_resolv_facts.yml
+++ b/roles/kubernetes/preinstall/tasks/set_resolv_facts.yml
@@ -98,7 +98,7 @@
       {%- elif dns_early|bool -%}
         {{ upstream_dns_servers|default([]) }}
       {%- else -%}
-        {{ [ dns_server ] }}
+        {{ [ dnsmasq_dns_server ] }}
       {%- endif -%}
 
 - name: generate nameservers to resolvconf

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -36,7 +36,7 @@ resolvconf_mode: docker_dns
 deploy_netchecker: false
 # Ip address of the kubernetes skydns service
 skydns_server: "{{ kube_service_addresses|ipaddr('net')|ipaddr(3)|ipaddr('address') }}"
-dns_server: "{{ kube_service_addresses|ipaddr('net')|ipaddr(2)|ipaddr('address') }}"
+dnsmasq_dns_server: "{{ kube_service_addresses|ipaddr('net')|ipaddr(2)|ipaddr('address') }}"
 dns_domain: "{{ cluster_name }}"
 
 # Kubernetes configuration dirs and system namespace.


### PR DESCRIPTION
* Rename dns_server to dnsmasq_dns_server so that it includes role prefix
as the var name is generic and conflicts when integrating with existing ansible automation.
*  Enable selinux state to be configurable with new var preinstall_selinux_state

Fixes: https://github.com/kubernetes-incubator/kubespray/issues/1571