### PR TITLE
Only write bastion ssh config when needed

### DIFF
--- a/roles/bastion-ssh-config/tasks/main.yml
+++ b/roles/bastion-ssh-config/tasks/main.yml
@@ -18,3 +18,4 @@
   template:
     src: ssh-bastion.conf
     dest: "{{ playbook_dir }}/ssh-bastion.conf"
+  when: has_bastion


### PR DESCRIPTION
This will allow running Kubespray when the user who runs it doesn't
have write permissions to the Kubespray dir, at least when not using
bastion.