### PR TITLE
Make ClusterRoleBinding to admit all nodes with right cert

### DIFF
--- a/roles/kubernetes-apps/ansible/tasks/main.yml
+++ b/roles/kubernetes-apps/ansible/tasks/main.yml
@@ -8,6 +8,23 @@
   delay: 6
   when: inventory_hostname == groups['kube-master'][0]
 
+- name: Kubernetes Apps | Add ClusterRoleBinding to admit nodes
+  template:
+    src: "node-crb.yml.j2"
+    dest: "{{ kube_config_dir }}/node-crb.yml"
+  register: node_crb_manifest
+  when: rbac_enabled
+
+- name: Apply workaround to allow all nodes with cert O=system:nodes to register
+  kube:
+    name: "system:node"
+    kubectl: "{{bin_dir}}/kubectl"
+    resource: "clusterrolebinding"
+    filename: "{{ kube_config_dir }}/node-crb.yml"
+  when:
+    - rbac_enabled
+    - node_crb_manifest.changed
+
 - name: Kubernetes Apps | Delete old kubedns resources
   kube:
     name: "kubedns"

--- a/roles/kubernetes-apps/ansible/templates/node-crb.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/node-crb.yml.j2
@@ -1,0 +1,17 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+  name: system:node
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:node
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:nodes


### PR DESCRIPTION
This is to work around #1856 which can occur when kubelet
hostname and resolvable hostname (or cloud instance name)
do not match.