### PR TITLE
Refactor terraform openstack into modules

### DIFF
--- a/contrib/terraform/openstack/kubespray.tf
+++ b/contrib/terraform/openstack/kubespray.tf
@@ -1,226 +1,35 @@
-resource "openstack_networking_floatingip_v2" "k8s_master" {
-    count = "${var.number_of_k8s_masters + var.number_of_k8s_masters_no_etcd}"
-    pool = "${var.floatingip_pool}"
+module "ips" {
+  source = "modules/ips"
+
+  number_of_k8s_masters = "${var.number_of_k8s_masters}"
+  number_of_k8s_masters_no_etcd = "${var.number_of_k8s_masters_no_etcd}"
+  number_of_k8s_nodes = "${var.number_of_k8s_nodes}"
+  floatingip_pool = "${var.floatingip_pool}"
 }
 
-resource "openstack_networking_floatingip_v2" "k8s_node" {
-    count = "${var.number_of_k8s_nodes}"
-    pool = "${var.floatingip_pool}"
+module "compute" {
+  source = "modules/compute"
+
+  cluster_name = "${var.cluster_name}"
+  number_of_k8s_masters = "${var.number_of_k8s_masters}"
+  number_of_k8s_masters_no_etcd = "${var.number_of_k8s_masters_no_etcd}"
+  number_of_etcd = "${var.number_of_etcd}"
+  number_of_k8s_masters_no_floating_ip = "${var.number_of_k8s_masters_no_floating_ip}"
+  number_of_k8s_masters_no_floating_ip_no_etcd = "${var.number_of_k8s_masters_no_floating_ip_no_etcd}"
+  number_of_k8s_nodes = "${var.number_of_k8s_nodes}"
+  number_of_k8s_nodes_no_floating_ip = "${var.number_of_k8s_nodes_no_floating_ip}"
+  number_of_gfs_nodes_no_floating_ip = "${var.number_of_gfs_nodes_no_floating_ip}"
+  gfs_volume_size_in_gb = "${var.gfs_volume_size_in_gb}"
+  public_key_path = "${var.public_key_path}"
+  image = "${var.image}"
+  image_gfs = "${var.image_gfs}"
+  ssh_user = "${var.ssh_user}"
+  ssh_user_gfs = "${var.ssh_user_gfs}"
+  flavor_k8s_master = "${var.flavor_k8s_master}"
+  flavor_k8s_node = "${var.flavor_k8s_node}"
+  flavor_etcd = "${var.flavor_etcd}"
+  flavor_gfs_node = "${var.flavor_gfs_node}"
+  network_name = "${var.network_name}"
+  k8s_master_fips = "${module.ips.k8s_master_fips}"
+  k8s_node_fips = "${module.ips.k8s_node_fips}"
 }
-
-
-resource "openstack_compute_keypair_v2" "k8s" {
-    name = "kubernetes-${var.cluster_name}"
-    public_key = "${file(var.public_key_path)}"
-}
-
-resource "openstack_compute_secgroup_v2" "k8s_master" {
-    name = "${var.cluster_name}-k8s-master"
-    description = "${var.cluster_name} - Kubernetes Master"
-}
-
-resource "openstack_compute_secgroup_v2" "k8s" {
-    name = "${var.cluster_name}-k8s"
-    description = "${var.cluster_name} - Kubernetes"
-    rule {
-        ip_protocol = "tcp"
-        from_port = "22"
-        to_port = "22"
-        cidr = "0.0.0.0/0"
-    }
-    rule {
-        ip_protocol = "icmp"
-        from_port = "-1"
-        to_port = "-1"
-        cidr = "0.0.0.0/0"
-    }
-    rule {
-        ip_protocol = "tcp"
-        from_port = "1"
-        to_port = "65535"
-        self = true
-    }
-    rule {
-        ip_protocol = "udp"
-        from_port = "1"
-        to_port = "65535"
-        self = true
-    }
-    rule {
-        ip_protocol = "icmp"
-        from_port = "-1"
-        to_port = "-1"
-        self = true
-    }
-}
-
-resource "openstack_compute_instance_v2" "k8s_master" {
-    name = "${var.cluster_name}-k8s-master-${count.index+1}"
-    count = "${var.number_of_k8s_masters}"
-    image_name = "${var.image}"
-    flavor_id = "${var.flavor_k8s_master}"
-    key_pair = "${openstack_compute_keypair_v2.k8s.name}"
-    network {
-        name = "${var.network_name}"
-    }
-    security_groups = [ "${openstack_compute_secgroup_v2.k8s_master.name}",
-                        "${openstack_compute_secgroup_v2.k8s.name}" ]
-    floating_ip = "${element(openstack_networking_floatingip_v2.k8s_master.*.address, count.index)}"
-    metadata = {
-        ssh_user = "${var.ssh_user}"
-        kubespray_groups = "etcd,kube-master,kube-node,k8s-cluster,vault"
-    }
-    
-}
-
-resource "openstack_compute_instance_v2" "k8s_master_no_etcd" {
-    name = "${var.cluster_name}-k8s-master-ne-${count.index+1}"
-    count = "${var.number_of_k8s_masters_no_etcd}"
-    image_name = "${var.image}"
-    flavor_id = "${var.flavor_k8s_master}"
-    key_pair = "${openstack_compute_keypair_v2.k8s.name}"
-    network {
-        name = "${var.network_name}"
-    }
-    security_groups = [ "${openstack_compute_secgroup_v2.k8s_master.name}",
-                        "${openstack_compute_secgroup_v2.k8s.name}" ]
-    floating_ip = "${element(openstack_networking_floatingip_v2.k8s_master.*.address, count.index + var.number_of_k8s_masters)}"
-    metadata = {
-        ssh_user = "${var.ssh_user}"
-        kubespray_groups = "kube-master,kube-node,k8s-cluster,vault"
-    }
-    
-}
-
-resource "openstack_compute_instance_v2" "etcd" {
-    name = "${var.cluster_name}-etcd-${count.index+1}"
-    count = "${var.number_of_etcd}"
-    image_name = "${var.image}"
-    flavor_id = "${var.flavor_etcd}"
-    key_pair = "${openstack_compute_keypair_v2.k8s.name}"
-    network {
-        name = "${var.network_name}"
-    }
-    security_groups = [ "${openstack_compute_secgroup_v2.k8s.name}" ]
-    metadata = {
-        ssh_user = "${var.ssh_user}"
-        kubespray_groups = "etcd,vault,no-floating"
-    }
-    provisioner "local-exec" {
-        command = "sed s/USER/${var.ssh_user}/ contrib/terraform/openstack/ansible_bastion_template.txt | sed s/BASTION_ADDRESS/${element(openstack_networking_floatingip_v2.k8s_master.*.address, 0)}/ > contrib/terraform/openstack/group_vars/no-floating.yml"
-    } 
-}
-
-
-resource "openstack_compute_instance_v2" "k8s_master_no_floating_ip" {
-    name = "${var.cluster_name}-k8s-master-nf-${count.index+1}"
-    count = "${var.number_of_k8s_masters_no_floating_ip}"
-    image_name = "${var.image}"
-    flavor_id = "${var.flavor_k8s_master}"
-    key_pair = "${openstack_compute_keypair_v2.k8s.name}"
-    network {
-        name = "${var.network_name}"
-    }
-    security_groups = [ "${openstack_compute_secgroup_v2.k8s_master.name}",
-                        "${openstack_compute_secgroup_v2.k8s.name}" ]
-    metadata = {
-        ssh_user = "${var.ssh_user}"
-        kubespray_groups = "etcd,kube-master,kube-node,k8s-cluster,vault,no-floating"
-    }
-    provisioner "local-exec" {
-        command = "sed s/USER/${var.ssh_user}/ contrib/terraform/openstack/ansible_bastion_template.txt | sed s/BASTION_ADDRESS/${element(openstack_networking_floatingip_v2.k8s_master.*.address, 0)}/ > contrib/terraform/openstack/group_vars/no-floating.yml"
-    }
-}
-
-resource "openstack_compute_instance_v2" "k8s_master_no_floating_ip_no_etcd" {
-    name = "${var.cluster_name}-k8s-master-ne-nf-${count.index+1}"
-    count = "${var.number_of_k8s_masters_no_floating_ip_no_etcd}"
-    image_name = "${var.image}"
-    flavor_id = "${var.flavor_k8s_master}"
-    key_pair = "${openstack_compute_keypair_v2.k8s.name}"
-    network {
-        name = "${var.network_name}"
-    }
-    security_groups = [ "${openstack_compute_secgroup_v2.k8s_master.name}",
-                        "${openstack_compute_secgroup_v2.k8s.name}" ]
-    metadata = {
-        ssh_user = "${var.ssh_user}"
-        kubespray_groups = "kube-master,kube-node,k8s-cluster,vault,no-floating"
-    }
-    provisioner "local-exec" {
-        command = "sed s/USER/${var.ssh_user}/ contrib/terraform/openstack/ansible_bastion_template.txt | sed s/BASTION_ADDRESS/${element(openstack_networking_floatingip_v2.k8s_master.*.address, 0)}/ > contrib/terraform/openstack/group_vars/no-floating.yml"
-    }
-}
-
-
-resource "openstack_compute_instance_v2" "k8s_node" {
-    name = "${var.cluster_name}-k8s-node-${count.index+1}"
-    count = "${var.number_of_k8s_nodes}"
-    image_name = "${var.image}"
-    flavor_id = "${var.flavor_k8s_node}"
-    key_pair = "${openstack_compute_keypair_v2.k8s.name}"
-    network {
-        name = "${var.network_name}"
-    }
-    security_groups = ["${openstack_compute_secgroup_v2.k8s.name}" ]
-    floating_ip = "${element(openstack_networking_floatingip_v2.k8s_node.*.address, count.index)}"
-    metadata = {
-        ssh_user = "${var.ssh_user}"
-        kubespray_groups = "kube-node,k8s-cluster,vault"
-    }
-}
-
-resource "openstack_compute_instance_v2" "k8s_node_no_floating_ip" {
-    name = "${var.cluster_name}-k8s-node-nf-${count.index+1}"
-    count = "${var.number_of_k8s_nodes_no_floating_ip}"
-    image_name = "${var.image}"
-    flavor_id = "${var.flavor_k8s_node}"
-    key_pair = "${openstack_compute_keypair_v2.k8s.name}"
-    network {
-        name = "${var.network_name}"
-    }
-    security_groups = ["${openstack_compute_secgroup_v2.k8s.name}" ]
-    metadata = {
-        ssh_user = "${var.ssh_user}"
-        kubespray_groups = "kube-node,k8s-cluster,vault,no-floating"
-    }
-    provisioner "local-exec" {
-	command = "sed s/USER/${var.ssh_user}/ contrib/terraform/openstack/ansible_bastion_template.txt | sed s/BASTION_ADDRESS/${element(openstack_networking_floatingip_v2.k8s_master.*.address, 0)}/ > contrib/terraform/openstack/group_vars/no-floating.yml"        
-    }
-}
-
-resource "openstack_blockstorage_volume_v2" "glusterfs_volume" {
-  name = "${var.cluster_name}-gfs-nephe-vol-${count.index+1}"
-  count = "${var.number_of_gfs_nodes_no_floating_ip}"
-  description = "Non-ephemeral volume for GlusterFS"
-  size = "${var.gfs_volume_size_in_gb}"
-}
-
-resource "openstack_compute_instance_v2" "glusterfs_node_no_floating_ip" {
-    name = "${var.cluster_name}-gfs-node-nf-${count.index+1}"
-    count = "${var.number_of_gfs_nodes_no_floating_ip}"
-    image_name = "${var.image_gfs}"
-    flavor_id = "${var.flavor_gfs_node}"
-    key_pair = "${openstack_compute_keypair_v2.k8s.name}"
-    network {
-        name = "${var.network_name}"
-    }
-    security_groups = ["${openstack_compute_secgroup_v2.k8s.name}" ]
-    metadata = {
-        ssh_user = "${var.ssh_user_gfs}"
-        kubespray_groups = "gfs-cluster,network-storage"
-    }
-    volume {
-        volume_id = "${element(openstack_blockstorage_volume_v2.glusterfs_volume.*.id, count.index)}"
-    }
-    provisioner "local-exec" {
-	command = "sed s/USER/${var.ssh_user}/ contrib/terraform/openstack/ansible_bastion_template.txt | sed s/BASTION_ADDRESS/${element(openstack_networking_floatingip_v2.k8s_master.*.address, 0)}/ > contrib/terraform/openstack/group_vars/gfs-cluster.yml"        
-    }
-}
-
-
-
-
-#output "msg" {
-#    value = "Your hosts are ready to go!\nYour ssh hosts are: ${join(", ", openstack_networking_floatingip_v2.k8s_master.*.address )}"
-#}

--- a/contrib/terraform/openstack/modules/compute/main.tf
+++ b/contrib/terraform/openstack/modules/compute/main.tf
@@ -1,0 +1,214 @@
+resource "openstack_compute_keypair_v2" "k8s" {
+    name = "kubernetes-${var.cluster_name}"
+    public_key = "${file(var.public_key_path)}"
+}
+
+resource "openstack_compute_secgroup_v2" "k8s_master" {
+    name = "${var.cluster_name}-k8s-master"
+    description = "${var.cluster_name} - Kubernetes Master"
+}
+
+resource "openstack_compute_secgroup_v2" "k8s" {
+    name = "${var.cluster_name}-k8s"
+    description = "${var.cluster_name} - Kubernetes"
+    rule {
+        ip_protocol = "tcp"
+        from_port = "22"
+        to_port = "22"
+        cidr = "0.0.0.0/0"
+    }
+    rule {
+        ip_protocol = "icmp"
+        from_port = "-1"
+        to_port = "-1"
+        cidr = "0.0.0.0/0"
+    }
+    rule {
+        ip_protocol = "tcp"
+        from_port = "1"
+        to_port = "65535"
+        self = true
+    }
+    rule {
+        ip_protocol = "udp"
+        from_port = "1"
+        to_port = "65535"
+        self = true
+    }
+    rule {
+        ip_protocol = "icmp"
+        from_port = "-1"
+        to_port = "-1"
+        self = true
+    }
+}
+
+resource "openstack_compute_instance_v2" "k8s_master" {
+    name = "${var.cluster_name}-k8s-master-${count.index+1}"
+    count = "${var.number_of_k8s_masters}"
+    image_name = "${var.image}"
+    flavor_id = "${var.flavor_k8s_master}"
+    key_pair = "${openstack_compute_keypair_v2.k8s.name}"
+    network {
+        name = "${var.network_name}"
+    }
+    security_groups = [ "${openstack_compute_secgroup_v2.k8s_master.name}",
+                        "${openstack_compute_secgroup_v2.k8s.name}" ]
+    floating_ip = "${var.k8s_master_fips[count.index]}"
+    metadata = {
+        ssh_user = "${var.ssh_user}"
+        kubespray_groups = "etcd,kube-master,kube-node,k8s-cluster,vault"
+    }
+
+}
+
+resource "openstack_compute_instance_v2" "k8s_master_no_etcd" {
+    name = "${var.cluster_name}-k8s-master-ne-${count.index+1}"
+    count = "${var.number_of_k8s_masters_no_etcd}"
+    image_name = "${var.image}"
+    flavor_id = "${var.flavor_k8s_master}"
+    key_pair = "${openstack_compute_keypair_v2.k8s.name}"
+    network {
+        name = "${var.network_name}"
+    }
+    security_groups = [ "${openstack_compute_secgroup_v2.k8s_master.name}",
+                        "${openstack_compute_secgroup_v2.k8s.name}" ]
+    floating_ip = "${var.k8s_master_fips[count.index + var.number_of_k8s_masters]}"
+    metadata = {
+        ssh_user = "${var.ssh_user}"
+        kubespray_groups = "kube-master,kube-node,k8s-cluster,vault"
+    }
+}
+
+resource "openstack_compute_instance_v2" "etcd" {
+    name = "${var.cluster_name}-etcd-${count.index+1}"
+    count = "${var.number_of_etcd}"
+    image_name = "${var.image}"
+    flavor_id = "${var.flavor_etcd}"
+    key_pair = "${openstack_compute_keypair_v2.k8s.name}"
+    network {
+        name = "${var.network_name}"
+    }
+    security_groups = [ "${openstack_compute_secgroup_v2.k8s.name}" ]
+    metadata = {
+        ssh_user = "${var.ssh_user}"
+        kubespray_groups = "etcd,vault,no-floating"
+    }
+    provisioner "local-exec" {
+        command = "sed s/USER/${var.ssh_user}/ contrib/terraform/openstack/ansible_bastion_template.txt | sed s/BASTION_ADDRESS/${var.k8s_master_fips[0]}/ > contrib/terraform/openstack/group_vars/no-floating.yml"
+    }
+}
+
+
+resource "openstack_compute_instance_v2" "k8s_master_no_floating_ip" {
+    name = "${var.cluster_name}-k8s-master-nf-${count.index+1}"
+    count = "${var.number_of_k8s_masters_no_floating_ip}"
+    image_name = "${var.image}"
+    flavor_id = "${var.flavor_k8s_master}"
+    key_pair = "${openstack_compute_keypair_v2.k8s.name}"
+    network {
+        name = "${var.network_name}"
+    }
+    security_groups = [ "${openstack_compute_secgroup_v2.k8s_master.name}",
+                        "${openstack_compute_secgroup_v2.k8s.name}" ]
+    metadata = {
+        ssh_user = "${var.ssh_user}"
+        kubespray_groups = "etcd,kube-master,kube-node,k8s-cluster,vault,no-floating"
+    }
+    provisioner "local-exec" {
+        command = "sed s/USER/${var.ssh_user}/ contrib/terraform/openstack/ansible_bastion_template.txt | sed s/BASTION_ADDRESS/${var.k8s_master_fips[0]}/ > contrib/terraform/openstack/group_vars/no-floating.yml"
+    }
+}
+
+resource "openstack_compute_instance_v2" "k8s_master_no_floating_ip_no_etcd" {
+    name = "${var.cluster_name}-k8s-master-ne-nf-${count.index+1}"
+    count = "${var.number_of_k8s_masters_no_floating_ip_no_etcd}"
+    image_name = "${var.image}"
+    flavor_id = "${var.flavor_k8s_master}"
+    key_pair = "${openstack_compute_keypair_v2.k8s.name}"
+    network {
+        name = "${var.network_name}"
+    }
+    security_groups = [ "${openstack_compute_secgroup_v2.k8s_master.name}",
+                        "${openstack_compute_secgroup_v2.k8s.name}" ]
+    metadata = {
+        ssh_user = "${var.ssh_user}"
+        kubespray_groups = "kube-master,kube-node,k8s-cluster,vault,no-floating"
+    }
+    provisioner "local-exec" {
+        command = "sed s/USER/${var.ssh_user}/ contrib/terraform/openstack/ansible_bastion_template.txt | sed s/BASTION_ADDRESS/${var.k8s_master_fips[0]}/ > contrib/terraform/openstack/group_vars/no-floating.yml"
+    }
+}
+
+
+resource "openstack_compute_instance_v2" "k8s_node" {
+    name = "${var.cluster_name}-k8s-node-${count.index+1}"
+    count = "${var.number_of_k8s_nodes}"
+    image_name = "${var.image}"
+    flavor_id = "${var.flavor_k8s_node}"
+    key_pair = "${openstack_compute_keypair_v2.k8s.name}"
+    network {
+        name = "${var.network_name}"
+    }
+    security_groups = ["${openstack_compute_secgroup_v2.k8s.name}" ]
+    floating_ip = "${var.k8s_node_fips[count.index]}"
+    metadata = {
+        ssh_user = "${var.ssh_user}"
+        kubespray_groups = "kube-node,k8s-cluster,vault"
+    }
+}
+
+resource "openstack_compute_instance_v2" "k8s_node_no_floating_ip" {
+    name = "${var.cluster_name}-k8s-node-nf-${count.index+1}"
+    count = "${var.number_of_k8s_nodes_no_floating_ip}"
+    image_name = "${var.image}"
+    flavor_id = "${var.flavor_k8s_node}"
+    key_pair = "${openstack_compute_keypair_v2.k8s.name}"
+    network {
+        name = "${var.network_name}"
+    }
+    security_groups = ["${openstack_compute_secgroup_v2.k8s.name}" ]
+    metadata = {
+        ssh_user = "${var.ssh_user}"
+        kubespray_groups = "kube-node,k8s-cluster,vault,no-floating"
+    }
+    provisioner "local-exec" {
+	command = "sed s/USER/${var.ssh_user}/ contrib/terraform/openstack/ansible_bastion_template.txt | sed s/BASTION_ADDRESS/${var.k8s_master_fips[0]}/ > contrib/terraform/openstack/group_vars/no-floating.yml"
+    }
+}
+
+resource "openstack_blockstorage_volume_v2" "glusterfs_volume" {
+  name = "${var.cluster_name}-gfs-nephe-vol-${count.index+1}"
+  count = "${var.number_of_gfs_nodes_no_floating_ip}"
+  description = "Non-ephemeral volume for GlusterFS"
+  size = "${var.gfs_volume_size_in_gb}"
+}
+
+resource "openstack_compute_instance_v2" "glusterfs_node_no_floating_ip" {
+    name = "${var.cluster_name}-gfs-node-nf-${count.index+1}"
+    count = "${var.number_of_gfs_nodes_no_floating_ip}"
+    image_name = "${var.image_gfs}"
+    flavor_id = "${var.flavor_gfs_node}"
+    key_pair = "${openstack_compute_keypair_v2.k8s.name}"
+    network {
+        name = "${var.network_name}"
+    }
+    security_groups = ["${openstack_compute_secgroup_v2.k8s.name}" ]
+    metadata = {
+        ssh_user = "${var.ssh_user_gfs}"
+        kubespray_groups = "gfs-cluster,network-storage"
+    }
+    volume {
+        volume_id = "${element(openstack_blockstorage_volume_v2.glusterfs_volume.*.id, count.index)}"
+    }
+    provisioner "local-exec" {
+	command = "sed s/USER/${var.ssh_user}/ contrib/terraform/openstack/ansible_bastion_template.txt | sed s/BASTION_ADDRESS/${var.k8s_master_fips[0]}/ > contrib/terraform/openstack/group_vars/gfs-cluster.yml"
+    }
+}
+
+
+
+
+#output "msg" {
+#    value = "Your hosts are ready to go!\nYour ssh hosts are: ${join(", ", openstack_networking_floatingip_v2.k8s_master.*.address )}"
+#}

--- a/contrib/terraform/openstack/modules/compute/variables.tf
+++ b/contrib/terraform/openstack/modules/compute/variables.tf
@@ -1,0 +1,67 @@
+variable "cluster_name" {
+}
+
+variable "number_of_k8s_masters" {
+}
+
+variable "number_of_k8s_masters_no_etcd" {
+}
+
+variable "number_of_etcd" {
+}
+
+variable "number_of_k8s_masters_no_floating_ip" {
+}
+
+variable "number_of_k8s_masters_no_floating_ip_no_etcd" {
+}
+
+variable "number_of_k8s_nodes" {
+}
+
+variable "number_of_k8s_nodes_no_floating_ip" {
+}
+
+variable "number_of_gfs_nodes_no_floating_ip" {
+}
+
+variable "gfs_volume_size_in_gb" {
+}
+
+variable "public_key_path" {
+}
+
+variable "image" {
+}
+
+variable "image_gfs" {
+}
+
+variable "ssh_user" {
+}
+
+variable "ssh_user_gfs" {
+}
+
+variable "flavor_k8s_master" {
+}
+
+variable "flavor_k8s_node" {
+}
+
+variable "flavor_etcd" {
+}
+
+variable "flavor_gfs_node" {
+}
+
+variable "network_name" {
+}
+
+variable "k8s_master_fips" {
+  type = "list"
+}
+
+variable "k8s_node_fips" {
+  type = "list"
+}

--- a/contrib/terraform/openstack/modules/ips/main.tf
+++ b/contrib/terraform/openstack/modules/ips/main.tf
@@ -1,0 +1,9 @@
+resource "openstack_networking_floatingip_v2" "k8s_master" {
+    count = "${var.number_of_k8s_masters + var.number_of_k8s_masters_no_etcd}"
+    pool = "${var.floatingip_pool}"
+}
+
+resource "openstack_networking_floatingip_v2" "k8s_node" {
+    count = "${var.number_of_k8s_nodes}"
+    pool = "${var.floatingip_pool}"
+}

--- a/contrib/terraform/openstack/modules/ips/outputs.tf
+++ b/contrib/terraform/openstack/modules/ips/outputs.tf
@@ -1,0 +1,7 @@
+output "k8s_master_fips" {
+    value = ["${openstack_networking_floatingip_v2.k8s_master.*.address}"]
+}
+
+output "k8s_node_fips" {
+    value = ["${openstack_networking_floatingip_v2.k8s_node.*.address}"]
+}

--- a/contrib/terraform/openstack/modules/ips/variables.tf
+++ b/contrib/terraform/openstack/modules/ips/variables.tf
@@ -1,0 +1,11 @@
+variable "number_of_k8s_masters" {
+}
+
+variable "number_of_k8s_masters_no_etcd" {
+}
+
+variable "number_of_k8s_nodes" {
+}
+
+variable "floatingip_pool" {
+}


### PR DESCRIPTION
**Cloud provider:** Openstack, provisined with Terraform
**Terraform version:** v0.9.11
**Kubespray version:** 54320c5b


## Use case:

`contrib/terraform/openstack/kubespray.tf` dynamically requests new floating IPs from the external pool, and releases them when `terraform destroy` is run. This means:
- It is not possible to use an existing (unattached) floating IP that already belongs to a tenancy, which is a problem when floating IPs are limited by a quota 
- If you have any external references to the floating IP (e.g. DNS) this has to be updated
- Changing this behaviour requires modifying (and therefore forking) `contrib/terraform/openstack/kubespray.tf`


## What this PR does

`kubespray.tf` is split into two modules:
- `modules/ips` handles floating ips
- `modules/compute` handles everything else

`kubespray.tf` is modified to use these modules but the behaviour should be unchanged.

These modules can be reused outside of this repository, and in future could be further divided, or optional modules added, for instance to setup a default network.

## Example of running this with existing floating IPs:
```diff
$ diff -u kubespray.tf kubespray.tf.nofloatingip

--- kubespray.tf        2017-10-18 16:23:29.000000000 +0100
+++ kubespray.tf.nofloatingip   2017-10-18 16:22:32.000000000 +0100
@@ -1,12 +1,3 @@
-module "ips" {
-  source = "modules/ips"
-
-  number_of_k8s_masters = "${var.number_of_k8s_masters}"
-  number_of_k8s_masters_no_etcd = "${var.number_of_k8s_masters_no_etcd}"
-  number_of_k8s_nodes = "${var.number_of_k8s_nodes}"
-  floatingip_pool = "${var.floatingip_pool}"
-}
-
 module "compute" {
   source = "modules/compute"

@@ -30,6 +21,6 @@
   flavor_etcd = "${var.flavor_etcd}"
   flavor_gfs_node = "${var.flavor_gfs_node}"
   network_name = "${var.network_name}"
-  k8s_master_fips = "${module.ips.k8s_master_fips}"
-  k8s_node_fips = "${module.ips.k8s_node_fips}"
+  k8s_master_fips = ["10.0.0.1"]
+  k8s_node_fips = ["10.0.0.2"]
 }
```


## Additional information

- There's a lot of duplication in the original `variables.tf` and the module variables files `modules/*/variables.tf`, I can't see how to get around this.
- This does not work with Terraform 0.10 due to a breaking change (`openstack_compute_instance_v2.{floating_ip,volume}` were removed): https://github.com/terraform-providers/terraform-provider-openstack/blob/master/CHANGELOG.md#010-june-21-2017. I've got some commits on a separate branch to get this working with 0.10 but it also requires changes to the `terraform.py` dynamic inventory.
- Comparison of old `kubespray.tf` with the new modules:

```diff
$ diff -u kubespray.tf.orig <(cat modules/ips/main.tf modules/compute/main.tf)

--- kubespray.tf.orig	2017-10-18 15:52:27.000000000 +0100
+++ /dev/fd/63	2017-10-18 16:51:13.000000000 +0100
@@ -7,8 +7,6 @@
     count = "${var.number_of_k8s_nodes}"
     pool = "${var.floatingip_pool}"
 }
-
-
 resource "openstack_compute_keypair_v2" "k8s" {
     name = "kubernetes-${var.cluster_name}"
     public_key = "${file(var.public_key_path)}"
@@ -65,12 +63,12 @@
     }
     security_groups = [ "${openstack_compute_secgroup_v2.k8s_master.name}",
                         "${openstack_compute_secgroup_v2.k8s.name}" ]
-    floating_ip = "${element(openstack_networking_floatingip_v2.k8s_master.*.address, count.index)}"
+    floating_ip = "${var.k8s_master_fips[count.index]}"
     metadata = {
         ssh_user = "${var.ssh_user}"
         kubespray_groups = "etcd,kube-master,kube-node,k8s-cluster,vault"
     }
-    
+
 }
 
 resource "openstack_compute_instance_v2" "k8s_master_no_etcd" {
@@ -84,12 +82,11 @@
     }
     security_groups = [ "${openstack_compute_secgroup_v2.k8s_master.name}",
                         "${openstack_compute_secgroup_v2.k8s.name}" ]
-    floating_ip = "${element(openstack_networking_floatingip_v2.k8s_master.*.address, count.index + var.number_of_k8s_masters)}"
+    floating_ip = "${var.k8s_master_fips[count.index + var.number_of_k8s_masters]}"
     metadata = {
         ssh_user = "${var.ssh_user}"
         kubespray_groups = "kube-master,kube-node,k8s-cluster,vault"
     }
-    
 }
 
 resource "openstack_compute_instance_v2" "etcd" {
@@ -107,8 +104,8 @@
         kubespray_groups = "etcd,vault,no-floating"
     }
     provisioner "local-exec" {
-        command = "sed s/USER/${var.ssh_user}/ contrib/terraform/openstack/ansible_bastion_template.txt | sed s/BASTION_ADDRESS/${element(openstack_networking_floatingip_v2.k8s_master.*.address, 0)}/ > contrib/terraform/openstack/group_vars/no-floating.yml"
-    } 
+        command = "sed s/USER/${var.ssh_user}/ contrib/terraform/openstack/ansible_bastion_template.txt | sed s/BASTION_ADDRESS/${var.k8s_master_fips[0]}/ > contrib/terraform/openstack/group_vars/no-floating.yml"
+    }
 }
 
 
@@ -128,7 +125,7 @@
         kubespray_groups = "etcd,kube-master,kube-node,k8s-cluster,vault,no-floating"
     }
     provisioner "local-exec" {
-        command = "sed s/USER/${var.ssh_user}/ contrib/terraform/openstack/ansible_bastion_template.txt | sed s/BASTION_ADDRESS/${element(openstack_networking_floatingip_v2.k8s_master.*.address, 0)}/ > contrib/terraform/openstack/group_vars/no-floating.yml"
+        command = "sed s/USER/${var.ssh_user}/ contrib/terraform/openstack/ansible_bastion_template.txt | sed s/BASTION_ADDRESS/${var.k8s_master_fips[0]}/ > contrib/terraform/openstack/group_vars/no-floating.yml"
     }
 }
 
@@ -148,7 +145,7 @@
         kubespray_groups = "kube-master,kube-node,k8s-cluster,vault,no-floating"
     }
     provisioner "local-exec" {
-        command = "sed s/USER/${var.ssh_user}/ contrib/terraform/openstack/ansible_bastion_template.txt | sed s/BASTION_ADDRESS/${element(openstack_networking_floatingip_v2.k8s_master.*.address, 0)}/ > contrib/terraform/openstack/group_vars/no-floating.yml"
+        command = "sed s/USER/${var.ssh_user}/ contrib/terraform/openstack/ansible_bastion_template.txt | sed s/BASTION_ADDRESS/${var.k8s_master_fips[0]}/ > contrib/terraform/openstack/group_vars/no-floating.yml"
     }
 }
 
@@ -163,7 +160,7 @@
         name = "${var.network_name}"
     }
     security_groups = ["${openstack_compute_secgroup_v2.k8s.name}" ]
-    floating_ip = "${element(openstack_networking_floatingip_v2.k8s_node.*.address, count.index)}"
+    floating_ip = "${var.k8s_node_fips[count.index]}"
     metadata = {
         ssh_user = "${var.ssh_user}"
         kubespray_groups = "kube-node,k8s-cluster,vault"
@@ -185,7 +182,7 @@
         kubespray_groups = "kube-node,k8s-cluster,vault,no-floating"
     }
     provisioner "local-exec" {
-	command = "sed s/USER/${var.ssh_user}/ contrib/terraform/openstack/ansible_bastion_template.txt | sed s/BASTION_ADDRESS/${element(openstack_networking_floatingip_v2.k8s_master.*.address, 0)}/ > contrib/terraform/openstack/group_vars/no-floating.yml"        
+	command = "sed s/USER/${var.ssh_user}/ contrib/terraform/openstack/ansible_bastion_template.txt | sed s/BASTION_ADDRESS/${var.k8s_master_fips[0]}/ > contrib/terraform/openstack/group_vars/no-floating.yml"
     }
 }
 
@@ -214,7 +211,7 @@
         volume_id = "${element(openstack_blockstorage_volume_v2.glusterfs_volume.*.id, count.index)}"
     }
     provisioner "local-exec" {
-	command = "sed s/USER/${var.ssh_user}/ contrib/terraform/openstack/ansible_bastion_template.txt | sed s/BASTION_ADDRESS/${element(openstack_networking_floatingip_v2.k8s_master.*.address, 0)}/ > contrib/terraform/openstack/group_vars/gfs-cluster.yml"        
+	command = "sed s/USER/${var.ssh_user}/ contrib/terraform/openstack/ansible_bastion_template.txt | sed s/BASTION_ADDRESS/${var.k8s_master_fips[0]}/ > contrib/terraform/openstack/group_vars/gfs-cluster.yml"
     }
 }
 ```
