### PR TITLE
Improved proxy support

### DIFF
--- a/cluster.yml
+++ b/cluster.yml
@@ -32,36 +32,42 @@
       tags: rkt
       when: "'rkt' in [etcd_deployment_type, kubelet_deployment_type, vault_deployment_type]"
     - { role: download, tags: download, skip_downloads: false }
+  environment: "{{proxy_env}}"
 
 - hosts: etcd:k8s-cluster:vault
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   roles:
     - { role: kubespray-defaults, when: "cert_management == 'vault'" }
     - { role: vault, tags: vault, vault_bootstrap: true, when: "cert_management == 'vault'" }
+  environment: "{{proxy_env}}"
 
 - hosts: etcd
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   roles:
     - { role: kubespray-defaults}
     - { role: etcd, tags: etcd, etcd_cluster_setup: true }
+  environment: "{{proxy_env}}"
 
 - hosts: k8s-cluster
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   roles:
     - { role: kubespray-defaults}
     - { role: etcd, tags: etcd, etcd_cluster_setup: false }
+  environment: "{{proxy_env}}"
 
 - hosts: etcd:k8s-cluster:vault
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   roles:
     - { role: kubespray-defaults}
     - { role: vault, tags: vault, when: "cert_management == 'vault'"}
+  environment: "{{proxy_env}}"
 
 - hosts: k8s-cluster
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   roles:
     - { role: kubespray-defaults}
     - { role: kubernetes/node, tags: node }
+  environment: "{{proxy_env}}"
 
 - hosts: kube-master
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
@@ -70,6 +76,7 @@
     - { role: kubernetes/master, tags: master }
     - { role: kubernetes/client, tags: client }
     - { role: kubernetes-apps/cluster_roles, tags: cluster-roles }
+  environment: "{{proxy_env}}"
 
 - hosts: k8s-cluster
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
@@ -77,6 +84,7 @@
     - { role: kubespray-defaults}
     - { role: kubernetes/kubeadm, tags: kubeadm, when: "kubeadm_enabled" }
     - { role: network_plugin, tags: network }
+  environment: "{{proxy_env}}"
 
 - hosts: kube-master
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
@@ -85,12 +93,14 @@
     - { role: kubernetes-apps/rotate_tokens, tags: rotate_tokens, when: "secret_changed|default(false)" }
     - { role: kubernetes-apps/network_plugin, tags: network }
     - { role: kubernetes-apps/policy_controller, tags: policy-controller }
+  environment: "{{proxy_env}}"
 
 - hosts: calico-rr
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   roles:
     - { role: kubespray-defaults}
     - { role: network_plugin/calico/rr, tags: network }
+  environment: "{{proxy_env}}"
 
 - hosts: k8s-cluster
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
@@ -98,9 +108,11 @@
     - { role: kubespray-defaults}
     - { role: dnsmasq, when: "dns_mode == 'dnsmasq_kubedns'", tags: dnsmasq }
     - { role: kubernetes/preinstall, when: "dns_mode != 'none' and resolvconf_mode == 'host_resolvconf'", tags: resolvconf }
+  environment: "{{proxy_env}}"
 
 - hosts: kube-master[0]
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   roles:
     - { role: kubespray-defaults}
     - { role: kubernetes-apps, tags: apps }
+  environment: "{{proxy_env}}"

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -40,7 +40,6 @@
   until: keyserver_task_result|succeeded
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
-  environment: "{{ proxy_env }}"
   with_items: "{{ docker_repo_key_info.repo_keys }}"
   when: not (ansible_os_family in ["CoreOS", "Container Linux by CoreOS"] or is_atomic)
 
@@ -68,7 +67,6 @@
   until: docker_task_result|succeeded
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
-  environment: "{{ proxy_env }}"
   with_items: "{{ docker_package_info.pkgs }}"
   notify: restart docker
   when: not (ansible_os_family in ["CoreOS", "Container Linux by CoreOS"] or is_atomic) and (docker_package_info.pkgs|length > 0)

--- a/roles/download/tasks/download_container.yml
+++ b/roles/download/tasks/download_container.yml
@@ -16,7 +16,6 @@
   until: pull_task_result|succeeded
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
-  environment: "{{ proxy_env }}"
   when:
     - download.enabled
     - download.container

--- a/roles/download/tasks/download_file.yml
+++ b/roles/download/tasks/download_file.yml
@@ -25,7 +25,6 @@
   until: "'OK' in get_url_result.msg or 'file already exists' in get_url_result.msg"
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
-  environment: "{{ proxy_env }}"
   when:
     - download.enabled
     - download.file

--- a/roles/kubernetes-apps/helm/templates/helm-container.j2
+++ b/roles/kubernetes-apps/helm/templates/helm-container.j2
@@ -7,7 +7,7 @@
   {% for dir in ssl_ca_dirs -%}
   -v {{ dir }}:{{ dir }}:ro \
   {% endfor -%} 
-  {% if proxy_env is defined -%}
+  {% if http_proxy is defined or https_proxy is defined -%}
   -e http_proxy="{{proxy_env.http_proxy}}" \
   -e https_proxy="{{proxy_env.https_proxy}}" \
   -e no_proxy="{{proxy_env.no_proxy}}" \

--- a/roles/kubernetes-apps/helm/templates/helm-container.j2
+++ b/roles/kubernetes-apps/helm/templates/helm-container.j2
@@ -6,6 +6,11 @@
   -v {{ helm_home_dir }}:{{ helm_home_dir }}:rw \
   {% for dir in ssl_ca_dirs -%}
   -v {{ dir }}:{{ dir }}:ro \
-  {% endfor -%}
+  {% endfor -%} 
+  {% if proxy_env is defined -%}
+  -e http_proxy="{{proxy_env.http_proxy}}" \
+  -e https_proxy="{{proxy_env.https_proxy}}" \
+  -e no_proxy="{{proxy_env.no_proxy}}" \
+  {% endif -%}
   {{ helm_image_repo }}:{{ helm_image_tag}} \
   "$@"

--- a/roles/kubernetes/preinstall/tasks/main.yml
+++ b/roles/kubernetes/preinstall/tasks/main.yml
@@ -113,7 +113,6 @@
   until: yum_task_result|succeeded
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
-  environment: "{{ proxy_env }}"
   when:
     - ansible_pkg_mgr == 'yum'
     - not is_atomic
@@ -126,7 +125,6 @@
     state: latest
     update_cache: yes
     cache_valid_time: 3600
-  environment: "{{ proxy_env }}"
   when: ansible_os_family == "Debian"
   tags:
     - bootstrap-os
@@ -137,7 +135,6 @@
   until: dnf_task_result|succeeded
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
-  environment: "{{ proxy_env }}"
   when:
     - ansible_distribution == "Fedora"
     - ansible_distribution_major_version > 21
@@ -152,7 +149,6 @@
   until: epel_task_result|succeeded
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
-  environment: "{{ proxy_env }}"
   changed_when: False
   when:
     - ansible_distribution in ["CentOS","RedHat"]
@@ -172,7 +168,6 @@
   until: pkgs_task_result|succeeded
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
-  environment: "{{ proxy_env }}"
   with_items: "{{required_pkgs | default([]) | union(common_required_pkgs|default([]))}}"
   when: not (ansible_os_family in ["CoreOS", "Container Linux by CoreOS"] or is_atomic)
   tags:

--- a/roles/rkt/tasks/install.yml
+++ b/roles/rkt/tasks/install.yml
@@ -23,7 +23,6 @@
   until: rkt_task_result|succeeded
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
-  environment: "{{ proxy_env }}"
   when: ansible_os_family == "Debian"
 
 - name: install rkt pkg on centos
@@ -34,5 +33,4 @@
   until: rkt_task_result|succeeded
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
-  environment: "{{ proxy_env }}"
   when: ansible_os_family == "RedHat"

--- a/roles/vault/tasks/cluster/systemd.yml
+++ b/roles/vault/tasks/cluster/systemd.yml
@@ -30,7 +30,7 @@
 
 - name: Create vault service systemd directory
   file:
-    path: /etc/systemd/system/vault.service.d 
+    path: /etc/systemd/system/vault.service.d
     state: directory
 
 - name: cluster/systemd | Add vault proxy env vars
@@ -38,7 +38,7 @@
     src: "http-proxy.conf.j2"
     dest: /etc/systemd/system/vault.service.d/http-proxy.conf
     backup: yes
-  when: http_proxy is defined or https_proxy is defined or no_proxy is defined
+  when: http_proxy is defined or https_proxy is defined
 
 - name: cluster/systemd | Enable vault.service
   systemd:

--- a/roles/vault/tasks/cluster/systemd.yml
+++ b/roles/vault/tasks/cluster/systemd.yml
@@ -28,6 +28,18 @@
     backup: yes
   register: vault_systemd_placement
 
+- name: Create vault service systemd directory
+  file:
+    path: /etc/systemd/system/vault.service.d 
+    state: directory
+
+- name: cluster/systemd | Add vault proxy env vars
+  template:
+    src: "http-proxy.conf.j2"
+    dest: /etc/systemd/system/vault.service.d/http-proxy.conf
+    backup: yes
+  when: http_proxy is defined or https_proxy is defined or no_proxy is defined
+
 - name: cluster/systemd | Enable vault.service
   systemd:
     daemon_reload: true

--- a/roles/vault/templates/http-proxy.conf.j2
+++ b/roles/vault/templates/http-proxy.conf.j2
@@ -1,0 +1,2 @@
+[Service]
+Environment={% if http_proxy %}"HTTP_PROXY={{ http_proxy }}"{% endif %} {% if https_proxy %}"HTTPS_PROXY={{ https_proxy }}"{% endif %} {% if no_proxy %}"NO_PROXY={{ no_proxy }}"{% endif %}


### PR DESCRIPTION
I'm still testing this internally, but I believe this proxy support PR is complete. The goal here is to add the ensure that all tasks have access to proxy variables if they exist. There were several tasks that were still failing in our environment when using proxies. Especially vault, rkt, and helm. I moved the environment conditions from each task into cluster.yml. This will ensure that proxy info is available everywhere and when this info is not provided (no proxies in use), these environment variables are simply empty strings.

Will remove the WIP tag when I've built successfully in both environments internally.