### PR TITLE
Fix kubelet container with alternate Docker data paths

### DIFF
--- a/roles/kubernetes/node/templates/kubelet-container.j2
+++ b/roles/kubernetes/node/templates/kubelet-container.j2
@@ -19,7 +19,7 @@
   -v /lib/modules:/lib/modules:ro \
   {% endif -%}
   -v /sys:/sys:ro \
-  -v {{ docker_daemon_graph }}:/var/lib/docker:rw \
+  -v {{ docker_daemon_graph }}:{{ docker_daemon_graph }}:rw \
   -v /var/log:/var/log:rw \
   -v /var/lib/kubelet:/var/lib/kubelet:shared \
   -v /var/lib/cni:/var/lib/cni:shared \


### PR DESCRIPTION
Some time ago I think the hardcoded `/var/lib/docker` was required, but kubelet running in a container has been aware of the Docker path since at least as far back as k8s 1.6.

Without this change, you see a large number of errors in the kubelet logs if you installed with a non-default `docker_daemon_graph`