### PR TITLE
Persist br_netfilter module loading

### DIFF
--- a/roles/kubernetes/node/tasks/main.yml
+++ b/roles/kubernetes/node/tasks/main.yml
@@ -79,6 +79,12 @@
     state: present
   when: modinfo_br_netfilter.rc == 0
 
+- name: Persist br_netfilter module
+  copy:
+    dest: /etc/modules-load.d/kubespray-br_netfilter.conf
+    content: br_netfilter
+  when: modinfo_br_netfilter.rc == 0
+
 # kube-proxy needs net.bridge.bridge-nf-call-iptables enabled when found if br_netfilter is not a module
 - name: Check if bridge-nf-call-iptables key exists
   command: "sysctl net.bridge.bridge-nf-call-iptables"


### PR DESCRIPTION
Adresses #1460 and #1708.

As far as I can see, `/etc/modules-load.d/` is viable on all supported distributions.