### PR TITLE
Add etcd_blkio_weight

### DIFF
--- a/roles/etcd/defaults/main.yml
+++ b/roles/etcd/defaults/main.yml
@@ -23,6 +23,8 @@ etcd_memory_limit: 512M
 # Uncomment to set CPU share for etcd
 # etcd_cpu_limit: 300m
 
+etcd_blkio_weight: 1000
+
 etcd_node_cert_hosts: "{{ groups['k8s-cluster'] | union(groups.get('calico-rr', [])) }}"
 
 etcd_compaction_retention: "8"

--- a/roles/etcd/templates/etcd.j2
+++ b/roles/etcd/templates/etcd.j2
@@ -12,6 +12,9 @@
   {% if etcd_cpu_limit is defined %}
   --cpu-shares={{ etcd_cpu_limit|regex_replace('m', '') }} \
   {% endif %}
+  {% if etcd_blkio_weight is defined %}
+  --blkio-weight={{ etcd_blkio_weight }} \
+  {% endif %}
   --name={{ etcd_member_name | default("etcd") }} \
   {{ etcd_image_repo }}:{{ etcd_image_tag }} \
   {% if etcd_after_v3 %}


### PR DESCRIPTION
As explained [on etcd docs](https://coreos.com/etcd/docs/latest/tuning.html#disk):

> An etcd cluster is very sensitive to disk latencies. Since etcd must persist proposals to its log, disk activity from other processes may cause long fsync latencies. The upshot is etcd may miss heartbeats, causing request timeouts and temporary leader loss. An etcd server can sometimes stably run alongside these processes when given a high disk priority.

Passing `--blkio-weight=1000` to docker can reduce latency (assuming CFQ scheduler is being used on the device).