### PR TITLE
start kubernetes-apps/network_plugin before rotate_tokens

### DIFF
--- a/cluster.yml
+++ b/cluster.yml
@@ -79,8 +79,8 @@
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   roles:
     - { role: kubespray-defaults}
-    - { role: kubernetes-apps/rotate_tokens, tags: rotate_tokens, when: "secret_changed|default(false)" }
     - { role: kubernetes-apps/network_plugin, tags: network }
+    - { role: kubernetes-apps/rotate_tokens, tags: rotate_tokens, when: "secret_changed|default(false)" }
     - { role: kubernetes-apps/policy_controller, tags: policy-controller }
     - { role: kubernetes/client, tags: client }
 


### PR DESCRIPTION
When create cluster on bare-metal servers with flannel network

playbook cluster.yml frees up to 36 min, on role kubernetes-apps/rotate_tokens
at this moment all nodes in state NotReady
in log show error:
cni.go:196] Unable to update cni config: No networks found in /etc/cni/net.d

i move kubernetes-apps/network_plugin before kubernetes-apps/rotate_tokens, and now daemonset flannel started and created config file in /etc/cni/net.d, node go to be Ready, and pod with rotate-token-test launch succesfull
