### PR TITLE
Change backup handler to only run v2 data backup if snap directory exists

### DIFF
--- a/roles/etcd/handlers/backup.yml
+++ b/roles/etcd/handlers/backup.yml
@@ -5,6 +5,7 @@
     - Refresh Time Fact
     - Set Backup Directory
     - Create Backup Directory
+    - Stat etcd v2 data directory
     - Backup etcd v2 data
     - Backup etcd v3 data
   when: etcd_cluster_is_healthy.rc == 0
@@ -24,7 +25,13 @@
     group: root
     mode: 0600
 
+- name: Stat etcd v2 data directory
+  stat:
+    path: "{{ etcd_data_dir }}/member"
+  register: etcd_data_dir_member
+
 - name: Backup etcd v2 data
+  when: etcd_data_dir_member.stat.exists
   command: >-
     {{ bin_dir }}/etcdctl backup
       --data-dir {{ etcd_data_dir }}


### PR DESCRIPTION
Adds a check for the existence of data in the etcd_data_directory before attempting an etcd v2 data backup.

Fixes #1593 