### PR TITLE
Change used chars for kubeadm tokens

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -87,8 +87,8 @@ bin_dir: /usr/local/bin
 
 ## Uncomment to enable experimental kubeadm deployment mode
 #kubeadm_enabled: false
-#kubeadm_token_first: "{{ lookup('password', 'credentials/kubeadm_token_first length=6  chars=ascii_letters,digits') }}"
-#kubeadm_token_second: "{{ lookup('password', 'credentials/kubeadm_token_second length=16 chars=ascii_letters,digits') }}"
+#kubeadm_token_first: "{{ lookup('password', 'credentials/kubeadm_token_first length=6  chars=ascii_lowercase,digits') }}"
+#kubeadm_token_second: "{{ lookup('password', 'credentials/kubeadm_token_second length=16 chars=ascii_lowercase,digits') }}"
 #kubeadm_token: "{{ kubeadm_token_first }}.{{ kubeadm_token_second }}"
 #
 ## Set these proxy values in order to update docker daemon to use proxies


### PR DESCRIPTION
Fixes error:
```
# timeout -k 240s 240s kubeadm init --config=/etc/kubernetes/kubeadm-config.yaml --skip-preflight-checks
[kubeadm] WARNING: kubeadm is in beta, please do not use it for production clusters.
[init] Using Kubernetes version: v1.7.5
[init] Using Authorization modes: [Node RBAC]
[preflight] Skipping pre-flight checks
[token: Invalid value: "zf5RV7.FAGe1e7iAAIzSlPm": token ["zf5RV7.FAGe1e7iAAIzSlPm"] was not of form ["^([a-z0-9]{6})\\.([a-z0-9]{16})$"], token: Invalid value: "zf5RV7.FAGe1e7iAAIzSlPm": token must be of form '[a-z0-9]{6}.[a-z0-9]{16}']
```

[kubeadm regexp source](https://github.com/kubernetes/kubernetes/blob/20fd96a161b88acf98ca6a7739606879658d42b2/cmd/kubeadm/app/util/token/tokens.go#L41)