### PR TITLE
remove kubedns versions and images

### DIFF
--- a/roles/kubernetes-apps/ansible/defaults/main.yml
+++ b/roles/kubernetes-apps/ansible/defaults/main.yml
@@ -1,24 +1,10 @@
 ---
-# Versions
-kubedns_version: 1.14.2
-kubednsautoscaler_version: 1.1.1
-
 # Limits for dnsmasq/kubedns apps
 dns_memory_limit: 170Mi
 dns_cpu_requests: 100m
 dns_memory_requests: 70Mi
 kubedns_min_replicas: 2
 kubedns_nodes_per_replica: 10
-
-# Images
-kubedns_image_repo: "gcr.io/google_containers/k8s-dns-kube-dns-amd64"
-kubedns_image_tag: "{{ kubedns_version }}"
-dnsmasq_nanny_image_repo: "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64"
-dnsmasq_nanny_image_tag: "{{ kubedns_version }}"
-dnsmasq_sidecar_image_repo: "gcr.io/google_containers/k8s-dns-sidecar-amd64"
-dnsmasq_sidecar_image_tag: "{{ kubedns_version }}"
-kubednsautoscaler_image_repo: "gcr.io/google_containers/cluster-proportional-autoscaler-amd64"
-kubednsautoscaler_image_tag: "{{ kubednsautoscaler_version }}"
 
 # Netchecker
 deploy_netchecker: false


### PR DESCRIPTION
kubedns versions and images has already been defined in roles/download/defaults/main.yml,there are two different versions in roles/download/defaults/main.yml and roles/kubernetes-apps/ansible/defaults/main.yml now.