### PR TITLE
change Start Calico resources

### DIFF
--- a/roles/kubernetes-apps/network_plugin/calico/tasks/main.yml
+++ b/roles/kubernetes-apps/network_plugin/calico/tasks/main.yml
@@ -7,4 +7,4 @@
     resource: "{{item.item.type}}"
     filename: "{{kube_config_dir}}/{{item.item.file}}"
     state: "{{item.changed | ternary('latest','present') }}"
-  with_items: "{{ calico_node_manifests.results }}"
+  with_items: "{{ calico_node_manifests.results[0] }}"


### PR DESCRIPTION
In daemonset, we don't need loop over each node to run this.

otherwise, ansible will get error.
```
error running kubectl (/usr/local/bin/kubectl --namespace=kube-system create --filename=/etc/kubernetes/calico-cr.yml) command (rc=1): Error from server (AlreadyExists): error when creating \"/etc/kubernetes/calico-cr.yml\": clusterroles.rbac.authorization.k8s.io \"calico-node\" already exists\n"}
```