### PR TITLE
Workaround for vagrant 1.9 and centos vm box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,7 @@
 
 require 'fileutils'
 
-Vagrant.require_version ">= 1.8.0"
+Vagrant.require_version ">= 1.9.0"
 
 CONFIG = File.join(File.dirname(__FILE__), "vagrant/config.rb")
 
@@ -122,6 +122,12 @@ Vagrant.configure("2") do |config|
       }
 
       config.vm.network :private_network, ip: ip
+      
+      # workaround for Vagrant 1.9.1 and centos vm
+      # https://github.com/hashicorp/vagrant/issues/8096
+      if Vagrant::VERSION == "1.9.1" && $os == "centos"
+        config.vm.provision "shell", inline: "service network restart", run: "always"
+      end
 
       # Only execute once the Ansible provisioner,
       # when all the machines are up and ready.

--- a/docs/vagrant.md
+++ b/docs/vagrant.md
@@ -1,7 +1,7 @@
 Vagrant Install
 =================
 
-Assuming you have Vagrant (1.8+) installed with virtualbox (it may work
+Assuming you have Vagrant (1.9+) installed with virtualbox (it may work
 with vmware, but is untested) you should be able to launch a 3 node
 Kubernetes cluster by simply running `$ vagrant up`.<br />
 


### PR DESCRIPTION
and increase minimal vagrant version to `1.9` 

passed with
```
vagrant 1.9.1
centos + flannel
```