### PR TITLE
Retry Remove all Docker containers in reset

### DIFF
--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -38,6 +38,10 @@
 
 - name: reset | remove all containers
   shell: "{{ docker_bin_dir }}/docker ps -aq | xargs -r docker rm -fv"
+  register: remove_all_containers
+  retries: 4
+  until: remove_all_containers.rc == 0
+  delay: 5
   tags: ['docker']
 
 - name: reset | restart docker if needed


### PR DESCRIPTION
Due to various occasional docker bugs, removing a container will sometimes fail. This can often be mitigated by trying again.