### PR TITLE
Allow for more customization of the tiller deploy

### DIFF
--- a/roles/kubernetes-apps/helm/defaults/main.yml
+++ b/roles/kubernetes-apps/helm/defaults/main.yml
@@ -6,3 +6,15 @@ helm_home_dir: "/root/.helm"
 
 # Deployment mode: host or docker
 helm_deployment_type: docker
+
+# Do not download the local repository cache on helm init
+helm_skip_refresh: false
+
+# Set URL for stable repository
+# helm_stable_repo_url: "https://kubernetes-charts.storage.googleapis.com"
+
+# Set node selector options for Tiller Deployment manifest.
+# tiller_node_selectors: "key1=val1,key2=val2"
+
+# Override values for the Tiller Deployment manifest.
+# tiller_override: "key1=val1,key2=val2"

--- a/roles/kubernetes-apps/helm/tasks/main.yml
+++ b/roles/kubernetes-apps/helm/tasks/main.yml
@@ -27,12 +27,14 @@
   when: dns_mode != 'none' and inventory_hostname == groups['kube-master'][0] and rbac_enabled
 
 - name: Helm | Install/upgrade helm
-  command: "{{ bin_dir }}/helm init --upgrade --tiller-image={{ tiller_image_repo }}:{{ tiller_image_tag }}"
+  command: >
+    {{ bin_dir }}/helm init --upgrade --tiller-image={{ tiller_image_repo }}:{{ tiller_image_tag }} --tiller-namespace={{ system_namespace }}
+    {% if helm_skip_refresh %} --skip-refresh{% endif %}
+    {% if helm_stable_repo_url is defined %} --stable-repo-url {{ helm_stable_repo_url }}{% endif %}
+    {% if rbac_enabled %} --service-account=tiller{% endif %}
+    {% if tiller_node_selectors is defined %} --node-selectors {{ tiller_node_selectors }}{% endif %}
+    {% if tiller_override is defined %} --override {{ tiller_override }}{% endif %}
   when: (helm_container is defined and helm_container.changed) or (helm_task_result is defined and helm_task_result.changed)
-
-- name: Helm | Patch tiller deployment for RBAC
-  command: "{{bin_dir}}/kubectl patch deployment tiller-deploy -p '{\"spec\":{\"template\":{\"spec\":{\"serviceAccount\":\"tiller\"}}}}' -n {{ system_namespace }}"
-  when: rbac_enabled
 
 - name: Helm | Set up bash completion
   shell: "umask 022 && {{ bin_dir }}/helm completion bash >/etc/bash_completion.d/helm.sh"


### PR DESCRIPTION
- Removes the "Patch Tiller deployment for RBAC" step, as tiller can be initialized with the right serviceaccount since a few versions ago.
- Deploys tiller to {{ system_namespace }} in case non-default used
- Includes a few new options for customization of tiller's deployment.

**Questions**

1. `tiller_node_selectors` and `tiller_override` should be a comma delimited list of options -- should I modify this to accept an array of options? e.g. `{{ tiller_node_selectors | join(',') }}`
2. Do these new variables need to be added to any other files/documentation?
3. A default could be added to deploy tiller on a master node via a toleration. Is that something I should include?



