### PR TITLE
Force synchronize to use ssh_args so it works when using bastion

### DIFF
--- a/roles/download/tasks/main.yml
+++ b/roles/download/tasks/main.yml
@@ -167,6 +167,7 @@
   synchronize:
     src: "{{ fname }}"
     dest: "{{ fname }}"
+    use_ssh_args: yes
     mode: pull
   delegate_to: localhost
   become: false
@@ -183,6 +184,7 @@
   synchronize:
     src: "{{ fname }}"
     dest: "{{ fname }}"
+    use_ssh_args: yes
     mode: push
   delegate_to: localhost
   become: false


### PR DESCRIPTION
In case ssh.config is set to use bastion, synchronize needs to use it too.