### PR TITLE
Parameterize dockerproject apt repo endpoints

### DIFF
--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -16,3 +16,5 @@ docker_container_storage_setup: false
 
 docker_rh_repo_base_url: 'https://yum.dockerproject.org/repo/main/centos/7'
 docker_rh_repo_gpgkey: 'https://yum.dockerproject.org/gpg'
+docker_apt_repo_base_url: 'https://apt.dockerproject.org/repo'
+docker_apt_repo_gpgkey: 'https://apt.dockerproject.org/gpg'

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -34,7 +34,7 @@
   action: "{{ docker_repo_key_info.pkg_key }}"
   args:
     id: "{{item}}"
-    keyserver: "{{docker_repo_key_info.keyserver}}"
+    url: "{{docker_repo_key_info.url}}"
     state: present
   register: keyserver_task_result
   until: keyserver_task_result|succeeded

--- a/roles/docker/vars/debian.yml
+++ b/roles/docker/vars/debian.yml
@@ -18,7 +18,7 @@ docker_package_info:
 
 docker_repo_key_info:
   pkg_key: apt_key
-  keyserver: hkp://p80.pool.sks-keyservers.net:80
+  url: '{{ docker_apt_repo_gpgkey }}'
   repo_keys:
     - 58118E89F3A912897C070ADBF76221572C52609D
 
@@ -26,6 +26,6 @@ docker_repo_info:
   pkg_repo: apt_repository
   repos:
     - >
-       deb https://apt.dockerproject.org/repo
+       deb {{ docker_apt_repo_base_url }}
        {{ ansible_distribution|lower }}-{{ ansible_distribution_release|lower }}
        main

--- a/roles/docker/vars/ubuntu.yml
+++ b/roles/docker/vars/ubuntu.yml
@@ -18,7 +18,7 @@ docker_package_info:
 
 docker_repo_key_info:
   pkg_key: apt_key
-  keyserver: hkp://p80.pool.sks-keyservers.net:80
+  url: '{{ docker_apt_repo_gpgkey }}'
   repo_keys:
     - 58118E89F3A912897C070ADBF76221572C52609D
 
@@ -26,6 +26,6 @@ docker_repo_info:
   pkg_repo: apt_repository
   repos:
     - >
-       deb https://apt.dockerproject.org/repo
+       deb {{ docker_apt_repo_base_url }}
        {{ ansible_distribution|lower }}-{{ ansible_distribution_release|lower }}
        main


### PR DESCRIPTION
This allows overriding of apt repo endpoints when internet sources are not accessible. Additionally, switch to using the dockerproject.org gpg key url for apt instead of keyservers.net