### PR TITLE
Update network policy setting for Kubernetes 1.8

### DIFF
--- a/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
@@ -78,7 +78,9 @@ spec:
 {%   endfor %}
 {% endif %}
 {% if enable_network_policy %}
+  {% if kube_version | version_compare('v1.8', '<')  %}
     - --runtime-config=extensions/v1beta1/networkpolicies=true
+  {% endif %}
 {% endif %}
     - --v={{ kube_log_level }}
     - --allow-privileged=true


### PR DESCRIPTION
It is now enabled by default in 1.8 with the api changed
to networking.k8s.io/v1 instead of extensions/v1beta1.