### PR TITLE
Set default value for disable_shared_pid

### DIFF
--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -20,7 +20,9 @@ kubelet_enable_cri: true
 kubelet_cgroups_per_qos: true
 # Set to empty to avoid cgroup creation
 kubelet_enforce_node_allocatable: "\"\""
-
+# Set false to enable sharing a pid namespace between containers in a pod.
+# Note that PID namespace sharing requires docker >= 1.13.1.
+kubelet_disable_shared_pid: true
 
 # Limits for kube components and nginx load balancer app
 kubelet_memory_limit: 512M

--- a/roles/kubernetes/node/templates/kubelet.kubeadm.env.j2
+++ b/roles/kubernetes/node/templates/kubelet.kubeadm.env.j2
@@ -27,6 +27,7 @@ KUBELET_HOSTNAME="--hostname-override={{ kube_override_hostname }}"
 --kube-reserved cpu={{ kubelet_cpu_limit }},memory={{ kubelet_memory_limit|regex_replace('Mi', 'M') }} \
 --node-status-update-frequency={{ kubelet_status_update_frequency }} \
 --cgroup-driver={{ kubelet_cgroup_driver|default(kubelet_cgroup_driver_detected) }} \
+--docker-disable-shared-pid={{ kubelet_disable_shared_pid }} \
 {% endset %}
 
 {# DNS settings for kubelet #}

--- a/roles/kubernetes/node/templates/kubelet.standard.env.j2
+++ b/roles/kubernetes/node/templates/kubelet.standard.env.j2
@@ -14,6 +14,7 @@ KUBELET_HOSTNAME="--hostname-override={{ kube_override_hostname }}"
 --pod-infra-container-image={{ pod_infra_image_repo }}:{{ pod_infra_image_tag }} \
 --kube-reserved cpu={{ kubelet_cpu_limit }},memory={{ kubelet_memory_limit|regex_replace('Mi', 'M') }} \
 --node-status-update-frequency={{ kubelet_status_update_frequency }} \
+--docker-disable-shared-pid={{ kubelet_disable_shared_pid }} \
 {% if kube_version | version_compare('v1.6', '>=') %}
 {# flag got removed with 1.7.0 #}
 {% if kube_version | version_compare('v1.7', '<') %}


### PR DESCRIPTION
Sharing PID namespace for Docker is disabled by default only in
Kubernetes 1.7. Explicitily enabling it by default could help reduce
unexpected results when upgrading to or downgrading from 1.7.