### PR TITLE
Remove proxy settings from etcd and kubernetes/master roles

### DIFF
--- a/cluster.yml
+++ b/cluster.yml
@@ -46,14 +46,12 @@
   roles:
     - { role: kubespray-defaults}
     - { role: etcd, tags: etcd, etcd_cluster_setup: true }
-  environment: "{{proxy_env}}"
 
 - hosts: k8s-cluster
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   roles:
     - { role: kubespray-defaults}
     - { role: etcd, tags: etcd, etcd_cluster_setup: false }
-  environment: "{{proxy_env}}"
 
 - hosts: etcd:k8s-cluster:vault
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
@@ -76,7 +74,6 @@
     - { role: kubernetes/master, tags: master }
     - { role: kubernetes/client, tags: client }
     - { role: kubernetes-apps/cluster_roles, tags: cluster-roles }
-  environment: "{{proxy_env}}"
 
 - hosts: k8s-cluster
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
@@ -84,7 +81,6 @@
     - { role: kubespray-defaults}
     - { role: kubernetes/kubeadm, tags: kubeadm, when: "kubeadm_enabled" }
     - { role: network_plugin, tags: network }
-  environment: "{{proxy_env}}"
 
 - hosts: kube-master
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
@@ -93,14 +89,12 @@
     - { role: kubernetes-apps/rotate_tokens, tags: rotate_tokens, when: "secret_changed|default(false)" }
     - { role: kubernetes-apps/network_plugin, tags: network }
     - { role: kubernetes-apps/policy_controller, tags: policy-controller }
-  environment: "{{proxy_env}}"
 
 - hosts: calico-rr
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   roles:
     - { role: kubespray-defaults}
     - { role: network_plugin/calico/rr, tags: network }
-  environment: "{{proxy_env}}"
 
 - hosts: k8s-cluster
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
@@ -115,4 +109,3 @@
   roles:
     - { role: kubespray-defaults}
     - { role: kubernetes-apps, tags: apps }
-  environment: "{{proxy_env}}"


### PR DESCRIPTION
When proxy vars are set, `uri` module tasks will attempt to route traffic through the proxy. This causes the "Wait for" tasks in the `etcd` and `kubernetes/master` roles to hang, as localhost connections struggle with a proxy.

As far as I know these roles only need local/cluster networking, so a proxy doesn't apply here anyway.