### PR TITLE
Fix calico leaving service behind.

### DIFF
--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -18,6 +18,7 @@
     - kubelet
     - etcd
     - vault
+    - calico-node
   register: services_removed
   tags: ['services']
 


### PR DESCRIPTION
Calico leaves a stray systemd unit file behind. This should fix it.