### PR TITLE
Allow setting cgroup driver for kubelet

### DIFF
--- a/roles/kubernetes/node/tasks/facts.yml
+++ b/roles/kubernetes/node/tasks/facts.yml
@@ -1,0 +1,8 @@
+- name: look up docker cgroup driver
+  shell: "docker info | grep 'Cgroup Driver' | awk -F': ' '{ print $2; }'"
+  register: docker_cgroup_driver_result
+
+- set_fact:
+    standalone_kubelet: >-
+      {%- if inventory_hostname in groups['kube-master'] and inventory_hostname not in groups['kube-node'] -%}true{%- else -%}false{%- endif -%}
+    kubelet_cgroup_driver_detected: "{{ docker_cgroup_driver_result.stdout }}"

--- a/roles/kubernetes/node/tasks/main.yml
+++ b/roles/kubernetes/node/tasks/main.yml
@@ -1,7 +1,5 @@
 ---
-- set_fact:
-    standalone_kubelet: >-
-      {%- if inventory_hostname in groups['kube-master'] and inventory_hostname not in groups['kube-node'] -%}true{%- else -%}false{%- endif -%}
+- include: facts.yml
   tags: facts
 
 - include: pre_upgrade.yml

--- a/roles/kubernetes/node/templates/kubelet.standard.env.j2
+++ b/roles/kubernetes/node/templates/kubelet.standard.env.j2
@@ -19,6 +19,7 @@ KUBELET_HOSTNAME="--hostname-override={{ kube_override_hostname }}"
 {% if kube_version | version_compare('v1.7', '<') %}
 --enable-cri={{ kubelet_enable_cri }} \
 {% endif %}
+--cgroup-driver={{ kubelet_cgroup_driver|default(kubelet_cgroup_driver_detected) }} \
 --cgroups-per-qos={{ kubelet_cgroups_per_qos }} \
 --enforce-node-allocatable={{ kubelet_enforce_node_allocatable }} {% endif %}{% endset %}
 


### PR DESCRIPTION
Red Hat family platforms run docker daemon with `--exec-opt
native.cgroupdriver=systemd`. When kubespray tried to start kubelet
service, it failed with:

Error: failed to run Kubelet: failed to create kubelet: misconfiguration: kubelet cgroup driver: "cgroupfs" is different from docker cgroup driver: "systemd"

Setting kubelet's cgroup driver to the correct value for the platform
fixes this issue.