### PR TITLE
Fix node authorization for cloudprovider installs

### DIFF
--- a/docs/vars.md
+++ b/docs/vars.md
@@ -72,8 +72,9 @@ following default cluster paramters:
   alpha/experimental Kubernetes features. (defaults is `[]`)
 * *authorization_modes* - A list of [authorization mode](
 https://kubernetes.io/docs/admin/authorization/#using-flags-for-your-authorization-module)
-  that the cluster should be configured for. Defaults to `['RBAC', 'Node']` (RBAC and Node authorizers).
-  Note: `RBAC` is enabled by default. Previously deployed clusters can be
+  that the cluster should be configured for. Defaults to `['Node', 'RBAC']`
+  (Node and RBAC authorizers).
+  Note: `Node` and `RBAC` are enabled by default. Previously deployed clusters can be
   converted to RBAC mode. However, your apps which rely on Kubernetes API will
   require a service account and cluster role bindings. You can override this
   setting by setting authorization_modes to `[]`.

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -147,8 +147,8 @@ openstack_lbaas_enabled: false
 
 ## List of authorization modes that must be configured for
 ## the k8s cluster. Only 'AlwaysAllow', 'AlwaysDeny', 'Node' and
-## 'RBAC' modes are tested.
-authorization_modes: ['RBAC', 'Node']
+## 'RBAC' modes are tested. Order is important.
+authorization_modes: ['Node', 'RBAC']
 rbac_enabled: "{{ 'RBAC' in authorization_modes or kubeadm_enabled }}"
 
 ## List of key=value pairs that describe feature gates for


### PR DESCRIPTION
In 1.8, the Node authorization mode should be listed first to
allow kubelet to access secrets. This seems to only impact
environments with cloudprovider enabled.