### PR TITLE
Updating CN for node certs generated by vault

### DIFF
--- a/roles/kubernetes/secrets/tasks/gen_certs_vault.yml
+++ b/roles/kubernetes/secrets/tasks/gen_certs_vault.yml
@@ -65,7 +65,9 @@
 # Issue node certs to k8s-cluster nodes
 - include: ../../../vault/tasks/shared/issue_cert.yml
   vars:
-    issue_cert_common_name: "system:node:{{ item.rsplit('/', 1)[1].rsplit('.', 1)[0] }}"
+    # Need to strip out the 'node-' prefix from the cert name so it can be used
+    # with the node authorization plugin ( CN matches kubelet node name )
+    issue_cert_common_name: "system:node:{{ item.rsplit('/', 1)[1].rsplit('.', 1)[0] | regex_replace('^node-', '') }}"
     issue_cert_copy_ca: "{{ item == kube_node_certs_needed|first }}"
     issue_cert_file_group: "{{ kube_cert_group }}"
     issue_cert_file_owner: kube


### PR DESCRIPTION
This allows the node authorization plugin to function correctly