### PR TITLE
Use include instead of import tasks to support v2.3

### DIFF
--- a/roles/download/tasks/main.yml
+++ b/roles/download/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- import_tasks: download_prep.yml
+- include: download_prep.yml
   when:
     - not skip_downloads|default(false)
 


### PR DESCRIPTION
Eventually 2.3 support will be dropped, so this is
a temporary change.