### PR TITLE
Fix apiserver manifest template

### DIFF
--- a/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
@@ -77,10 +77,8 @@ spec:
     - --runtime-config={{ conf }}
 {%   endfor %}
 {% endif %}
-{% if enable_network_policy %}
-  {% if kube_version | version_compare('v1.8', '<')  %}
+{% if enable_network_policy and kube_version | version_compare('v1.8', '<') }
     - --runtime-config=extensions/v1beta1/networkpolicies=true
-  {% endif %}
 {% endif %}
     - --v={{ kube_log_level }}
     - --allow-privileged=true


### PR DESCRIPTION
There was an extra indention on the `--v` flag
when enable_netword_policy is set and version < v1.8