### PR TITLE
provide environment for rkt trust and run with etcd

### DIFF
--- a/roles/etcd/tasks/install_rkt.yml
+++ b/roles/etcd/tasks/install_rkt.yml
@@ -10,6 +10,7 @@
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
   changed_when: false
+  environment: "{{proxy_env}}"
 
 - name: Install | Copy etcdctl binary from rkt container
   command: >-
@@ -24,3 +25,4 @@
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
   changed_when: false
+  environment: "{{proxy_env}}"


### PR DESCRIPTION
This fixes another small issue we encountered when deploying behind a proxy. After removing a bunch of the "environment" directives in #1925, we found that there were still a couple of places where we were calling `rkt run` and `rkt trust`. As opposed to adding the environment values to the full role, I've added them to each task that needs it. Would love to make sure that @chadswen is cool with this as well, but I don't think it'll break you guys.