### PR TITLE
With network_plugin: flannel first play of playbook cluster.yml freeze for 36 min

### DIFF
--- a/roles/network_plugin/flannel/tasks/main.yml
+++ b/roles/network_plugin/flannel/tasks/main.yml
@@ -8,6 +8,11 @@
   register: flannel_rbac_manifest
   when: inventory_hostname == groups['kube-master'][0] and rbac_enabled
 
+- name: Flannel | Create cni-flannel config
+  template:
+    src: 10-flannel.conflist.j2
+    dest: "/etc/cni/net.d/10-flannel.conflist"
+
 - name: Flannel | Create cni-flannel manifest
   template:
     src: cni-flannel.yml.j2

--- a/roles/network_plugin/flannel/templates/10-flannel.conflist.j2
+++ b/roles/network_plugin/flannel/templates/10-flannel.conflist.j2
@@ -1,0 +1,19 @@
+{
+  "name":"cbr0",
+  "cniVersion":"0.3.1",
+  "plugins":[
+    {
+      "type":"flannel",
+      "delegate":{
+        "forceAddress":true,
+        "isDefaultGateway":true
+      }
+    },
+    {
+      "type":"portmap",
+      "capabilities":{
+        "portMappings":true
+      }
+    }
+  ]
+}


### PR DESCRIPTION
on initial setup (first play cluster.yml) node not started, with messages in log:
```
cni.go:196] Unable to update cni config: No networks found in /etc/cni/net.d
kubelet.go:2095] Container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:docker: network plugin is not ready: cni config uninitialized
```
play wait 36 min, until nodes set ready...

Add config 10-flannel.conflist, kube-nodes started and daemonset flannel launch on all nodes, and recreate config.
