### PR TITLE
Fix netchecker update side effect

### DIFF
--- a/roles/kubernetes-apps/ansible/tasks/netchecker.yml
+++ b/roles/kubernetes-apps/ansible/tasks/netchecker.yml
@@ -1,4 +1,21 @@
 ---
+
+- name: Kubernetes Apps | Check if netchecker-server manifest already exists
+  stat:
+    path: "{{ kube_config_dir }}/netchecker-server-deployment.yml.j2"
+  register: netchecker_server_manifest
+  tags: ['facts', 'upgrade']
+
+- name: Kubernetes Apps | Apply netchecker-server manifest to update annotations
+  kube:
+    name: "netchecker-server"
+    namespace: "{{ netcheck_namespace }}"
+    kubectl: "{{bin_dir}}/kubectl"
+    resource: "deploy"
+    state: latest
+  when: inventory_hostname == groups['kube-master'][0] and netchecker_server_manifest.stat.exists
+  tags: upgrade
+
 - name: Kubernetes Apps | Lay Down Netchecker Template
   template:
     src: "{{item.file}}"

--- a/tests/testcases/030_check-network.yml
+++ b/tests/testcases/030_check-network.yml
@@ -16,12 +16,12 @@
     shell: "{{bin_dir}}/kubectl get pods --all-namespaces -owide"
     register: get_pods
 
-  - debug: msg="{{get_pods.stdout}}"
+  - debug: msg="{{get_pods.stdout.split('\n')}}"
 
   - name: Get pod names
     shell: "{{bin_dir}}/kubectl get pods -o json"
     register: pods
-    until: '"ContainerCreating" not in pods.stdout'
+    until: '"ContainerCreating" not in get_pods.stdout'
     retries: 60
     delay: 2
     no_log: true

--- a/tests/testcases/030_check-network.yml
+++ b/tests/testcases/030_check-network.yml
@@ -21,7 +21,7 @@
   - name: Get pod names
     shell: "{{bin_dir}}/kubectl get pods -o json"
     register: pods
-    until: '"ContainerCreating" not in get_pods.stdout'
+    until: '"ContainerCreating" not in pods.stdout'
     retries: 60
     delay: 2
     no_log: true


### PR DESCRIPTION
kubectl apply should only be used on resources created
with kubectl apply. To workaround this, we should apply
the old manifest before upgrading it.