### PR TITLE
only mount volumes if local_volumes_enabled is true. fix rkt flags

### DIFF
--- a/roles/kubernetes/node/templates/kubelet-container.j2
+++ b/roles/kubernetes/node/templates/kubelet-container.j2
@@ -26,7 +26,9 @@
   -v /var/run:/var/run:rw \
   -v {{kube_config_dir}}:{{kube_config_dir}}:ro \
   -v /etc/os-release:/etc/os-release:ro \
+{% if local_volumes_enabled == true %}
   -v {{ local_volume_base_dir }}:{{ local_volume_base_dir }}:shared \
+{% endif %}
   {{ hyperkube_image_repo }}:{{ hyperkube_image_tag}} \
   ./hyperkube kubelet \
   "$@"

--- a/roles/kubernetes/node/templates/kubelet.rkt.service.j2
+++ b/roles/kubernetes/node/templates/kubelet.rkt.service.j2
@@ -28,11 +28,13 @@ ExecStart=/usr/bin/rkt run \
         --volume var-lib-docker,kind=host,source={{ docker_daemon_graph }},readOnly=false \
         --volume var-lib-kubelet,kind=host,source=/var/lib/kubelet,readOnly=false,recursive=true \
         --volume var-log,kind=host,source=/var/log \
+{% if local_volumes_enabled == true %}
+        --volume local-volume-base-dir,kind=host,source={{ local_volume_base_dir }},readOnly=false,recursive=true \
+{% endif %}
 {% if kube_network_plugin in ["calico", "weave", "canal", "flannel"] %}
         --volume etc-cni,kind=host,source=/etc/cni,readOnly=true \
         --volume opt-cni,kind=host,source=/opt/cni,readOnly=true \
         --volume var-lib-cni,kind=host,source=/var/lib/cni,readOnly=false \
-        --volume local-volume-base-dir,kind=host,source={{ local_volume_base_dir }},readOnly=false,recursive=true \
         --mount volume=etc-cni,target=/etc/cni \
         --mount volume=opt-cni,target=/opt/cni \
         --mount volume=var-lib-cni,target=/var/lib/cni \
@@ -50,7 +52,9 @@ ExecStart=/usr/bin/rkt run \
         --mount volume=var-lib-kubelet,target=/var/lib/kubelet \
         --mount volume=var-log,target=/var/log \
         --mount volume=hosts,target=/etc/hosts \
+{% if local_volumes_enabled == true %}
         --mount volume=local-volume-base-dir,target={{ local_volume_base_dir }} \
+{% endif %}
         --stage1-from-dir=stage1-fly.aci \
 {% if kube_hyperkube_image_repo == "docker" %}
         --insecure-options=image \


### PR DESCRIPTION
Couple of things in here with the new local volume provisioner. I found that with `local_volume_enabled` set to false, I ran into some issues with `/mnt/disks` path not existing (to be expected). So there's a new conditional to check if `local_volume_enabled` is true before providing the mount flags. Also had to fix some small syntax errors in the rkt on and move it out of the conditional that checks for network plugins.