### PR TITLE
Fix node-cidr-mask-size defaulting to /24 for flannel and cloud network

### DIFF
--- a/roles/kubernetes/master/templates/manifests/kube-controller-manager.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-controller-manager.manifest.j2
@@ -54,6 +54,7 @@ spec:
     - --allocate-node-cidrs=true
     - --cluster-cidr={{ kube_pods_subnet }}
     - --service-cluster-ip-range={{ kube_service_addresses }}
+    - --node-cidr-mask-size={{ kube_network_node_prefix }}
 {% endif %}
 {% if kube_feature_gates %}
     - --feature-gates={{ kube_feature_gates|join(',') }}


### PR DESCRIPTION
When setting `--allocate-node-cidr=true`, also set `--node-cidr-mask-size`, as described in #1712.