### PR TITLE
Fix the issue where cluster upgrade does not restart kubelet service

### DIFF
--- a/roles/kubernetes/node/templates/kubelet.docker.service.j2
+++ b/roles/kubernetes/node/templates/kubelet.docker.service.j2
@@ -1,3 +1,4 @@
+# kubelet_version={{ kube_version }}
 [Unit]
 Description=Kubernetes Kubelet Server
 Documentation=https://github.com/GoogleCloudPlatform/kubernetes

--- a/roles/kubernetes/node/templates/kubelet.host.service.j2
+++ b/roles/kubernetes/node/templates/kubelet.host.service.j2
@@ -1,3 +1,4 @@
+# kubelet_version={{ kube_version }}
 [Unit]
 Description=Kubernetes Kubelet Server
 Documentation=https://github.com/GoogleCloudPlatform/kubernetes

--- a/roles/kubernetes/node/templates/kubelet.rkt.service.j2
+++ b/roles/kubernetes/node/templates/kubelet.rkt.service.j2
@@ -1,3 +1,4 @@
+# kubelet_version={{ kube_version }}
 [Unit]
 Description=Kubernetes Kubelet Server
 Documentation=https://github.com/GoogleCloudPlatform/kubernetes


### PR DESCRIPTION
Using the `upgrade.yml` playbook for cluster upgrade, even though the various components updated with the new version of the executables, `kubectl get nodes` still shows that the cluster is on the old kube version.

Dug around the playbook, it turns out that the step [`install | Write kubelet systemd init file`](https://github.com/kubernetes-incubator/kubespray/blob/master/roles/kubernetes/node/tasks/install.yml#L40-L47) which is supposed to restart the kubelet service after it's done did not restart the kubelet service. This is due to the fact that an upgrade does not change the content of the systemd unit file and as a result, the handler was not fired.

The fix here is to write the kubernetes version as a comment in the systemd unit file, so an upgrade to a different version will rewrite this file, causing the `notify` handler to be executed.

This is a bit of a hack, granted. I'm open to other suggestions.