### PR TITLE
Don't delegate cert gathering before creating admin.conf

### DIFF
--- a/roles/kubernetes/client/tasks/main.yml
+++ b/roles/kubernetes/client/tasks/main.yml
@@ -16,8 +16,6 @@
 - name: Gather certs for admin kubeconfig
   slurp:
     src: "{{ item }}"
-  delegate_to: "{{ groups['kube-master'][0] }}"
-  delegate_facts: no
   register: admin_certs
   with_items:
     - "{{ kube_cert_dir }}/ca.pem"


### PR DESCRIPTION
In the current client task, there's a step where certs are slurped. It's currently delegating this task to kube-master[0] only, but this breaks kubespray builds where you may not be using the script-based cert generation (specifically when using vault). Additionally, this was causing only the certs from the first master to be used in admin.conf across all nodes.

This PR removes the delegation, allowing each master to get an admin.conf created with its own certs and removing the assumption that kube-master[0] has admin certs for other kube-master nodes.