### PR TITLE
Fix systemd service unit for docker >= 17.03

### DIFF
--- a/roles/docker/templates/docker.service.j2
+++ b/roles/docker/templates/docker.service.j2
@@ -18,7 +18,7 @@ Environment=GOTRACEBACK=crash
 ExecReload=/bin/kill -s HUP $MAINPID
 Delegate=yes
 KillMode=process
-ExecStart={{ docker_bin_dir }}/docker daemon \
+ExecStart={{ docker_bin_dir }}/docker{% if docker_version.stdout|version_compare('17.03', '<') %} daemon{% else %}d{% endif %} \
           $DOCKER_OPTS \
           $DOCKER_STORAGE_OPTIONS \
           $DOCKER_NETWORK_OPTIONS \


### PR DESCRIPTION
Starting with docker 17.03, docker daemon has to be run using dockerd binary instead of docker daemon.
This PR should support all versions.