### PR TITLE
Flannel RBAC Fix

### DIFF
--- a/roles/kubernetes-apps/network_plugin/flannel/tasks/main.yml
+++ b/roles/kubernetes-apps/network_plugin/flannel/tasks/main.yml
@@ -1,19 +1,14 @@
 ---
-- name: "Flannel | Create ServiceAccount ClusterRole and ClusterRoleBinding"
-  command: "{{ bin_dir }}/kubectl apply -f {{ kube_config_dir }}/cni-flannel-rbac.yml"
-  run_once: true
-  when: rbac_enabled and flannel_rbac_manifest.changed
-
 - name: Flannel | Start Resources
   kube:
-    name: "kube-flannel"
-    kubectl: "{{ bin_dir }}/kubectl"
-    filename: "{{ kube_config_dir }}/cni-flannel.yml"
-    resource: "ds"
-    namespace: "{{system_namespace}}"
+    name: "{{item.item.name}}"
+    namespace: "{{ system_namespace }}"
+    kubectl: "{{bin_dir}}/kubectl"
+    resource: "{{item.item.type}}"
+    filename: "{{kube_config_dir}}/{{item.item.file}}"
     state: "latest"
-  with_items: "{{ flannel_manifest.changed }}"
-  when: inventory_hostname == groups['kube-master'][0]
+  with_items: "{{ flannel_node_manifests.results }}"
+  when: inventory_hostname == groups['kube-master'][0] and not item|skipped
 
 - name: Flannel | Wait for flannel subnet.env file presence
   wait_for:

--- a/roles/network_plugin/flannel/tasks/main.yml
+++ b/roles/network_plugin/flannel/tasks/main.yml
@@ -1,16 +1,14 @@
 ---
 - include: pre-upgrade.yml
 
-- name: Flannel | Create cni-flannel-rbac manifest
+- name: Flannel | Create Flannel manifests
   template:
-    src: cni-flannel-rbac.yml.j2
-    dest: "{{ kube_config_dir }}/cni-flannel-rbac.yml"
-  register: flannel_rbac_manifest
-  when: inventory_hostname == groups['kube-master'][0] and rbac_enabled
-
-- name: Flannel | Create cni-flannel manifest
-  template:
-    src: cni-flannel.yml.j2
-    dest: "{{ kube_config_dir }}/cni-flannel.yml"
-  register: flannel_manifest
-  when: inventory_hostname == groups['kube-master'][0]
+    src: "{{item.file}}.j2"
+    dest: "{{kube_config_dir}}/{{item.file}}"
+  with_items:
+    - {name: flannel, file: cni-flannel-rbac.yml, type: sa}
+    - {name: kube-flannel, file: cni-flannel.yml, type: ds}
+  register: flannel_node_manifests
+  when:
+    - inventory_hostname in groups['kube-master']
+    - rbac_enabled or item.type not in rbac_resources


### PR DESCRIPTION
Fixes a bug that can occur if `cni-flannel-rbac.yml` was written but the playbook failed before it was applied. Uses the same approach as calico.