### PR TITLE
Update kubelet.kubeadm.env.j2 

### DIFF
--- a/roles/kubernetes/node/templates/kubelet.kubeadm.env.j2
+++ b/roles/kubernetes/node/templates/kubelet.kubeadm.env.j2
@@ -2,7 +2,7 @@
 ### All upstream values should be present in this file
 
 # logging to stderr means we get it in the systemd journal
-KUBE_LOGGING="--logtostderr=true"
+KUBE_LOGTOSTDERR="--logtostderr=true"
 KUBE_LOG_LEVEL="--v={{ kube_log_level }}"
 # The address for the info server to serve on (set to 0.0.0.0 or "" for all interfaces)
 KUBELET_ADDRESS="--address={{ ip | default("0.0.0.0") }} {% if ip is defined %} --node-ip={{ ip }}{% endif %}"


### PR DESCRIPTION
I think the variables name used on systemd is KUBE_LOGTOSTDERR, on the following template we use KUBE_LOGGING. The KUBE_LOGGING is not referenced nowhere on the code. Can someone please confirm? 