### PR TITLE
change ssh_args/bastion configuration

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,7 +1,6 @@
 [ssh_connection]
 pipelining=True
-ansible_ssh_common_args = -o ControlMaster=auto -o ControlPersist=30m -o ConnectionAttempts=100
-#ansible_ssh_common_args = -F {{ inventory_dir|quote }}/ssh-bastion.conf -o ControlMaster=auto -o ControlPersist=30m -o ConnectionAttempts=100
+ssh_args = -o ControlMaster=auto -o ControlPersist=30m -o ConnectionAttempts=100 -o UserKnownHostsFile=/dev/null
 #control_path = ~/.ssh/ansible-%%r@%%h:%%p
 [defaults]
 host_key_checking=False
@@ -12,3 +11,4 @@ stdout_callback = skippy
 library = ./library
 callback_whitelist = profile_tasks
 roles_path = roles:$VIRTUAL_ENV/usr/local/share/kubespray/roles:$VIRTUAL_ENV/usr/local/share/ansible/roles
+deprecation_warnings=False

--- a/contrib/terraform/aws/README.md
+++ b/contrib/terraform/aws/README.md
@@ -36,9 +36,10 @@ terraform apply -var-file=credentials.tfvars -var 'loadbalancer_apiserver_addres
 
 - Terraform automatically creates an Ansible Inventory file called `hosts` with the created infrastructure in the directory `inventory`
 
-- Ansible will automatically generate an ssh config file for your bastion hosts. To make use of it, make sure you have a line in your `ansible.cfg` file that looks like the following:
+- Ansible will automatically generate an ssh config file for your bastion hosts. To connect to hosts with ssh using bastion host use generated ssh-bastion.conf. 
+  Ansible automatically detects bastion and changes ssh_args  
 ```commandline
-ssh_args = -F ./ssh-bastion.conf -o ControlMaster=auto -o ControlPersist=30m 
+ssh -F ./ssh-bastion.conf user@$ip 
 ```
 
 - Once the infrastructure is created, you can run the kubespray playbooks and supply inventory/hosts with the `-i` flag.

--- a/roles/bastion-ssh-config/templates/ssh-bastion.conf
+++ b/roles/bastion-ssh-config/templates/ssh-bastion.conf
@@ -16,7 +16,5 @@ Host {{ bastion_ip }}
   ControlPersist 5m
 
 Host {{ vars['hosts'] }}
-  ProxyCommand ssh -W %h:%p {{ real_user }}@{{ bastion_ip }} {% if ansible_ssh_private_key_file is defined %}-i {{ ansible_ssh_private_key_file }}{% endif %}
-
-  StrictHostKeyChecking no
+  ProxyCommand ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -W %h:%p {{ real_user }}@{{ bastion_ip }} {% if ansible_ssh_private_key_file is defined %}-i {{ ansible_ssh_private_key_file }}{% endif %}
 {% endif %}

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -2,6 +2,11 @@
 ## Required for bootstrap-os/preinstall/download roles and setting facts
 # Valid bootstrap options (required): ubuntu, coreos, centos, none
 bootstrap_os: none
+
+# Use proxycommand if bastion host is in group all
+# This change obseletes editing ansible.cfg file depending on bastion existance
+ansible_ssh_common_args: "{% if 'bastion' in groups['all'] %} -o ProxyCommand='ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -W %h:%p {{ ansible_user }}@{{hostvars['bastion']['ansible_host']}} ' {% endif %}"
+
 kube_api_anonymous_auth: false
 
 # Default value, but will be set to true automatically if detected


### PR DESCRIPTION
* there was wrong usage of ansible_ssh_common_args, you cannot use that in ansible.cfg, there still should be ssh_args
* now ansible automatically detects if it uses bastion host (if it's provided in inventory) and configures ansible_ssh_common_args in kubespray-defaults to use bastion
* ssh-bastion.conf still generates and can be used for manual ssh to hosts.
* updated terraform readme also with new information