### PR TITLE
upgrading from weave version 2.0.1 to 2.0.4

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -27,7 +27,7 @@ calico_version: "v2.5.0"
 calico_ctl_version: "v1.5.0"
 calico_cni_version: "v1.10.0"
 calico_policy_version: "v0.7.0"
-weave_version: 2.0.1
+weave_version: 2.0.4
 flannel_version: "v0.8.0"
 flannel_cni_version: "v0.2.0"
 pod_infra_version: 3.0


### PR DESCRIPTION
This upgrade has been testing offline on a 1.7.5 cluster