### PR TITLE
Eliminate jinja2 template expression warning and rename coreos-python var

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -122,7 +122,7 @@ Vagrant.configure("2") do |config|
       }
 
       config.vm.network :private_network, ip: ip
-      
+
       # workaround for Vagrant 1.9.1 and centos vm
       # https://github.com/hashicorp/vagrant/issues/8096
       if Vagrant::VERSION == "1.9.1" && $os == "centos"
@@ -140,7 +140,7 @@ Vagrant.configure("2") do |config|
           if File.exist?(File.join(File.dirname($inventory), "hosts"))
             ansible.inventory_path = $inventory
           end
-          ansible.sudo = true
+          ansible.become = true
           ansible.limit = "all"
           ansible.host_key_checking = false
           ansible.raw_arguments = ["--forks=#{$num_instances}", "--flush-cache"]

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -75,7 +75,7 @@ kube-apiserver via port 8080. A kubeconfig file is not necessary in this case,
 because kubectl will use http://localhost:8080 to connect. The kubeconfig files
 generated will point to localhost (on kube-masters) and kube-node hosts will
 connect either to a localhost nginx proxy or to a loadbalancer if configured.
-More details on this process are in the [HA guide](ha.md).
+More details on this process are in the [HA guide](ha-mode.md).
 
 Kubespray permits connecting to the cluster remotely on any IP of any 
 kube-master host on port 6443 by default. However, this requires 

--- a/roles/bootstrap-os/defaults/main.yml
+++ b/roles/bootstrap-os/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
 pypy_version: 2.4.0
-pip_python_modules:
+pip_python_coreos_modules:
   - httplib2
   - six

--- a/roles/bootstrap-os/defaults/main.yml
+++ b/roles/bootstrap-os/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
-pypy_version: 2.4.0
 pip_python_coreos_modules:
   - httplib2
   - six

--- a/roles/bootstrap-os/tasks/bootstrap-coreos.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-coreos.yml
@@ -51,4 +51,4 @@
 - name: Install required python modules
   pip:
     name: "{{ item }}"
-  with_items: "{{pip_python_modules}}"
+  with_items: "{{pip_python_coreos_modules}}"

--- a/roles/bootstrap-os/tasks/bootstrap-debian.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-debian.yml
@@ -16,7 +16,7 @@
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y python-minimal python-pip dbus
   when:
-    "{{ need_bootstrap.results | map(attribute='rc') | sort | last | bool }}"
+    need_bootstrap.results | map(attribute='rc') | sort | last | bool
 
 - set_fact:
     ansible_python_interpreter: "/usr/bin/python"


### PR DESCRIPTION
Did some refactorings to eliminate warning and streamline scripts 