### PR TITLE
Prune unnecessary certs from vault setup

### DIFF
--- a/roles/etcd/tasks/sync_etcd_master_certs.yml
+++ b/roles/etcd/tasks/sync_etcd_master_certs.yml
@@ -4,20 +4,17 @@
   set_fact:
     etcd_master_cert_list: >-
         {{ etcd_master_cert_list|default([]) +  [
-        "admin-" + item + ".pem",
-        "member-" + item + ".pem"
+        "admin-" + inventory_hostname + ".pem",
+        "member-" + inventory_hostname + ".pem"
         ] }}
-  with_items: "{{ groups.etcd }}"
-  run_once: true
 
 - include: ../../vault/tasks/shared/sync_file.yml
   vars:
     sync_file: "{{ item }}"
     sync_file_dir: "{{ etcd_cert_dir }}"
-    sync_file_hosts: "{{ groups.etcd }}"
+    sync_file_hosts: [ "{{ inventory_hostname }}" ]
     sync_file_is_cert: true
   with_items: "{{ etcd_master_cert_list|d([]) }}"
-  run_once: true
 
 - name: sync_etcd_certs | Set facts for etcd sync_file results
   set_fact:
@@ -33,8 +30,7 @@
   vars:
     sync_file: ca.pem
     sync_file_dir: "{{ etcd_cert_dir }}"
-    sync_file_hosts: "{{ groups.etcd }}"
-  run_once: true
+    sync_file_hosts: [ "{{ inventory_hostname }}" ]
 
 - name: sync_etcd_certs | Unset sync_file_results after ca.pem sync
   set_fact:

--- a/roles/etcd/tasks/sync_etcd_node_certs.yml
+++ b/roles/etcd/tasks/sync_etcd_node_certs.yml
@@ -2,14 +2,13 @@
 
 - name: sync_etcd_node_certs | Create list of node certs needing creation
   set_fact:
-    etcd_node_cert_list: "{{ etcd_node_cert_list|default([]) +  ['node-' + item + '.pem'] }}"
-  with_items: "{{ etcd_node_cert_hosts }}"
+    etcd_node_cert_list: "{{ etcd_node_cert_list|default([]) +  ['node-' + inventory_hostname + '.pem'] }}"
 
 - include: ../../vault/tasks/shared/sync_file.yml
   vars:
     sync_file: "{{ item }}"
     sync_file_dir: "{{ etcd_cert_dir }}"
-    sync_file_hosts: "{{ etcd_node_cert_hosts }}"
+    sync_file_hosts: [ "{{ inventory_hostname }}" ]
     sync_file_is_cert: true
   with_items: "{{ etcd_node_cert_list|d([]) }}"
 
@@ -27,7 +26,7 @@
   vars:
     sync_file: ca.pem
     sync_file_dir: "{{ etcd_cert_dir }}"
-    sync_file_hosts: "{{ etcd_node_cert_hosts }}"
+    sync_file_hosts: "{{ groups['etcd'] }}"
 
 - name: sync_etcd_node_certs | Unset sync_file_results after ca.pem
   set_fact:

--- a/roles/kubernetes/secrets/tasks/sync_kube_master_certs.yml
+++ b/roles/kubernetes/secrets/tasks/sync_kube_master_certs.yml
@@ -2,15 +2,14 @@
 
 - name: sync_kube_master_certs | Create list of needed kube admin certs
   set_fact:
-    kube_admin_cert_list: "{{ kube_admin_cert_list|d([]) + ['admin-' + item + '.pem'] }}"
-  with_items: "{{ groups['kube-master'] }}"
+    kube_admin_cert_list: "{{ kube_admin_cert_list|d([]) + ['admin-' + inventory_hostname + '.pem'] }}"
 
 - include: ../../../vault/tasks/shared/sync_file.yml
   vars:
     sync_file: "{{ item }}"
     sync_file_dir: "{{ kube_cert_dir }}"
     sync_file_group: "{{ kube_cert_group }}"
-    sync_file_hosts: "{{ groups['kube-master'] }}"
+    sync_file_hosts: [ "{{ inventory_hostname }}" ]
     sync_file_is_cert: true
     sync_file_owner: kube
   with_items: "{{ kube_admin_cert_list|d([]) }}"

--- a/roles/kubernetes/secrets/tasks/sync_kube_node_certs.yml
+++ b/roles/kubernetes/secrets/tasks/sync_kube_node_certs.yml
@@ -2,15 +2,14 @@
 
 - name: sync_kube_node_certs | Create list of needed certs
   set_fact:
-    kube_node_cert_list: "{{ kube_node_cert_list|default([]) + ['node-' + item + '.pem'] }}"
-  with_items: "{{ groups['k8s-cluster'] }}"
+    kube_node_cert_list: "{{ kube_node_cert_list|default([]) + ['node-' + inventory_hostname + '.pem'] }}"
 
 - include: ../../../vault/tasks/shared/sync_file.yml
   vars:
     sync_file: "{{ item }}"
     sync_file_dir: "{{ kube_cert_dir }}"
     sync_file_group: "{{ kube_cert_group }}"
-    sync_file_hosts: "{{ groups['k8s-cluster'] }}"
+    sync_file_hosts: [ "{{ inventory_hostname }}" ]
     sync_file_is_cert: true
     sync_file_owner: kube
   with_items: "{{ kube_node_cert_list|default([]) }}"
@@ -39,15 +38,14 @@
 
 - name: sync_kube_node_certs | Create list of needed kube-proxy certs
   set_fact:
-    kube_proxy_cert_list: "{{ kube_proxy_cert_list|default([]) + ['kube-proxy-' + item + '.pem'] }}"
-  with_items: "{{ groups['k8s-cluster'] }}"
+    kube_proxy_cert_list: "{{ kube_proxy_cert_list|default([]) + ['kube-proxy-' + inventory_hostname + '.pem'] }}"
 
 - include: ../../../vault/tasks/shared/sync_file.yml
   vars:
     sync_file: "{{ item }}"
     sync_file_dir: "{{ kube_cert_dir }}"
     sync_file_group: "{{ kube_cert_group }}"
-    sync_file_hosts: "{{ groups['k8s-cluster'] }}"
+    sync_file_hosts: [ "{{ inventory_hostname }}" ]
     sync_file_owner: kube
   with_items: "{{ kube_proxy_cert_list|default([]) }}"
 

--- a/roles/vault/tasks/shared/sync_file.yml
+++ b/roles/vault/tasks/shared/sync_file.yml
@@ -16,8 +16,7 @@
 - name: "sync_file | Set fact for key path name"
   set_fact:
     sync_file_key_path: "{{ sync_file_path.rsplit('.', 1)|first + '-key.' + sync_file_path.rsplit('.', 1)|last }}"
-  when: >-
-        sync_file_is_cert|d() and (sync_file_key_path is not defined or sync_file_key_path == '')
+  when: sync_file_key_path is not defined or sync_file_key_path == ''
 
 - name: "sync_file | Check if {{sync_file_path}} file exists"
   stat:
@@ -28,31 +27,29 @@
   stat:
     path: "{{ sync_file_key_path }}"
   register: sync_file_key_stat
-  when: sync_file_is_cert|d()
 
 - name: "sync_file | Combine all possible file sync sources"
   set_fact:
     sync_file_srcs: "{{ sync_file_srcs|default([]) + [host_item] }}"
-  with_items: "{{ sync_file_hosts | unique }}"
+  with_items: "{{ sync_file_hosts|default() | unique }}"
   loop_control:
     loop_var: host_item
-  when: hostvars[host_item].get("sync_file_stat", {}).get("stat", {}).get("exists")
+  when: sync_file_stat.stat.exists|default()
 
 - name: "sync_file | Combine all possible key file sync sources"
   set_fact:
     sync_file_key_srcs: "{{ sync_file_key_srcs|default([]) + [host_item] }}"
-  with_items: "{{ sync_file_hosts | unique }}"
+  with_items: "{{ sync_file_hosts|default() | unique }}"
   loop_control:
     loop_var: host_item
-  when: sync_file_is_cert|d() and hostvars[host_item].get("sync_file_key_stat", {}).get("stat", {}).get("exists")
+  when: sync_file_key_stat.stat.exists|default()
 
 - name: "sync_file | Remove sync sources with files that do not match sync_file_srcs|first"
   set_fact:
     _: "{% if inventory_hostname in sync_file_srcs %}{{ sync_file_srcs.remove(inventory_hostname) }}{% endif %}"
   when: >-
         sync_file_srcs|d([])|length > 1 and
-        inventory_hostname != sync_file_srcs|first and
-        sync_file_stat.stat.get("checksum") != hostvars[sync_file_srcs|first].get("sync_file_stat", {}).get("stat", {}).get("checksum")
+        inventory_hostname != sync_file_srcs|first
 
 - name: "sync_file | Remove sync sources with keys that do not match sync_file_srcs|first"
   set_fact:
@@ -60,8 +57,7 @@
   when: >-
         sync_file_is_cert|d() and
         sync_file_key_srcs|d([])|length > 1 and
-        inventory_hostname != sync_file_key_srcs|first and
-        sync_file_key_stat.stat.get("checksum") != hostvars[sync_file_srcs|first].get("sync_file_key_stat", {}).get("stat", {}).get("checksum")
+        inventory_hostname != sync_file_key_srcs|first
 
 - name: "sync_file | Consolidate file and key sources"
   set_fact:


### PR DESCRIPTION
This should speed up vault deployment by removing the syncing of all certs to all nodes. Each node should now only have the certificates that belong to that node. 