### PR TITLE
Support for disabling apiserver insecure port

### DIFF
--- a/inventory/group_vars/k8s-cluster.yml
+++ b/inventory/group_vars/k8s-cluster.yml
@@ -20,7 +20,7 @@ kube_token_dir: "{{ kube_config_dir }}/tokens"
 # This is where to save basic auth file
 kube_users_dir: "{{ kube_config_dir }}/users"
 
-kube_api_anonymous_auth: false
+kube_api_anonymous_auth: true
 
 ## Change this to use another Kubernetes version, e.g. a current beta release
 kube_version: v1.8.2
@@ -106,6 +106,8 @@ kube_network_node_prefix: 24
 kube_apiserver_ip: "{{ kube_service_addresses|ipaddr('net')|ipaddr(1)|ipaddr('address') }}"
 kube_apiserver_port: 6443 # (https)
 kube_apiserver_insecure_port: 8080 # (http)
+# Set to 0 to disable insecure port - Requires RBAC in authorization_modes and kube_api_anonymous_auth: true
+#kube_apiserver_insecure_port: 0 # (disabled)
 
 # DNS configuration.
 # Kubernetes cluster name, also will be used as DNS domain

--- a/roles/kubernetes-apps/ansible/tasks/main.yml
+++ b/roles/kubernetes-apps/ansible/tasks/main.yml
@@ -1,7 +1,10 @@
 ---
 - name: Kubernetes Apps | Wait for kube-apiserver
   uri:
-    url: "{{ kube_apiserver_insecure_endpoint }}/healthz"
+    url: "{{ kube_apiserver_endpoint }}/healthz"
+    validate_certs: no
+    client_cert: "{{ kube_cert_dir }}/apiserver.pem"
+    client_key: "{{ kube_cert_dir }}/apiserver-key.pem"
   register: result
   until: result.status == 200
   retries: 10

--- a/roles/kubernetes-apps/cluster_roles/tasks/main.yml
+++ b/roles/kubernetes-apps/cluster_roles/tasks/main.yml
@@ -1,7 +1,10 @@
 ---
 - name: Kubernetes Apps | Wait for kube-apiserver
   uri:
-    url: "{{ kube_apiserver_insecure_endpoint }}/healthz"
+    url: "{{ kube_apiserver_endpoint }}/healthz"
+    validate_certs: no
+    client_cert: "{{ kube_cert_dir }}/apiserver.pem"
+    client_key: "{{ kube_cert_dir }}/apiserver-key.pem"
   register: result
   until: result.status == 200
   retries: 10

--- a/roles/kubernetes/master/handlers/main.yml
+++ b/roles/kubernetes/master/handlers/main.yml
@@ -39,7 +39,10 @@
 
 - name: Master | wait for the apiserver to be running
   uri:
-    url: "{{ kube_apiserver_insecure_endpoint }}/healthz"
+    url: "{{ kube_apiserver_endpoint }}/healthz"
+    validate_certs: no
+    client_cert: "{{ kube_cert_dir }}/apiserver.pem"
+    client_key: "{{ kube_cert_dir }}/apiserver-key.pem"
   register: result
   until: result.status == 200
   retries: 20

--- a/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
@@ -110,9 +110,17 @@ spec:
       httpGet:
         host: 127.0.0.1
         path: /healthz
+{% if kube_apiserver_insecure_port == 0 %}
+        port: {{ kube_apiserver_port }}
+        scheme: HTTPS
+{% else %}
         port: {{ kube_apiserver_insecure_port }}
-      initialDelaySeconds: 30
-      timeoutSeconds: 10
+{% endif %}
+      failureThreshold: 8
+      initialDelaySeconds: 15
+      periodSeconds: 10
+      successThreshold: 1
+      timeoutSeconds: 15
     volumeMounts:
     - mountPath: {{ kube_config_dir }}
       name: kubernetes-config

--- a/roles/kubernetes/preinstall/tasks/verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/verify-settings.yml
@@ -78,3 +78,9 @@
     that: ansible_swaptotal_mb == 0
   when: kubelet_fail_swap_on|default(true)
   ignore_errors: "{{ ignore_assert_errors }}"
+
+- name: Stop if RBAC and anonymous-auth are not enabled when insecure port is disabled
+  assert:
+    that: rbac_enabled and kube_api_anonymous_auth
+  when: kube_apiserver_insecure_port == 0
+  ignore_errors: "{{ ignore_assert_errors }}"


### PR DESCRIPTION
This allows `kube_apiserver_insecure_port` to be set to 0 (disabled). Here's what had to change:

1. Make the `uri` module "Wait for apiserver up" checks use `kube_apiserver_port` (HTTPS)
2. Add apiserver client cert/key to the "Wait for apiserver up" checks
3. Update apiserver liveness probe to use HTTPS ports if `kube_apiserver_insecure_port == 0`
4. Set `kube_api_anonymous_auth` to true to allow liveness probe to hit apiserver's /healthz over HTTPS (livenessProbes can't use client cert/key unfortunately)
5. RBAC has to be enabled for anonymous requests which are in the `system:unauthenticated` group. This group is granted access to /healthz by one of RBAC's default ClusterRoleBindings. kubeadm also uses this approach for apiserver liveness authz.

Changes 1 and 2 should work for everyone, but 3, 4, and 5 required new coupling of currently independent configuration settings (RBAC and anonymous-auth must be on). To get around this I also added a settings check that ensures both are enabled.

Question: is there a reason we wouldn't want anonymous-auth on by default? This PR changes the default to true. The apiserver binary defaults anonymous-auth to true, and as long as you aren't using the "AlwaysAllow" authorizer that shouldn't be an issue.

Fixes #1940 