### PR TITLE
removed the key for tolerations in flannel daemonset 

### DIFF
--- a/roles/network_plugin/flannel/templates/cni-flannel.yml.j2
+++ b/roles/network_plugin/flannel/templates/cni-flannel.yml.j2
@@ -103,7 +103,6 @@ spec:
           mountPath: /host/opt/cni/bin/
       hostNetwork: true
       tolerations:
-      - key: node-role.kubernetes.io/master
         operator: Exists
         effect: NoSchedule
       volumes:


### PR DESCRIPTION
We noticed when adding a custom taint to a node that this meant that the flannel daemonset was no longer scheduled on it, which is a problem as our cluster relies on flannel.
This change is to make the tolerations on the flannel daemonset the same as the other network_plugns (weave, canal etc) so that the ds still gets scheduled on all nodes.