### PR TITLE
[contrib/network-storage/glusterfs] bootstrap for glusterfs nodes

### DIFF
--- a/contrib/network-storage/glusterfs/glusterfs.yml
+++ b/contrib/network-storage/glusterfs/glusterfs.yml
@@ -1,8 +1,17 @@
 ---
+- hosts: gfs-cluster
+  gather_facts: false
+  vars:
+    ansible_ssh_pipelining: false
+  roles:
+   - { role: bootstrap-os, tags: bootstrap-os}
+
 - hosts: all
   gather_facts: true
 
 - hosts: gfs-cluster
+  vars:
+    ansible_ssh_pipelining: true
   roles:
     - { role: glusterfs/server }
 
@@ -12,6 +21,5 @@
 
 - hosts: kube-master[0]
   roles:
-    - { role: kubernetes-pv/lib }
     - { role: kubernetes-pv }
 

--- a/contrib/network-storage/glusterfs/group_vars
+++ b/contrib/network-storage/glusterfs/group_vars
@@ -1,0 +1,1 @@
+../../../inventory/group_vars

--- a/contrib/network-storage/glusterfs/roles/bootstrap-os
+++ b/contrib/network-storage/glusterfs/roles/bootstrap-os
@@ -1,0 +1,1 @@
+../../../../roles/bootstrap-os


### PR DESCRIPTION
Allows the bootstrap ansible roles to be used for glusterfs nodes in the contrib/network-storage/glusterfs part.