### PR TITLE
Proxy Handling: Make use of hidden uri argument: use_proxy: false

### DIFF
--- a/roles/etcd/handlers/main.yml
+++ b/roles/etcd/handlers/main.yml
@@ -22,6 +22,7 @@
   uri:
     url: "https://{% if is_etcd_master %}{{ etcd_address }}{% else %}127.0.0.1{% endif %}:2379/health"
     validate_certs: no
+    use_proxy: false
   register: result
   until: result.status is defined and result.status == 200
   retries: 10

--- a/roles/kubernetes-apps/ansible/tasks/main.yml
+++ b/roles/kubernetes-apps/ansible/tasks/main.yml
@@ -2,6 +2,7 @@
 - name: Kubernetes Apps | Wait for kube-apiserver
   uri:
     url: "{{ kube_apiserver_insecure_endpoint }}/healthz"
+    use_proxy: false
   register: result
   until: result.status == 200
   retries: 10

--- a/roles/kubernetes-apps/network_plugin/weave/tasks/main.yml
+++ b/roles/kubernetes-apps/network_plugin/weave/tasks/main.yml
@@ -13,6 +13,7 @@
   uri:
     url: http://127.0.0.1:6784/status
     return_content: yes
+    use_proxy: false    
   register: weave_status
   retries: 180
   delay: 5

--- a/roles/kubernetes-apps/network_plugin/weave/tasks/main.yml
+++ b/roles/kubernetes-apps/network_plugin/weave/tasks/main.yml
@@ -13,7 +13,7 @@
   uri:
     url: http://127.0.0.1:6784/status
     return_content: yes
-    use_proxy: false    
+    use_proxy: false
   register: weave_status
   retries: 180
   delay: 5

--- a/roles/kubernetes-apps/rotate_tokens/tasks/main.yml
+++ b/roles/kubernetes-apps/rotate_tokens/tasks/main.yml
@@ -14,7 +14,7 @@
     method: GET
     return_content: no
     validate_certs: no
-    use_proxy: false    
+    use_proxy: false
     headers:
       Authorization: "Bearer {{ (default_token_data.stdout|from_json)['data']['token']|b64decode }}"
   register: check_secret

--- a/roles/kubernetes-apps/rotate_tokens/tasks/main.yml
+++ b/roles/kubernetes-apps/rotate_tokens/tasks/main.yml
@@ -14,6 +14,7 @@
     method: GET
     return_content: no
     validate_certs: no
+    use_proxy: false    
     headers:
       Authorization: "Bearer {{ (default_token_data.stdout|from_json)['data']['token']|b64decode }}"
   register: check_secret

--- a/roles/kubernetes/master/handlers/main.yml
+++ b/roles/kubernetes/master/handlers/main.yml
@@ -24,6 +24,7 @@
 - name: Master | wait for kube-scheduler
   uri:
     url: http://localhost:10251/healthz
+    use_proxy: false
   register: scheduler_result
   until: scheduler_result.status == 200
   retries: 60
@@ -32,6 +33,7 @@
 - name: Master | wait for kube-controller-manager
   uri:
     url: http://localhost:10252/healthz
+    use_proxy: false
   register: controller_manager_result
   until: controller_manager_result.status == 200
   retries: 15
@@ -40,6 +42,7 @@
 - name: Master | wait for the apiserver to be running
   uri:
     url: "{{ kube_apiserver_insecure_endpoint }}/healthz"
+    use_proxy: false
   register: result
   until: result.status == 200
   retries: 20

--- a/roles/network_plugin/calico/tasks/main.yml
+++ b/roles/network_plugin/calico/tasks/main.yml
@@ -83,6 +83,7 @@
   uri:
     url: https://localhost:2379/health
     validate_certs: no
+    use_proxy: false
   register: result
   until: result.status == 200 or result.status == 401
   retries: 10

--- a/roles/vault/tasks/bootstrap/start_vault_temp.yml
+++ b/roles/vault/tasks/bootstrap/start_vault_temp.yml
@@ -19,6 +19,7 @@
 - name: bootstrap/start_vault_temp | Initialize vault-temp
   uri:
     url: "http://localhost:{{ vault_port }}/v1/sys/init"
+    use_proxy: false
     headers: "{{ vault_client_headers }}"
     method: PUT
     body_format: json
@@ -38,6 +39,7 @@
 - name: bootstrap/start_vault_temp | Unseal vault-temp
   uri:
     url: "http://localhost:{{ vault_port }}/v1/sys/unseal"
+    use_proxy: false
     headers: "{{ vault_headers }}"
     method: POST
     body_format: json

--- a/roles/vault/tasks/cluster/init.yml
+++ b/roles/vault/tasks/cluster/init.yml
@@ -3,6 +3,7 @@
 - name: cluster/init | Initialize Vault
   uri:
     url: "https://{{ groups.vault|first }}:{{ vault_port }}/v1/sys/init"
+    use_proxy: false
     headers: "{{ vault_client_headers }}"
     method: POST
     body_format: json

--- a/roles/vault/tasks/cluster/systemd.yml
+++ b/roles/vault/tasks/cluster/systemd.yml
@@ -38,6 +38,7 @@
 - name: cluster/systemd | Query local vault until service is up
   uri:
     url: "{{ vault_config.listener.tcp.tls_disable|d()|ternary('http', 'https') }}://localhost:{{ vault_port }}/v1/sys/health"
+    use_proxy: false
     headers: "{{ vault_client_headers }}"
     status_code: 200,429,500,501
   register: vault_health_check

--- a/roles/vault/tasks/cluster/unseal.yml
+++ b/roles/vault/tasks/cluster/unseal.yml
@@ -6,6 +6,7 @@
 - name: cluster/unseal | Unseal Vault
   uri:
     url: "https://localhost:{{ vault_port }}/v1/sys/unseal"
+    use_proxy: false
     headers: "{{ vault_headers }}"
     method: POST
     body_format: json
@@ -17,6 +18,7 @@
 - name: cluster/unseal | Wait until server is ready
   uri:
     url: "https://localhost:{{ vault_port }}/v1/sys/health"
+    use_proxy: false
     headers: "{{ vault_headers }}"
     method: HEAD
     status_code: 200, 429

--- a/roles/vault/tasks/shared/auth_backend.yml
+++ b/roles/vault/tasks/shared/auth_backend.yml
@@ -2,6 +2,7 @@
 - name: shared/auth_backend | Test if the auth backend exists
   uri:
     url: "{{ vault_leader_url }}/v1/sys/auth/{{ auth_backend_path }}/tune"
+    use_proxy: false
     headers: "{{ vault_headers }}"
     validate_certs: false
   ignore_errors: true
@@ -10,6 +11,7 @@
 - name: shared/auth_backend | Add the cert auth backend if needed
   uri:
     url: "{{ vault_leader_url }}/v1/sys/auth/{{ auth_backend_path }}"
+    use_proxy: false
     headers: "{{ vault_headers }}"
     method: POST
     body_format: json

--- a/roles/vault/tasks/shared/cert_auth_mount.yml
+++ b/roles/vault/tasks/shared/cert_auth_mount.yml
@@ -12,6 +12,7 @@
 - name: shared/auth_mount | Create a dummy role for issuing certs from auth-pki
   uri:
     url: "{{ hostvars[groups.vault|first]['vault_leader_url'] }}/v1/auth-pki/roles/dummy"
+    use_proxy: false
     headers: "{{ hostvars[groups.vault|first]['vault_headers'] }}"
     method: POST
     body_format: json

--- a/roles/vault/tasks/shared/check_etcd.yml
+++ b/roles/vault/tasks/shared/check_etcd.yml
@@ -3,6 +3,7 @@
 - name: check_etcd | Check if etcd is up and reachable
   uri:
     url: "{{ vault_etcd_url }}/health"
+    use_proxy: false
     validate_certs: no
     return_content: yes
   until: vault_etcd_health_check.status == 200 or vault_etcd_health_check.status == 401

--- a/roles/vault/tasks/shared/check_vault.yml
+++ b/roles/vault/tasks/shared/check_vault.yml
@@ -10,6 +10,7 @@
 - name: check_vault | Attempt to pull local https Vault health
   uri:
     url: "{{ vault_config.listener.tcp.tls_disable|d()|ternary('http', 'https') }}://localhost:{{ vault_port }}/v1/sys/health"
+    use_proxy: false
     headers: "{{ vault_client_headers }}"
     status_code: 200,429,500,501,503
     validate_certs: no

--- a/roles/vault/tasks/shared/config_ca.yml
+++ b/roles/vault/tasks/shared/config_ca.yml
@@ -6,6 +6,7 @@
 - name: config_ca | Pull current CA cert from Vault
   uri:
     url: "{{ vault_leader_url }}/v1/{{ config_ca_mount_path }}/ca/pem"
+    use_proxy: false
     headers: "{{ vault_headers }}"
     return_content: true
     status_code: 200,204
@@ -20,6 +21,7 @@
 - name: config_ca | Configure pki mount to use the found root CA cert and key
   uri:
     url: "{{ vault_leader_url }}/v1/{{ config_ca_mount_path }}/config/ca"
+    use_proxy: false
     headers: "{{ vault_headers }}"
     method: POST
     body_format: json

--- a/roles/vault/tasks/shared/create_role.yml
+++ b/roles/vault/tasks/shared/create_role.yml
@@ -3,6 +3,7 @@
 - name: create_role | Create a policy for the new role allowing issuing
   uri:
     url: "{{ hostvars[groups.vault|first]['vault_leader_url'] }}/v1/sys/policy/{{ create_role_name }}"
+    use_proxy: false
     headers: "{{ hostvars[groups.vault|first]['vault_headers'] }}"
     method: PUT
     body_format: json
@@ -25,6 +26,7 @@
 - name: create_role | Create {{ create_role_name }} role in the {{ create_role_mount_path }} pki mount
   uri:
     url: "{{ hostvars[groups.vault|first]['vault_leader_url'] }}/v1/{{ create_role_mount_path }}/roles/{{ create_role_name }}"
+    use_proxy: false
     headers: "{{ hostvars[groups.vault|first]['vault_headers'] }}"
     method: POST
     body_format: json

--- a/roles/vault/tasks/shared/find_leader.yml
+++ b/roles/vault/tasks/shared/find_leader.yml
@@ -3,6 +3,7 @@
 - name: find_leader | Find the current http Vault leader
   uri:
     url: "{{ vault_config.listener.tcp.tls_disable|d()|ternary('http', 'https') }}://localhost:{{ vault_port }}/v1/sys/health"
+    use_proxy: false
     headers: "{{ hostvars[groups.vault|first]['vault_headers'] }}"
     method: HEAD
     status_code: 200,429,503

--- a/roles/vault/tasks/shared/gen_ca.yml
+++ b/roles/vault/tasks/shared/gen_ca.yml
@@ -8,6 +8,7 @@
 - name: "bootstrap/gen_ca | Generate {{ gen_ca_mount_path }} root CA"
   uri:
     url: "{{ vault_leader_url }}/v1/{{ gen_ca_mount_path }}/root/generate/exported"
+    use_proxy: false
     headers: "{{ gen_ca_vault_headers }}"
     method: POST
     body_format: json

--- a/roles/vault/tasks/shared/gen_userpass.yml
+++ b/roles/vault/tasks/shared/gen_userpass.yml
@@ -2,6 +2,7 @@
 - name: shared/gen_userpass | Create the Username/Password combo for the role
   uri:
     url: "{{ hostvars[groups.vault|first]['vault_leader_url'] }}/v1/auth/userpass/users/{{ gen_userpass_username }}"
+    use_proxy: false
     headers: "{{ hostvars[groups.vault|first]['vault_headers'] }}"
     method: POST
     body_format: json

--- a/roles/vault/tasks/shared/issue_cert.yml
+++ b/roles/vault/tasks/shared/issue_cert.yml
@@ -41,6 +41,7 @@
 - name: gen_certs_vault | Log into Vault and obtain an token
   uri:
     url: "{{ hostvars[groups.vault|first]['vault_leader_url'] }}/v1/auth/userpass/login/{{ user_vault_creds.username }}"
+    use_proxy: false
     headers:
       Accept: application/json
       Content-Type: application/json
@@ -69,6 +70,7 @@
 - name: "issue_cert | Generate {{ issue_cert_path }} for {{ issue_cert_role }} role"
   uri:
     url: "{{ issue_cert_url }}/v1/{{ issue_cert_mount_path|d('pki') }}/issue/{{ issue_cert_role }}"
+    use_proxy: false
     headers: "{{ issue_cert_headers }}"
     method: POST
     body_format: json

--- a/roles/vault/tasks/shared/pki_mount.yml
+++ b/roles/vault/tasks/shared/pki_mount.yml
@@ -2,6 +2,7 @@
 - name: "shared/mount | Test if {{ pki_mount_path }} PKI mount exists"
   uri:
     url: "{{ vault_leader_url }}/v1/sys/mounts/{{ pki_mount_path }}/tune"
+    use_proxy: false
     headers: "{{ vault_headers }}"
   ignore_errors: true
   register: vault_pki_mount_check
@@ -14,6 +15,7 @@
 - name: shared/mount | Mount {{ pki_mount_path }} PKI mount if needed
   uri:
     url: "{{ vault_leader_url }}/v1/sys/mounts/{{ pki_mount_path }}"
+    use_proxy: false
     headers: "{{ vault_headers }}"
     method: POST
     body_format: json


### PR DESCRIPTION
The uri moule has hidden argumentssuch as use_proxy :
As all health checks ar done in the cluster, we should force use_proxy: false, so any proxy configuration won't break the uri calls.

ok: [localhost] => {
    "changed": false,
    "connection": "Keep-Alive",
    "content_length": "2724",
    "content_type": "text/html; charset=UTF-8",
    "cookies": {},
    "date": "Wed, 25 Oct 2017 08:49:35 GMT",
    "failed": false,
    "invocation": {
        "module_args": {
            "attributes": null,
            "backup": null,
            "body": null,
            "body_format": "raw",
            "client_cert": null,
            "client_key": null,
            "content": null,
            "creates": null,
            "delimiter": null,
            "dest": null,
            "directory_mode": null,
            "follow": false,
            "follow_redirects": "safe",
            "force": false,
            "force_basic_auth": false,
            "group": null,
            "headers": {},
            "http_agent": "ansible-httpget",
            "method": "GET",
            "mode": null,
            "owner": null,
            "regexp": null,
            "remote_src": null,
            "removes": null,
            "return_content": false,
            "selevel": null,
            "serole": null,
            "setype": null,
            "seuser": null,
            "src": null,
            "status_code": [
                200
            ],
            "timeout": 30,
            "unsafe_writes": null,
            "url": "http://www.cgoogle.com",
            "url_password": null,
            "url_username": null,
            **"use_proxy": true,**
            "validate_certs": true
        }
    },
    "keep_alive": "timeout=5, max=39",
    "msg": "OK (2724 bytes)",
    "redirected": false,
    "server": "Apache",
    "status": 200,
    "url": "http://www.cgoogle.com",
    "x_adblock_key": "MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBAKX74ixpzVyXbJprcLfbH4psP4+L2entqri0lzh6pkAaXLPIcclv6DQBeJJjGFWrBIF6QMyFwXT5CCRyjS2penECAwEAAQ==_Zcf+n9TGenmu9radHqXbjDb+/BSBtdL3oFDCj6dIesloUTjDD0Jb2HVyuYJxmT8jJbVVoSXWP7LoZhkjCwUrvQ=="
