### PR TITLE
fix #1788 lock dashboard version to 1.6.3 

### DIFF
--- a/roles/kubernetes-apps/ansible/defaults/main.yml
+++ b/roles/kubernetes-apps/ansible/defaults/main.yml
@@ -40,8 +40,8 @@ netchecker_server_memory_requests: 64M
 
 # Dashboard
 dashboard_enabled: false
-dashboard_image_repo: kubernetesdashboarddev/kubernetes-dashboard-amd64
-dashboard_image_tag: head
+dashboard_image_repo: gcr.io/google_containers/kubernetes-dashboard-amd64
+dashboard_image_tag: v1.6.3
 
 # Limits for dashboard
 dashboard_cpu_limit: 100m


### PR DESCRIPTION
partially fix #1788 lock dashboard version to 1.6.3 while we get 1.7.x working