### PR TITLE
Fixed kubelet standard log environment

### DIFF
--- a/roles/kubernetes/node/templates/kubelet.standard.env.j2
+++ b/roles/kubernetes/node/templates/kubelet.standard.env.j2
@@ -1,5 +1,5 @@
 # logging to stderr means we get it in the systemd journal
-KUBE_LOGGING="--logtostderr=true"
+KUBE_LOGTOSTDERR="--logtostderr=true"
 KUBE_LOG_LEVEL="--v={{ kube_log_level }}"
 # The address for the info server to serve on (set to 0.0.0.0 or "" for all interfaces)
 KUBELET_ADDRESS="--address={{ ip | default("0.0.0.0") }} {% if ip is defined %} --node-ip={{ ip }}{% endif %}"


### PR DESCRIPTION
Change KUBE_LOGGING to KUBE_LOGTOSTDERR, when installing kubelet
as host type.