### PR TITLE
Consolidate kube-proxy module and sysctl loading

### DIFF
--- a/roles/kubernetes/node/tasks/main.yml
+++ b/roles/kubernetes/node/tasks/main.yml
@@ -49,6 +49,37 @@
   when: kube_apiserver_node_port_range is defined
   tags: kube-proxy
 
+- name: Verify if br_netfilter module exists
+  shell: "modinfo br_netfilter"
+  register: modinfo_br_netfilter
+  failed_when: modinfo_br_netfilter.rc not in [0, 1]
+  changed_when: false
+
+- name: Enable br_netfilter module
+  modprobe:
+    name: br_netfilter
+    state: present
+  when: modinfo_br_netfilter.rc == 0
+
+# kube-proxy needs net.bridge.bridge-nf-call-iptables enabled when found if br_netfilter is not a module
+- name: Check if bridge-nf-call-iptables key exists
+  command: "sysctl net.bridge.bridge-nf-call-iptables"
+  failed_when: false
+  changed_when: false
+  register: sysctl_bridge_nf_call_iptables
+
+- name: Enable bridge-nf-call tables
+  sysctl:
+    name: "{{ item }}"
+    state: present
+    value: 1
+    reload: yes
+  when: modinfo_br_netfilter.rc == 1 and sysctl_bridge_nf_call_iptables.rc == 0
+  with_items:
+    - net.bridge.bridge-nf-call-iptables
+    - net.bridge.bridge-nf-call-arptables
+    - net.bridge.bridge-nf-call-ip6tables
+
 - name: Write proxy manifest
   template:
     src: manifests/kube-proxy.manifest.j2

--- a/roles/network_plugin/flannel/tasks/main.yml
+++ b/roles/network_plugin/flannel/tasks/main.yml
@@ -1,37 +1,6 @@
 ---
 - include: pre-upgrade.yml
 
-- name: Flannel | Verify if br_netfilter module exists
-  shell: "modinfo br_netfilter"
-  register: modinfo_br_netfilter
-  failed_when: modinfo_br_netfilter.rc not in [0, 1]
-  changed_when: false
-
-- name: Flannel | Enable br_netfilter module
-  modprobe:
-    name: br_netfilter
-    state: present
-  when: modinfo_br_netfilter.rc == 0
-
-# kube-proxy needs net.bridge.bridge-nf-call-iptables enabled when found if br_netfilter is not a module
-- name: Flannel | Check if bridge-nf-call-iptables key exists
-  command: "sysctl net.bridge.bridge-nf-call-iptables"
-  failed_when: false
-  changed_when: false
-  register: sysctl_bridge_nf_call_iptables
-
-- name: Flannel | Enable bridge-nf-call tables
-  sysctl:
-    name: "{{ item }}"
-    state: present
-    value: 1
-    reload: yes
-  when: modinfo_br_netfilter.rc == 1 and sysctl_bridge_nf_call_iptables.rc == 0
-  with_items:
-    - net.bridge.bridge-nf-call-iptables
-    - net.bridge.bridge-nf-call-arptables
-    - net.bridge.bridge-nf-call-ip6tables
-
 - name: Flannel | Create cni-flannel-rbac manifest
   template:
     src: cni-flannel-rbac.yml.j2

--- a/roles/network_plugin/weave/tasks/main.yml
+++ b/roles/network_plugin/weave/tasks/main.yml
@@ -4,18 +4,6 @@
 - include: seed.yml
   when: weave_mode_seed
 
-- name: Weave | Verify if br_netfilter module exists
-  shell: "modinfo br_netfilter"
-  register: modinfo_br_netfilter
-  failed_when: modinfo_br_netfilter.rc not in [0, 1]
-  changed_when: false
-
-- name: Weave | Enable br_netfilter module
-  modprobe:
-    name: br_netfilter
-    state: present
-  when: modinfo_br_netfilter.rc == 0
-
 - name: Weave | Copy cni plugins from hyperkube
   command: "{{ docker_bin_dir }}/docker run --rm -v /opt/cni/bin:/cnibindir {{ hyperkube_image_repo }}:{{ hyperkube_image_tag }} /bin/cp -r /opt/cni/bin/. /cnibindir/"
   register: cni_task_result


### PR DESCRIPTION
This sets br_netfilter and net.bridge.bridge-nf-call-iptables sysctl from a single play before kube-proxy is first ran instead of from the flannel and weave network_plugin roles after kube-proxy is started