### PR TITLE
set to 3 digit version number

### DIFF
--- a/roles/kubernetes/preinstall/tasks/verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/verify-settings.yml
@@ -2,7 +2,7 @@
 - name: Stop if ansible version is too low
   assert:
     that:
-      - ansible_version.full|version_compare('2.3.0.0', '>=')
+      - ansible_version.full|version_compare('2.3.0', '>=')
   run_once: yes
 
 - name: Stop if non systemd OS type


### PR DESCRIPTION
Version check for 2.3.0 is only 3 digits long.  Set the check to that. 