### PR TITLE
Workaround ansible bug where access var via dict doesn't get real value

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -122,7 +122,7 @@ Vagrant.configure("2") do |config|
       }
 
       config.vm.network :private_network, ip: ip
-      
+
       # workaround for Vagrant 1.9.1 and centos vm
       # https://github.com/hashicorp/vagrant/issues/8096
       if Vagrant::VERSION == "1.9.1" && $os == "centos"
@@ -140,7 +140,7 @@ Vagrant.configure("2") do |config|
           if File.exist?(File.join(File.dirname($inventory), "hosts"))
             ansible.inventory_path = $inventory
           end
-          ansible.sudo = true
+          ansible.become = true
           ansible.limit = "all"
           ansible.host_key_checking = false
           ansible.raw_arguments = ["--forks=#{$num_instances}", "--flush-cache"]

--- a/roles/kubernetes/preinstall/tasks/verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/verify-settings.yml
@@ -28,20 +28,21 @@
   when: cloud_provider is defined and cloud_provider == 'azure'
   ignore_errors: "{{ ignore_assert_errors }}"
 
+ # simplify this items-list when   https://github.com/ansible/ansible/issues/15753  is resolved
 - name: "Stop if known booleans are set as strings (Use JSON format on CLI: -e \"{'key': true }\")"
   assert:
-    that: vars[item]|type_debug == 'bool'
-    msg: "{{vars[item]}} isn't a bool"
+    that: item.value|type_debug == 'bool'
+    msg: "{{item.value}} isn't a bool"
   run_once: yes
   with_items:
-    - kubeadm_enabled
-    - download_run_once
-    - deploy_netchecker
-    - download_always_pull
-    - efk_enabled
-    - helm_enabled
-    - openstack_lbaas_enabled
-    - rbac_enabled
+    - { name: kubeadm_enabled,      value: "{{ kubeadm_enabled }}" }
+    - { name: download_run_once,    value: "{{ download_run_once }}" }
+    - { name: deploy_netchecker,    value: "{{ deploy_netchecker }}" }
+    - { name: download_always_pull, value: "{{ download_always_pull }}" }
+    - { name: efk_enabled,          value: "{{ efk_enabled }}" }
+    - { name: helm_enabled,         value: "{{ helm_enabled }}" }
+    - { name: openstack_lbaas_enabled, value: "{{ openstack_lbaas_enabled }}" }
+    - { name: rbac_enabled,         value: "{{ rbac_enabled }}" }
   ignore_errors: "{{ ignore_assert_errors }}"
 
 - name: Stop if even number of etcd hosts

--- a/roles/kubernetes/preinstall/tasks/verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/verify-settings.yml
@@ -28,21 +28,21 @@
   when: cloud_provider is defined and cloud_provider == 'azure'
   ignore_errors: "{{ ignore_assert_errors }}"
 
- # simplify this items-list when   https://github.com/ansible/ansible/issues/15753  is resolved
+# simplify this items-list when   https://github.com/ansible/ansible/issues/15753  is resolved
 - name: "Stop if known booleans are set as strings (Use JSON format on CLI: -e \"{'key': true }\")"
   assert:
     that: item.value|type_debug == 'bool'
     msg: "{{item.value}} isn't a bool"
   run_once: yes
   with_items:
-    - { name: kubeadm_enabled,      value: "{{ kubeadm_enabled }}" }
-    - { name: download_run_once,    value: "{{ download_run_once }}" }
-    - { name: deploy_netchecker,    value: "{{ deploy_netchecker }}" }
+    - { name: kubeadm_enabled, value: "{{ kubeadm_enabled }}" }
+    - { name: download_run_once, value: "{{ download_run_once }}" }
+    - { name: deploy_netchecker, value: "{{ deploy_netchecker }}" }
     - { name: download_always_pull, value: "{{ download_always_pull }}" }
-    - { name: efk_enabled,          value: "{{ efk_enabled }}" }
-    - { name: helm_enabled,         value: "{{ helm_enabled }}" }
+    - { name: efk_enabled, value: "{{ efk_enabled }}" }
+    - { name: helm_enabled, value: "{{ helm_enabled }}" }
     - { name: openstack_lbaas_enabled, value: "{{ openstack_lbaas_enabled }}" }
-    - { name: rbac_enabled,         value: "{{ rbac_enabled }}" }
+    - { name: rbac_enabled, value: "{{ rbac_enabled }}" }
   ignore_errors: "{{ ignore_assert_errors }}"
 
 - name: Stop if even number of etcd hosts


### PR DESCRIPTION
When accessing a variable via it's name "{{ foo }}" its value is 
retrieved. But when the variable value is retrieved via the vars-dict
"{{ vars['foo'] }}" this doesn't resolve the expression of the variable
any more due to a bug. So e.g. a expression foo="{{ 1 == 1 }}" isn't 
longer resolved but just returned as string "1 == 1".