### PR TITLE
Adding ability to specify altnames for vault cert

### DIFF
--- a/roles/vault/defaults/main.yml
+++ b/roles/vault/defaults/main.yml
@@ -83,6 +83,11 @@ vault_ca_options:
     format: pem
     ttl: "{{ vault_max_lease_ttl }}"
     exclude_cn_from_sans: true
+    altnames:
+      - "vault.{{ system_namespace }}.svc.{{ dns_domain }}"
+      - "vault.{{ system_namespace }}.svc"
+      - "vault.{{ system_namespace }}"
+      - "vault"
   etcd:
     common_name: etcd
     format: pem

--- a/roles/vault/tasks/bootstrap/gen_vault_certs.yml
+++ b/roles/vault/tasks/bootstrap/gen_vault_certs.yml
@@ -2,7 +2,7 @@
 - include: ../shared/issue_cert.yml
   vars:
     issue_cert_common_name: "{{ vault_pki_mounts.vault.roles[0].name }}"
-    issue_cert_alt_names: "{{ groups.vault + ['localhost'] }}"
+    issue_cert_alt_names: "{{ groups.vault + ['localhost'] + vault_ca_options.vault.altnames|default() }}"
     issue_cert_hosts: "{{ groups.vault }}"
     issue_cert_ip_sans: >-
         [


### PR DESCRIPTION
Allows us to add a vault service+endpoint and let that address work. Ex, `vault.kube-system.svc.cluster.local`