### PR TITLE
Add option for fact cache expiry

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -7,6 +7,8 @@ host_key_checking=False
 gathering = smart
 fact_caching = jsonfile
 fact_caching_connection = /tmp
+# Once created, fact cache is never force updated. Enable this if you're getting stale data in your runs (e.g. stale `etcd_access_addresses`)
+# fact_caching_timeout = 7200 # 2 hours
 stdout_callback = skippy
 library = ./library
 callback_whitelist = profile_tasks

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -7,8 +7,9 @@ host_key_checking=False
 gathering = smart
 fact_caching = jsonfile
 fact_caching_connection = /tmp
-# Once created, fact cache is never force updated. Enable this if you're getting stale data in your runs (e.g. stale `etcd_access_addresses`)
-# fact_caching_timeout = 7200 # 2 hours
+# Once created, fact cache is never force updated. This is why the tiemeout exists. If you're still getting 
+# stale data in your runs (e.g. stale `etcd_access_addresses`), you might want to use `--flush-cache`. 
+fact_caching_timeout = 7200 # 2 hours
 stdout_callback = skippy
 library = ./library
 callback_whitelist = profile_tasks


### PR DESCRIPTION
By adding the `fact_caching_timeout` we avoid having really stale/invalid data ending up in there. 
Leaving commented out by default, for backwards compatibility, but nice to have there.