### PR TITLE
Remove cert_managment var definition from k8s-cluster group vars

### DIFF
--- a/inventory/group_vars/k8s-cluster.yml
+++ b/inventory/group_vars/k8s-cluster.yml
@@ -137,7 +137,6 @@ docker_bin_dir: "/usr/bin"
 # Settings for containerized control plane (etcd/kubelet/secrets)
 etcd_deployment_type: docker
 kubelet_deployment_type: host
-cert_management: script
 vault_deployment_type: docker
 
 # K8s image pull policy (imagePullPolicy)


### PR DESCRIPTION
This var defined [here](https://github.com/kubernetes-incubator/kubespray/blob/master/inventory/group_vars/all.yml#L115) in example group_vars.