### PR TITLE
Force kubelet certificates to be generated as lowercase

### DIFF
--- a/roles/kubernetes/secrets/files/make-ssl.sh
+++ b/roles/kubernetes/secrets/files/make-ssl.sh
@@ -105,14 +105,13 @@ fi
 if [ -n "$HOSTS" ]; then
     for host in $HOSTS; do
         cn="${host%%.*}"
-        gen_key_and_cert "node-${host}" "/CN=system:node:${cn}/O=system:nodes"
+        gen_key_and_cert "node-${host}" "/CN=system:node:${cn,,}/O=system:nodes"
     done
 fi
 
 # system:node-proxier
 if [ -n "$HOSTS" ]; then
     for host in $HOSTS; do
-        cn="${host%%.*}"
         # kube-proxy
         gen_key_and_cert "kube-proxy-${host}" "/CN=system:kube-proxy/O=system:node-proxier"
     done


### PR DESCRIPTION
All nodes get converted to lowercase, so certs should set
CN with lowercase as well.