### PR TITLE
Include /opt/bin in PATH for host deployed kubelet on CoreOS

### DIFF
--- a/roles/kubernetes/node/templates/kubelet.j2
+++ b/roles/kubernetes/node/templates/kubelet.j2
@@ -72,3 +72,8 @@ KUBELET_CLOUDPROVIDER="--cloud-provider={{ cloud_provider }}"
 {% else %}
 KUBELET_CLOUDPROVIDER=""
 {% endif %}
+
+{% if ansible_os_family in ['CoreOS', 'Container Linux by CoreOS'] %}
+# set PATH to include /opt/bin (e.g. for socat)
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin
+{% endif %}

--- a/roles/kubernetes/node/templates/kubelet.j2
+++ b/roles/kubernetes/node/templates/kubelet.j2
@@ -73,7 +73,4 @@ KUBELET_CLOUDPROVIDER="--cloud-provider={{ cloud_provider }}"
 KUBELET_CLOUDPROVIDER=""
 {% endif %}
 
-{% if ansible_os_family in ['CoreOS', 'Container Linux by CoreOS'] %}
-# set PATH to include /opt/bin (e.g. for socat)
-PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin
-{% endif %}
+PATH={{ bin_dir }}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin


### PR DESCRIPTION
This is required for things like Helm that rely on `socat` for port forwarding. This is related to #1575 which installs socat for CoreOS