### PR TITLE
Include bin_dir when patching helm tiller with kubectl

### DIFF
--- a/roles/kubernetes-apps/helm/tasks/main.yml
+++ b/roles/kubernetes-apps/helm/tasks/main.yml
@@ -36,7 +36,7 @@
   when: helm_container.changed
 
 - name: Helm | Patch tiller deployment for RBAC
-  command: kubectl patch deployment tiller-deploy -p '{"spec":{"template":{"spec":{"serviceAccount":"tiller"}}}}' -n {{ system_namespace }}
+  command: "{{bin_dir}}/kubectl patch deployment tiller-deploy -p '{\"spec\":{\"template\":{\"spec\":{\"serviceAccount\":\"tiller\"}}}}' -n {{ system_namespace }}"
   when: rbac_enabled
 
 - name: Helm | Set up bash completion


### PR DESCRIPTION
When helm is enabled `kubectl patch deployment tiller-deploy` fails because `kubectl` is not in the default PATH on CentOS 7. Other tasks in this repository invoke `{{bin_dir}}/kubectl` instead of `kubectl`. This PR adds the missing `{{bin_dir}}`

Closes https://github.com/kubernetes-incubator/kubespray/issues/1761