### PR TITLE
loadbalancer_api wrong variables in ini style formatting

### DIFF
--- a/contrib/terraform/aws/create-infrastructure.tf
+++ b/contrib/terraform/aws/create-infrastructure.tf
@@ -172,8 +172,7 @@ data "template_file" "inventory" {
         list_node = "${join("\n",aws_instance.k8s-worker.*.tags.Name)}"
         list_etcd = "${join("\n",aws_instance.k8s-etcd.*.tags.Name)}"
         elb_api_fqdn = "apiserver_loadbalancer_domain_name=\"${module.aws-elb.aws_elb_api_fqdn}\""
-        elb_api_port = "loadbalancer_apiserver.port=${var.aws_elb_api_port}"
-        loadbalancer_apiserver_address = "loadbalancer_apiserver.address=${var.loadbalancer_apiserver_address}"
+        elb_api_server = "loadbalancer_apiserver={\"port\": ${var.aws_elb_api_port}, \"address\": \"${var.loadbalancer_apiserver_address}\"}"
     }
 
 }

--- a/contrib/terraform/aws/templates/inventory.tpl
+++ b/contrib/terraform/aws/templates/inventory.tpl
@@ -25,5 +25,4 @@ kube-master
 
 [k8s-cluster:vars]
 ${elb_api_fqdn}
-${elb_api_port}
-${loadbalancer_apiserver_address}
+${elb_api_server}


### PR DESCRIPTION
Change loadbalancer_api to generate dict not 2 variables with . in them.