### PR TITLE
Fix an error with Canal when RBAC are disabled

### DIFF
--- a/roles/kubernetes-apps/network_plugin/canal/tasks/main.yml
+++ b/roles/kubernetes-apps/network_plugin/canal/tasks/main.yml
@@ -8,6 +8,4 @@
     filename: "{{kube_config_dir}}/{{item.item.file}}"
     state: "latest"
   with_items: "{{ canal_manifests.results }}"
-  when:
-    - inventory_hostname == groups['kube-master'][0]
-    - rbac_enabled or item.item.type not in rbac_resources
+  when: inventory_hostname == groups['kube-master'][0] and not item|skipped

--- a/roles/kubernetes-apps/network_plugin/canal/tasks/main.yml
+++ b/roles/kubernetes-apps/network_plugin/canal/tasks/main.yml
@@ -8,4 +8,6 @@
     filename: "{{kube_config_dir}}/{{item.item.file}}"
     state: "latest"
   with_items: "{{ canal_manifests.results }}"
-  when: inventory_hostname == groups['kube-master'][0]
+  when:
+    - inventory_hostname == groups['kube-master'][0]
+    - rbac_enabled or item.item.type not in rbac_resources


### PR DESCRIPTION
I've fixed an issue introduced by the commit https://github.com/kubernetes-incubator/kubespray/commit/a3e6896a43195fa49141a4f00d1bdf0a70ce20f4 when we deploy Kubernetes with Canal and RBAC disabled.

I don't know if I've to open an issue here for such fix. Please let me know if I've to fill one.