### PR TITLE
Use fail-swap-on flag only for kube_version >= 1.8

### DIFF
--- a/roles/kubernetes/node/templates/kubelet.kubeadm.env.j2
+++ b/roles/kubernetes/node/templates/kubelet.kubeadm.env.j2
@@ -28,7 +28,11 @@ KUBELET_HOSTNAME="--hostname-override={{ kube_override_hostname }}"
 --node-status-update-frequency={{ kubelet_status_update_frequency }} \
 --cgroup-driver={{ kubelet_cgroup_driver|default(kubelet_cgroup_driver_detected) }} \
 --docker-disable-shared-pid={{ kubelet_disable_shared_pid }} \
+{% if kube_version | version_compare('v1.8', '<') %}
+--experimental-fail-swap-on={{ kubelet_fail_swap_on|default(true)}} \
+{% else %}
 --fail-swap-on={{ kubelet_fail_swap_on|default(true)}} \
+{% endif %}
 {% endset %}
 
 {# Node reserved CPU/memory #}

--- a/roles/kubernetes/node/templates/kubelet.standard.env.j2
+++ b/roles/kubernetes/node/templates/kubelet.standard.env.j2
@@ -24,7 +24,11 @@ KUBELET_HOSTNAME="--hostname-override={{ kube_override_hostname }}"
 {% endif %}
 --cgroup-driver={{ kubelet_cgroup_driver|default(kubelet_cgroup_driver_detected) }} \
 --cgroups-per-qos={{ kubelet_cgroups_per_qos }} \
+{% if kube_version | version_compare('v1.8', '<') %}
+--experimental-fail-swap-on={{ kubelet_fail_swap_on|default(true)}} \
+{% else %}
 --fail-swap-on={{ kubelet_fail_swap_on|default(true)}} \
+{% endif %}
 --enforce-node-allocatable={{ kubelet_enforce_node_allocatable }} {% endif %}{% endset %}
 
 {# DNS settings for kubelet #}


### PR DESCRIPTION
Kubelet < 1.8 do not accept `--fail-swap-on` flag.