### PR TITLE
Avoid that checking-statement produces an ansible change state

### DIFF
--- a/roles/bootstrap-os/tasks/bootstrap-coreos.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-coreos.yml
@@ -3,6 +3,7 @@
   raw: stat /opt/bin/.bootstrapped
   register: need_bootstrap
   failed_when: false
+  changed_when: false
   tags:
     - facts
 

--- a/roles/bootstrap-os/tasks/bootstrap-debian.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-debian.yml
@@ -5,6 +5,7 @@
   raw: which "{{ item }}"
   register: need_bootstrap
   failed_when: false
+  changed_when: false
   with_items:
     - python
     - pip

--- a/roles/bootstrap-os/tasks/bootstrap-ubuntu.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-ubuntu.yml
@@ -5,6 +5,7 @@
   raw: which "{{ item }}"
   register: need_bootstrap
   failed_when: false
+  changed_when: false
   with_items:
     - python
     - pip

--- a/roles/kubernetes-apps/rotate_tokens/tasks/main.yml
+++ b/roles/kubernetes-apps/rotate_tokens/tasks/main.yml
@@ -2,10 +2,12 @@
 - name: Rotate Tokens | Get default token name
   shell: "{{ bin_dir }}/kubectl get secrets -o custom-columns=name:{.metadata.name} --no-headers | grep -m1 default-token"
   register: default_token
+  changed_when: false
 
 - name: Rotate Tokens | Get default token data
   command: "{{ bin_dir }}/kubectl get secrets {{ default_token.stdout }} -ojson"
   register: default_token_data
+  changed_when: false
   run_once: true
 
 - name: Rotate Tokens | Test if default certificate is expired

--- a/roles/kubernetes/secrets/tasks/main.yml
+++ b/roles/kubernetes/secrets/tasks/main.yml
@@ -80,6 +80,7 @@
 - name: "Gen_certs | Get certificate serials on kube masters"
   shell: "openssl x509 -in {{ kube_cert_dir }}/{{ item }} -noout -serial | cut -d= -f2"
   register: "master_certificate_serials"
+  changed_when: false
   with_items:
     - "admin-{{ inventory_hostname }}.pem"
     - "apiserver.pem"
@@ -98,6 +99,7 @@
 - name: "Gen_certs | Get certificate serials on kube nodes"
   shell: "openssl x509 -in {{ kube_cert_dir }}/{{ item }} -noout -serial | cut -d= -f2"
   register: "node_certificate_serials"
+  changed_when: false
   with_items:
     - "node-{{ inventory_hostname }}.pem"
     - "kube-proxy-{{ inventory_hostname }}.pem"


### PR DESCRIPTION
The ansible task "Check if bootstrap is needed" is a pure read-only
task and therefor should not cause a pseudo "change" in the summary.