### PR TITLE
Insert a newline in bastion ssh config after ProxyCommand conditional

### DIFF
--- a/roles/bastion-ssh-config/templates/ssh-bastion.conf
+++ b/roles/bastion-ssh-config/templates/ssh-bastion.conf
@@ -17,5 +17,6 @@ Host {{ bastion_ip }}
 
 Host {{ vars['hosts'] }}
   ProxyCommand ssh -W %h:%p {{ real_user }}@{{ bastion_ip }} {% if ansible_ssh_private_key_file is defined %}-i {{ ansible_ssh_private_key_file }}{% endif %}
+
   StrictHostKeyChecking no
 {% endif %}


### PR DESCRIPTION
[Ansible strips the first newline after a template block](http://docs.ansible.com/ansible/latest/template_module.html#notes), leading to missing newline in `ssh-bastion.conf` when a bastion is defined, e.g.
```
Host  192.168.0.1
  ProxyCommand ssh -W %h:%p centos@10.0.0.1   StrictHostKeyChecking no
```
This PRs adds in an additional newline:
```
Host  192.168.0.1
  ProxyCommand ssh -W %h:%p centos@10.0.0.1
  StrictHostKeyChecking no
```