### PR TITLE
Adds support for separate etcd machines on terraform/openstack deployment

### DIFF
--- a/contrib/terraform/openstack/README.md
+++ b/contrib/terraform/openstack/README.md
@@ -11,7 +11,7 @@ services.
 
 There are some assumptions made to try and ensure it will work on your openstack cluster.
 
-* floating-ips are used for access, but you can have masters and nodes that don't use floating-ips if needed. You need currently at least 1 floating ip, which we would suggest is used on a master.
+* floating-ips are used for access, but you can have masters and nodes that don't use floating-ips if needed. You need currently at least 1 floating ip, which needs to be used on a master. If using more than one, at least one should be on a master for bastions to work fine.
 * you already have a suitable OS image in glance
 * you already have both an internal network and a floating-ip pool created
 * you have security-groups enabled
@@ -75,7 +75,9 @@ $ echo Setting up Terraform creds && \
   export TF_VAR_auth_url=${OS_AUTH_URL}
 ```
 
-If you want to provision master or node VMs that don't use floating ips, write on a `my-terraform-vars.tfvars` file, for example:
+##### Alternative: etcd inside masters
+
+If you want to provision master or node VMs that don't use floating ips and where etcd is inside masters, write on a `my-terraform-vars.tfvars` file, for example:
 
 ```
 number_of_k8s_masters = "1"
@@ -84,6 +86,28 @@ number_of_k8s_nodes_no_floating_ip = "1"
 number_of_k8s_nodes = "0"
 ```
 This will provision one VM as master using a floating ip, two additional masters using no floating ips (these will only have private ips inside your tenancy) and one VM as node, again without a floating ip.
+
+##### Alternative: etcd on separate machines
+
+If you want to provision master or node VMs that don't use floating ips and where **etcd is on separate nodes from Kubernetes masters**, write on a `my-terraform-vars.tfvars` file, for example:
+
+```
+number_of_etcd = "3"
+number_of_k8s_masters = "0"
+number_of_k8s_masters_no_etcd = "1"
+number_of_k8s_masters_no_floating_ip = "0"
+number_of_k8s_masters_no_floating_ip_no_etcd = "2"
+number_of_k8s_nodes_no_floating_ip = "1"
+number_of_k8s_nodes = "2"
+
+flavor_k8s_node = "desired-flavor-id" 
+flavor_k8s_master = "desired-flavor-id"
+flavor_etcd = "desired-flavor-id"
+```
+
+This will provision one VM as master using a floating ip, two additional masters using no floating ips (these will only have private ips inside your tenancy), two VMs as nodes with floating ips, one VM as node without floating ip and three VMs for etcd. 
+
+##### Alternative: add GlusterFS
 
 Additionally, now the terraform based installation supports provisioning of a GlusterFS shared file system based on a separate set of VMs, running either a Debian or RedHat based set of VMs. To enable this, you need to add to your `my-terraform-vars.tfvars` the following variables:
 

--- a/contrib/terraform/openstack/variables.tf
+++ b/contrib/terraform/openstack/variables.tf
@@ -6,7 +6,19 @@ variable "number_of_k8s_masters" {
   default = 2
 }
 
+variable "number_of_k8s_masters_no_etcd" {
+  default = 2
+}
+
+variable "number_of_etcd" {
+  default = 2
+}
+
 variable "number_of_k8s_masters_no_floating_ip" {
+  default = 2
+}
+
+variable "number_of_k8s_masters_no_floating_ip_no_etcd" {
   default = 2
 }
 
@@ -56,6 +68,10 @@ variable "flavor_k8s_master" {
 }
 
 variable "flavor_k8s_node" {
+  default = 3
+}
+
+variable "flavor_etcd" {
   default = 3
 }
 


### PR DESCRIPTION
This PR gives the terraform/openstack deployment the ability to provision a cluster with a separate set of machines for etcd, separated from the master machines. I have tested this locally to work on our OpenStack installation at EMBL-EBI EMBASSY Cloud.