### PR TITLE
Use api lookup for kubelet hostname when using cloudprovider

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -116,8 +116,8 @@ before_script:
       -e ansible_python_interpreter=${PYPATH}
       -e ansible_ssh_user=${SSH_USER}
       -e bootstrap_os=${BOOTSTRAP_OS}
-      -e cert_management=${CERT_MGMT:-script}
       -e cloud_provider=gce
+      -e cert_management=${CERT_MGMT:-script}
       -e "{deploy_netchecker: true}"
       -e "{download_localhost: ${DOWNLOAD_LOCALHOST}}"
       -e "{download_run_once: ${DOWNLOAD_RUN_ONCE}}"
@@ -185,6 +185,7 @@ before_script:
       -b --become-user=root -e cloud_provider=gce $LOG_LEVEL -e kube_network_plugin=${KUBE_NETWORK_PLUGIN}
       --private-key=${HOME}/.ssh/id_rsa
       -e bootstrap_os=${BOOTSTRAP_OS}
+      -e cloud_provider=gce
       -e ansible_python_interpreter=${PYPATH}
       -e "{deploy_netchecker: true}"
       -e "{download_localhost: ${DOWNLOAD_LOCALHOST}}"
@@ -219,6 +220,7 @@ before_script:
       -b --become-user=root -e cloud_provider=gce $LOG_LEVEL -e kube_network_plugin=${KUBE_NETWORK_PLUGIN}
       --private-key=${HOME}/.ssh/id_rsa
       -e bootstrap_os=${BOOTSTRAP_OS}
+      -e cloud_provider=gce
       -e ansible_python_interpreter=${PYPATH}
       -e reset_confirmation=yes
       --limit "all:!fake_hosts"
@@ -232,6 +234,7 @@ before_script:
       -b --become-user=root -e cloud_provider=gce $LOG_LEVEL -e kube_network_plugin=${KUBE_NETWORK_PLUGIN}
       --private-key=${HOME}/.ssh/id_rsa
       -e bootstrap_os=${BOOTSTRAP_OS}
+      -e cloud_provider=gce
       -e ansible_python_interpreter=${PYPATH}
       -e "{deploy_netchecker: true}"
       -e "{download_localhost: ${DOWNLOAD_LOCALHOST}}"

--- a/cluster.yml
+++ b/cluster.yml
@@ -62,7 +62,6 @@
   roles:
     - { role: kubespray-defaults}
     - { role: kubernetes/node, tags: node }
-    - { role: network_plugin, tags: network }
 
 - hosts: kube-master
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
@@ -75,6 +74,7 @@
   roles:
     - { role: kubespray-defaults}
     - { role: kubernetes/kubeadm, tags: kubeadm, when: "kubeadm_enabled" }
+    - { role: network_plugin, tags: network }
 
 - hosts: kube-master
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"

--- a/roles/network_plugin/calico/tasks/main.yml
+++ b/roles/network_plugin/calico/tasks/main.yml
@@ -6,6 +6,13 @@
     enabled: yes
   failed_when: false
 
+- name: Calico | Get kubelet hostname
+  shell: >-
+    kubectl get node -o custom-columns='NAME:.metadata.name,INTERNAL-IP:.status.addresses[?(@.type=="InternalIP")].address'
+    | egrep "[[:space:]]{{ ansible_all_ipv4_addresses | join('[[:space:]]|[[:space:]]') }}[[:space:]]*$" | cut -d" " -f1
+  register: calico_kubelet_name
+  when: cloud_provider is defined
+
 - name: Calico | Write Calico cni config
   template:
     src: "cni-calico.conf.j2"

--- a/roles/network_plugin/calico/templates/cni-calico.conf.j2
+++ b/roles/network_plugin/calico/templates/cni-calico.conf.j2
@@ -1,7 +1,7 @@
 {
   "name": "calico-k8s-network",
 {% if cloud_provider is defined %}
-  "nodename": "{{ inventory_hostname }}",
+  "nodename": "{{ calico_kubelet_name.stdout }}",
 {% else %}
   "nodename": "{{ ansible_hostname }}",
 {% endif %}


### PR DESCRIPTION
The value cannot be determined properly via local facts, so
checking k8s api is the most reliable way to look up what hostname
is used when using a cloudprovider.