### PR TITLE
Update OpenStack Terraform: Modules, Bastions, and New Floating IP config

### DIFF
--- a/contrib/terraform/openstack/README.md
+++ b/contrib/terraform/openstack/README.md
@@ -114,6 +114,7 @@ ones:
 |---------|-------------|
 |`cluster_name` | All OpenStack resources will use the Terraform variable`cluster_name` (default`example`) in their name to make it easier to track. For example the first compute resource will be named`example-kubernetes-1`. |
 |`network_name` | The name to be given to the internal network that will be generated |
+|`dns_nameservers`| An array of DNS name server names to be used by hosts in the internal subnet. | 
 |`floatingip_pool` | Name of the pool from which floating IPs will be allocated |
 |`external_net` | UUID of the external network that will be routed to |
 |`flavor_k8s_master`,`flavor_k8s_node`,`flavor_etcd`, `flavor_bastion`,`flavor_gfs_node` | Flavor depends on your openstack installation, you can get available flavor IDs through`nova flavor-list` |

--- a/contrib/terraform/openstack/README.md
+++ b/contrib/terraform/openstack/README.md
@@ -5,64 +5,90 @@ Openstack.
 
 ## Status
 
-This will install a Kubernetes cluster on an Openstack Cloud. It has been tested on a
-OpenStack Cloud provided by [BlueBox](https://www.blueboxcloud.com/) and on OpenStack at [EMBL-EBI's](http://www.ebi.ac.uk/) [EMBASSY Cloud](http://www.embassycloud.org/). This should work on most modern installs of OpenStack that support the basic
-services.
+This will install a Kubernetes cluster on an Openstack Cloud. It should work on
+most modern installs of OpenStack that support the basic services.
 
-There are some assumptions made to try and ensure it will work on your openstack cluster.
+## Approach
+The terraform configuration inspects variables found in
+[variables.tf](variables.tf) to create resources in your OpenStack cluster.
+There is a [python script](../terraform.py) that reads the generated`.tfstate`
+file to generate a dynamic inventory that is consumed by the main ansible script
+to actually install kubernetes and stand up the cluster.
 
-* floating-ips are used for access, but you can have masters and nodes that don't use floating-ips if needed. You need currently at least 1 floating ip, which needs to be used on a master. If using more than one, at least one should be on a master for bastions to work fine.
-* you already have a suitable OS image in glance
-* you already have both an internal network and a floating-ip pool created
-* you have security-groups enabled
+### Networking
+The configuration includes creating a private subnet with a router to the
+external net. It will allocate floating-ips from a pool and assign them to the
+hosts where that makes sense. You have the option of creating bastion hosts
+inside the private subnet to access the nodes there.
 
+### Kubernetes Nodes
+You can create many different kubernetes topologies by setting the number of
+different classes of hosts. For each class there are options for allocating
+floating ip addresses or not.
+- Master Nodes with etcd
+- Master nodes without etcd
+- Standalone etcd hosts
+- Kubernetes worker nodes
+
+Note that the ansible script will report an invalid configuration if you wind up
+with an even number of etcd instances since that is not a valid configuration.
+
+### Gluster FS
+The terraform configuration supports provisioning of an optional GlusterFS
+shared file system based on a separate set of VMs. To enable this, you need to
+specify
+- the number of gluster hosts
+- Size of the non-ephemeral volumes to be attached to store the GlusterFS bricks
+- Other properties related to provisioning the hosts
+
+Even if you are using Container Linux by CoreOS for your cluster, you will still
+need the GlusterFS VMs to be based on either Debian or RedHat based images,
+Container Linux by CoreOS cannot serve GlusterFS, but can connect to it through
+binaries available on hyperkube v1.4.3_coreos.0 or higher.
 
 ## Requirements
 
 - [Install Terraform](https://www.terraform.io/intro/getting-started/install.html)
+- [Install Ansible](http://docs.ansible.com/ansible/latest/intro_installation.html)
+- you already have a suitable OS image in glance
+- you already have a floating-ip pool created
+- you have security-groups enabled
+- you have a pair of keys generated that can be used to secure the new hosts
+
+## Module Architecture
+The configuration is divided into three modules:
+- Network
+- IPs
+- Compute
+
+The main reason for splitting the configuration up in this way is to easily
+accommodate situations where floating IPs are limited by a quota or if you have
+any external references to the floating IP (e.g. DNS) that would otherwise have
+to be updated.
+
+You can force your existing IPs by modifying the compute variables in
+`kubespray.tf` as
+
+```
+k8s_master_fips = ["151.101.129.67"]
+k8s_node_fips = ["151.101.129.68"]
+```
 
 ## Terraform
-
-Terraform will be used to provision all of the OpenStack resources. It is also used to deploy and provision the software
-requirements.
+Terraform will be used to provision all of the OpenStack resources. It is also
+used to deploy and provision the software requirements.
 
 ### Prep
 
 #### OpenStack
 
-Ensure your OpenStack **Identity v2** credentials are loaded in environment variables. This can be done by downloading a credentials .rc file from your OpenStack dashboard and sourcing it:
+Ensure your OpenStack **Identity v2** credentials are loaded in environment
+variables. This can be done by downloading a credentials .rc file from your
+OpenStack dashboard and sourcing it:
 
 ```
 $ source ~/.stackrc
 ```
-
-> You must set **OS_REGION_NAME** and **OS_TENANT_ID** environment variables not required by openstack CLI
-
-You will need two networks before installing, an internal network and
-an external (floating IP Pool) network. The internet network can be shared as
-we use security groups to provide network segregation. Due to the many
-differences between OpenStack installs the Terraform does not attempt to create
-these for you.
-
-By default Terraform will expect that your networks are called `internal` and
-`external`. You can change this by altering the Terraform variables `network_name` and `floatingip_pool`. This can be done on a new variables file or through environment variables.
-
-A full list of variables you can change can be found at [variables.tf](variables.tf).
-
-All OpenStack resources will use the Terraform variable `cluster_name` (
-default `example`) in their name to make it easier to track. For example the
-first compute resource will be named `example-kubernetes-1`.
-
-#### Terraform
-
-Ensure your local ssh-agent is running and your ssh key has been added. This
-step is required by the terraform provisioner:
-
-```
-$ eval $(ssh-agent -s)
-$ ssh-add ~/.ssh/id_rsa
-```
-
 
 Ensure that you have your Openstack credentials loaded into Terraform
 environment variables. Likely via a command similar to:
@@ -75,61 +101,105 @@ $ echo Setting up Terraform creds && \
   export TF_VAR_auth_url=${OS_AUTH_URL}
 ```
 
-##### Alternative: etcd inside masters
+### Terraform Variables
+The construction of the cluster is driven by values found in
+[variables.tf](variables.tf).
 
-If you want to provision master or node VMs that don't use floating ips and where etcd is inside masters, write on a `my-terraform-vars.tfvars` file, for example:
+The best way to set these values is to create a file in the project's root
+directory called something like`my-terraform-vars.tfvars`. Many of the
+variables are obvious. Here is a summary of some of the more interesting
+ones:
 
-```
-number_of_k8s_masters = "1"
-number_of_k8s_masters_no_floating_ip = "2"
-number_of_k8s_nodes_no_floating_ip = "1"
-number_of_k8s_nodes = "0"
-```
-This will provision one VM as master using a floating ip, two additional masters using no floating ips (these will only have private ips inside your tenancy) and one VM as node, again without a floating ip.
+|Variable | Description |
+|---------|-------------|
+|`cluster_name` | All OpenStack resources will use the Terraform variable`cluster_name` (default`example`) in their name to make it easier to track. For example the first compute resource will be named`example-kubernetes-1`. |
+|`network_name` | The name to be given to the internal network that will be generated |
+|`floatingip_pool` | Name of the pool from which floating IPs will be allocated |
+|`external_net` | UUID of the external network that will be routed to |
+|`flavor_k8s_master`,`flavor_k8s_node`,`flavor_etcd`, `flavor_bastion`,`flavor_gfs_node` | Flavor depends on your openstack installation, you can get available flavor IDs through`nova flavor-list` |
+|`image`,`image_gfs` | Name of the image to use in provisioning the compute resources. Should already be loaded into glance. |
+|`ssh_user`,`ssh_user_gfs` | The username to ssh into the image with. This usually depends on the image you have selected |
+|`public_key_path` | Path on your local workstation to the public key file you wish to use in creating the key pairs |
+|`number_of_k8s_masters`, `number_of_k8s_masters_no_floating_ip` | Number of nodes that serve as both master and etcd. These can be provisioned with or without floating IP addresses|
+|`number_of_k8s_masters_no_etcd`, `number_of_k8s_masters_no_floating_ip_no_etcd` |  Number of nodes that serve as just master with no etcd. These can be provisioned with or without floating IP addresses |
+|`number_of_etcd` | Number of pure etcd nodes |
+|`number_of_k8s_nodes`, `number_of_k8s_nodes_no_floating_ip` | Kubernetes worker nodes. These can be provisioned with or without floating ip addresses. |
+|`number_of_bastions` | Number of bastion hosts to create. Scripts assume this is really just zero or one |
+|`number_of_gfs_nodes_no_floating_ip` | Number of gluster servers to provision. |
+| `gfs_volume_size_in_gb` | Size of the non-ephemeral volumes to be attached to store the GlusterFS bricks |
 
-##### Alternative: etcd on separate machines
+## Initializing Terraform
+Before Terraform can operate on your cluster you need to install required
+plugins. This is accomplished with the command
 
-If you want to provision master or node VMs that don't use floating ips and where **etcd is on separate nodes from Kubernetes masters**, write on a `my-terraform-vars.tfvars` file, for example:
-
-```
-number_of_etcd = "3"
-number_of_k8s_masters = "0"
-number_of_k8s_masters_no_etcd = "1"
-number_of_k8s_masters_no_floating_ip = "0"
-number_of_k8s_masters_no_floating_ip_no_etcd = "2"
-number_of_k8s_nodes_no_floating_ip = "1"
-number_of_k8s_nodes = "2"
-
-flavor_k8s_node = "desired-flavor-id" 
-flavor_k8s_master = "desired-flavor-id"
-flavor_etcd = "desired-flavor-id"
-```
-
-This will provision one VM as master using a floating ip, two additional masters using no floating ips (these will only have private ips inside your tenancy), two VMs as nodes with floating ips, one VM as node without floating ip and three VMs for etcd. 
-
-##### Alternative: add GlusterFS
-
-Additionally, now the terraform based installation supports provisioning of a GlusterFS shared file system based on a separate set of VMs, running either a Debian or RedHat based set of VMs. To enable this, you need to add to your `my-terraform-vars.tfvars` the following variables:
-
-```
-# Flavour depends on your openstack installation, you can get available flavours through `nova flavor-list`
-flavor_gfs_node = "af659280-5b8a-42b5-8865-a703775911da"
-# This is the name of an image already available in your openstack installation.
-image_gfs = "Ubuntu 15.10"
-number_of_gfs_nodes_no_floating_ip = "3"
-# This is the size of the non-ephemeral volumes to be attached to store the GlusterFS bricks.
-gfs_volume_size_in_gb = "50"
-# The user needed for the image choosen for GlusterFS.
-ssh_user_gfs = "ubuntu"
+```bash
+$ terraform init contrib/terraform/openstack
 ```
 
-If these variables are provided, this will give rise to a new ansible group called `gfs-cluster`, for which we have added ansible roles to execute in the ansible provisioning step. If you are using Container Linux by CoreOS, these GlusterFS VM necessarily need to be either Debian or RedHat based VMs, Container Linux by CoreOS cannot serve GlusterFS, but can connect to it through binaries available on hyperkube v1.4.3_coreos.0 or higher.
+## Provisioning Cluster with Terraform
+You can apply the terraform config to your cluster with the following command
+issued from the project's root directory
+```bash
+$ terraform apply -state=contrib/terraform/openstack/terraform.tfstate -var-file=my-terraform-vars.tfvars contrib/terraform/openstack
+```
 
-GlusterFS is not deployed by the standard `cluster.yml` playbook, see the [glusterfs playbook documentation](../../network-storage/glusterfs/README.md) for instructions.
+if you chose to create a bastion host, this script will create
+`contrib/terraform/openstack/k8s-cluster.yml` with an ssh command for ansible to
+be able to access your machines tunneling  through the bastion's ip adress. If
+you want to manually handle the ssh tunneling to these machines, please delete
+or move that file. If you want to use this, just leave it there, as ansible will
+pick it up automatically.
 
-# Configure Cluster variables
 
-Edit `inventory/group_vars/all.yml`:
+## Destroying Cluster with Terraform
+You can destroy a config deployed to your cluster with the following command
+issued from the project's root directory
+```bash
+$ terraform destroy -state=contrib/terraform/openstack/terraform.tfstate -var-file=my-terraform-vars.tfvars contrib/terraform/openstack
+```
+
+## Debugging Cluster Provisioning
+You can enable debugging output from Terraform by setting
+`OS_DEBUG` to 1 and`TF_LOG` to`DEBUG` before runing the terraform command
+
+
+# Running the Ansible Script
+Ensure your local ssh-agent is running and your ssh key has been added. This
+step is required by the terraform provisioner:
+
+```
+$ eval $(ssh-agent -s)
+$ ssh-add ~/.ssh/id_rsa
+```
+
+
+Make sure you can connect to the hosts:
+
+```
+$ ansible -i contrib/terraform/openstack/hosts -m ping all
+example-k8s_node-1 | SUCCESS => {
+    "changed": false,
+    "ping": "pong"
+}
+example-etcd-1 | SUCCESS => {
+    "changed": false,
+    "ping": "pong"
+}
+example-k8s-master-1 | SUCCESS => {
+    "changed": false,
+    "ping": "pong"
+}
+```
+
+if you are deploying a system that needs bootstrapping, like Container Linux by
+CoreOS, these might have a state`FAILED` due to Container Linux by CoreOS not
+having python. As long as the state is not`UNREACHABLE`, this is fine.
+
+if it fails try to connect manually via SSH ... it could be something as simple as a stale host key.
+
+## Configure Cluster variables
+
+Edit`inventory/group_vars/all.yml`:
 - Set variable **bootstrap_os** according selected image
 ```
 # Valid bootstrap options (required): ubuntu, coreos, centos, none
@@ -147,7 +217,7 @@ bin_dir: /opt/bin
 ```
 cloud_provider: openstack
 ```
-Edit `inventory/group_vars/k8s-cluster.yml`:
+Edit`inventory/group_vars/k8s-cluster.yml`:
 - Set variable **kube_network_plugin** according selected networking
 ```
 # Choose network plugin (calico, weave or flannel)
@@ -168,63 +238,13 @@ resolvconf_mode: host_resolvconf
 
 For calico configure OpenStack Neutron ports: [OpenStack](/docs/openstack.md)
 
-# Provision a Kubernetes Cluster on OpenStack
-
-If not using a tfvars file for your setup, then execute:
-```
-terraform apply -state=contrib/terraform/openstack/terraform.tfstate contrib/terraform/openstack
-openstack_compute_secgroup_v2.k8s_master: Creating...
-  description: "" => "example - Kubernetes Master"
-  name:        "" => "example-k8s-master"
-  rule.#:      "" => "<computed>"
-...
-...
-Apply complete! Resources: 9 added, 0 changed, 0 destroyed.
-
-The state of your infrastructure has been saved to the path
-below. This state is required to modify and destroy your
-infrastructure, so keep it safe. To inspect the complete state
-use the `terraform show` command.
-
-State path: contrib/terraform/openstack/terraform.tfstate
-```
-
-Alternatively, if you wrote your terraform variables on a file `my-terraform-vars.tfvars`, your command would look like:
-```
-terraform apply -state=contrib/terraform/openstack/terraform.tfstate -var-file=my-terraform-vars.tfvars contrib/terraform/openstack
-```
-
-if you choose to add masters or nodes without floating ips (only internal ips on your OpenStack tenancy), this script will create as well a file `contrib/terraform/openstack/k8s-cluster.yml` with an ssh command for ansible to be able to access your machines tunneling  through the first floating ip used. If you want to manually handling the ssh tunneling to these machines, please delete or move that file. If you want to use this, just leave it there, as ansible will pick it up automatically.
-
-Make sure you can connect to the hosts:
-
-```
-$ ansible -i contrib/terraform/openstack/hosts -m ping all
-example-k8s_node-1 | SUCCESS => {
-    "changed": false,
-    "ping": "pong"
-}
-example-etcd-1 | SUCCESS => {
-    "changed": false,
-    "ping": "pong"
-}
-example-k8s-master-1 | SUCCESS => {
-    "changed": false,
-    "ping": "pong"
-}
-```
-
-if you are deploying a system that needs bootstrapping, like Container Linux by CoreOS, these might have a state `FAILED` due to Container Linux by CoreOS not having python. As long as the state is not `UNREACHABLE`, this is fine.
-
-if it fails try to connect manually via SSH ... it could be somthing as simple as a stale host key.
-
-Deploy kubernetes:
+## Deploy kubernetes:
 
 ```
 $ ansible-playbook --become -i contrib/terraform/openstack/hosts cluster.yml
 ```
 
-# Set up local kubectl
+## Set up local kubectl
 1. Install kubectl on your workstation:
 [Install and Set Up kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 2. Add route to internal IP of master node (if needed):
@@ -245,16 +265,15 @@ ssh [os-user]@[master-ip] sudo cat /etc/kubernetes/ssl/admin-[cluster_name]-k8s-
 ssh [os-user]@[master-ip] sudo cat /etc/kubernetes/ssl/admin-[cluster_name]-k8s-master-1.pem > admin.pem
 ssh [os-user]@[master-ip] sudo cat /etc/kubernetes/ssl/ca.pem > ca.pem
 ```
-5. Edit OpenStack Neutron master's Security Group to allow TCP connections to port 6443
-6. Configure kubectl:
+5. Configure kubectl:
 ```
 kubectl config set-cluster default-cluster --server=https://[master-internal-ip]:6443 \
-    --certificate-authority=ca.pem 
+    --certificate-authority=ca.pem
 
 kubectl config set-credentials default-admin \
     --certificate-authority=ca.pem \
     --client-key=admin-key.pem \
-    --client-certificate=admin.pem 
+    --client-certificate=admin.pem
 
 kubectl config set-context default-system --cluster=default-cluster --user=default-admin
 kubectl config use-context default-system
@@ -264,19 +283,24 @@ kubectl config use-context default-system
 kubectl version
 ```
 
+If you are using floating ip addresses then you may get this error:
+```
+Unable to connect to the server: x509: certificate is valid for 10.0.0.6, 10.0.0.6, 10.233.0.1, 127.0.0.1, not 132.249.238.25
+```
+
+You can tell kubectl to ignore this condition by adding the
+`--insecure-skip-tls-verify` option.
+
+## GlusterFS
+GlusterFS is not deployed by the standard`cluster.yml` playbook, see the
+[glusterfs playbook documentation](../../network-storage/glusterfs/README.md)
+for instructions.
+
+Basically you will install gluster as
+```bash
+$ ansible-playbook --become -i contrib/terraform/openstack/hosts ./contrib/network-storage/glusterfs/glusterfs.yml
+```
+
+
 # What's next
 [Start Hello Kubernetes Service](https://kubernetes.io/docs/tasks/access-application-cluster/service-access-application-cluster/)
-
-# clean up:
-
-```
-$ terraform destroy
-Do you really want to destroy?
-  Terraform will delete all your managed infrastructure.
-  There is no undo. Only 'yes' will be accepted to confirm.
-
-  Enter a value: yes
-...
-...
-Apply complete! Resources: 0 added, 0 changed, 12 destroyed.
-```

--- a/contrib/terraform/openstack/kubespray.tf
+++ b/contrib/terraform/openstack/kubespray.tf
@@ -67,12 +67,6 @@ resource "openstack_compute_secgroup_v2" "k8s" {
     }
 }
 
-resource "openstack_networking_floatingip_v2" "bastion" {
-    count = "${var.number_of_bastions}"
-    pool = "${var.floatingip_pool}"
-    depends_on = ["openstack_networking_router_interface_v2.k8s"]
-}
-
 resource "openstack_networking_floatingip_v2" "k8s_master" {
     count = "${var.number_of_k8s_masters}"
     pool = "${var.floatingip_pool}"
@@ -96,19 +90,36 @@ resource "openstack_compute_instance_v2" "bastion" {
     }
     security_groups = [ "${openstack_compute_secgroup_v2.k8s.name}",
                         "default" ]
-    floating_ip = "${element(openstack_networking_floatingip_v2.bastion.*.address, count.index)}"
     metadata = {
         ssh_user = "${var.ssh_user}"
         kubespray_groups = "bastion"
     }
 
     provisioner "local-exec" {
-	command = "sed s/USER/${var.ssh_user}/ contrib/terraform/openstack/ansible_bastion_template.txt | sed s/BASTION_ADDRESS/${element(openstack_networking_floatingip_v2.bastion.*.address, 0)}/ > group_vars/no-floating.yml"
+	command = "sed s/USER/${var.ssh_user}/ contrib/terraform/openstack/ansible_bastion_template.txt | sed s/BASTION_ADDRESS/${element(openstack_networking_floatingip_v2.bastion.*.address, 0)}/ > contrib/terraform/openstack/group_vars/no-floating.yml"
     }
 
     user_data = "#cloud-config\nmanage_etc_hosts: localhost\npackage_update: true\npackage_upgrade: true"
-
     depends_on = [ "openstack_networking_network_v2.k8s" ]
+}
+
+resource "openstack_networking_floatingip_v2" "bastion" {
+    count = "${var.number_of_bastions}"
+    pool = "${var.floatingip_pool}"
+    depends_on = ["openstack_networking_router_interface_v2.k8s"]
+}
+
+
+resource "openstack_compute_floatingip_associate_v2" "bastion" {
+    count = "${var.number_of_bastions}"
+    floating_ip = "${element(openstack_networking_floatingip_v2.bastion.*.address, count.index)}"
+    instance_id = "${element(openstack_compute_instance_v2.bastion.*.id, count.index)}"
+}
+
+resource "openstack_compute_floatingip_associate_v2" "k8s_master" {
+    count = "${var.number_of_k8s_masters}"
+    floating_ip = "${element(openstack_networking_floatingip_v2.k8s_master.*.address, count.index)}"
+    instance_id = "${element(openstack_compute_instance_v2.k8s_master.*.id, count.index)}"
 }
 
 resource "openstack_compute_instance_v2" "k8s_master" {
@@ -121,18 +132,15 @@ resource "openstack_compute_instance_v2" "k8s_master" {
         name = "${var.network_name}"
     }
     security_groups = [ "${openstack_compute_secgroup_v2.k8s_master.name}",
-<<<<<<< HEAD
-                        "${openstack_compute_secgroup_v2.k8s.name}" ]
-=======
                         "${openstack_compute_secgroup_v2.k8s.name}",
                         "default" ]
->>>>>>> 1263936... Adding bastion and private network provisioning for openstack terraform
-    floating_ip = "${element(openstack_networking_floatingip_v2.k8s_master.*.address, count.index)}"
     metadata = {
         ssh_user = "${var.ssh_user}"
         kubespray_groups = "etcd,kube-master,kube-node,k8s-cluster,vault"
     }
+    user_data = "#cloud-config\nmanage_etc_hosts: localhost\npackage_update: true\npackage_upgrade: true"
 
+    depends_on = [ "openstack_networking_network_v2.k8s" ]
 }
 
 resource "openstack_compute_instance_v2" "k8s_master_no_etcd" {
@@ -171,11 +179,12 @@ resource "openstack_compute_instance_v2" "etcd" {
     provisioner "local-exec" {
         command = "sed s/USER/${var.ssh_user}/ contrib/terraform/openstack/ansible_bastion_template.txt | sed s/BASTION_ADDRESS/${element(openstack_networking_floatingip_v2.k8s_master.*.address, 0)}/ > contrib/terraform/openstack/group_vars/no-floating.yml"
     }
-}
     user_data = "#cloud-config\nmanage_etc_hosts: localhost\npackage_update: true\npackage_upgrade: true"
 
     depends_on = [ "openstack_networking_network_v2.k8s" ]
+
 }
+
 
 resource "openstack_compute_instance_v2" "k8s_master_no_floating_ip" {
     name = "${var.cluster_name}-k8s-master-nf-${count.index+1}"
@@ -230,7 +239,6 @@ resource "openstack_compute_instance_v2" "k8s_node" {
     }
     security_groups = [ "${openstack_compute_secgroup_v2.k8s.name}",
                         "default" ]
-    floating_ip = "${element(openstack_networking_floatingip_v2.k8s_node.*.address, count.index)}"
     metadata = {
         ssh_user = "${var.ssh_user}"
         kubespray_groups = "kube-node,k8s-cluster"
@@ -238,6 +246,12 @@ resource "openstack_compute_instance_v2" "k8s_node" {
     user_data = "#cloud-config\nmanage_etc_hosts: localhost\npackage_update: true\npackage_upgrade: true"
 
     depends_on = [ "openstack_networking_network_v2.k8s" ]
+}
+
+resource "openstack_compute_floatingip_associate_v2" "k8s_node" {
+    count = "${var.number_of_k8s_masters}"
+    floating_ip = "${element(openstack_networking_floatingip_v2.k8s_node.*.address, count.index)}"
+    instance_id = "${element(openstack_compute_instance_v2.k8s_node.*.id, count.index)}"
 }
 
 resource "openstack_compute_instance_v2" "k8s_node_no_floating_ip" {

--- a/contrib/terraform/openstack/kubespray.tf
+++ b/contrib/terraform/openstack/kubespray.tf
@@ -1,17 +1,30 @@
-resource "openstack_networking_floatingip_v2" "k8s_master" {
-    count = "${var.number_of_k8s_masters + var.number_of_k8s_masters_no_etcd}"
-    pool = "${var.floatingip_pool}"
+resource "openstack_networking_router_v2" "k8s" {
+  name             = "internal"
+  admin_state_up   = "true"
+  external_gateway = "${var.external_net}"
 }
 
-resource "openstack_networking_floatingip_v2" "k8s_node" {
-    count = "${var.number_of_k8s_nodes}"
-    pool = "${var.floatingip_pool}"
+resource "openstack_networking_network_v2" "k8s" {
+  name           = "${var.network_name}"
+  admin_state_up = "true"
 }
 
+resource "openstack_networking_subnet_v2" "k8s" {
+  name            = "internal"
+  network_id      = "${openstack_networking_network_v2.k8s.id}"
+  cidr            = "10.0.0.0/24"
+  ip_version      = 4
+  dns_nameservers = ["8.8.8.8", "8.8.4.4"]
+}
+
+resource "openstack_networking_router_interface_v2" "k8s" {
+  router_id = "${openstack_networking_router_v2.k8s.id}"
+  subnet_id = "${openstack_networking_subnet_v2.k8s.id}"
+}
 
 resource "openstack_compute_keypair_v2" "k8s" {
     name = "kubernetes-${var.cluster_name}"
-    public_key = "${file(var.public_key_path)}"
+    public_key = "${chomp(file(var.public_key_path))}"
 }
 
 resource "openstack_compute_secgroup_v2" "k8s_master" {
@@ -54,6 +67,50 @@ resource "openstack_compute_secgroup_v2" "k8s" {
     }
 }
 
+resource "openstack_networking_floatingip_v2" "bastion" {
+    count = "${var.number_of_bastions}"
+    pool = "${var.floatingip_pool}"
+    depends_on = ["openstack_networking_router_interface_v2.k8s"]
+}
+
+resource "openstack_networking_floatingip_v2" "k8s_master" {
+    count = "${var.number_of_k8s_masters}"
+    pool = "${var.floatingip_pool}"
+    depends_on = ["openstack_networking_router_interface_v2.k8s"]
+}
+
+resource "openstack_networking_floatingip_v2" "k8s_node" {
+    count = "${var.number_of_k8s_nodes}"
+    pool = "${var.floatingip_pool}"
+    depends_on = ["openstack_networking_router_interface_v2.k8s"]
+}
+
+resource "openstack_compute_instance_v2" "bastion" {
+    name = "${var.cluster_name}-bastion-${count.index+1}"
+    count = "${var.number_of_bastions}"
+    image_name = "${var.image}"
+    flavor_id = "${var.flavor_bastion}"
+    key_pair = "${openstack_compute_keypair_v2.k8s.name}"
+    network {
+        name = "${var.network_name}"
+    }
+    security_groups = [ "${openstack_compute_secgroup_v2.k8s.name}",
+                        "default" ]
+    floating_ip = "${element(openstack_networking_floatingip_v2.bastion.*.address, count.index)}"
+    metadata = {
+        ssh_user = "${var.ssh_user}"
+        kubespray_groups = "bastion"
+    }
+
+    provisioner "local-exec" {
+	command = "sed s/USER/${var.ssh_user}/ contrib/terraform/openstack/ansible_bastion_template.txt | sed s/BASTION_ADDRESS/${element(openstack_networking_floatingip_v2.bastion.*.address, 0)}/ > group_vars/no-floating.yml"
+    }
+
+    user_data = "#cloud-config\nmanage_etc_hosts: localhost\npackage_update: true\npackage_upgrade: true"
+
+    depends_on = [ "openstack_networking_network_v2.k8s" ]
+}
+
 resource "openstack_compute_instance_v2" "k8s_master" {
     name = "${var.cluster_name}-k8s-master-${count.index+1}"
     count = "${var.number_of_k8s_masters}"
@@ -64,13 +121,18 @@ resource "openstack_compute_instance_v2" "k8s_master" {
         name = "${var.network_name}"
     }
     security_groups = [ "${openstack_compute_secgroup_v2.k8s_master.name}",
+<<<<<<< HEAD
                         "${openstack_compute_secgroup_v2.k8s.name}" ]
+=======
+                        "${openstack_compute_secgroup_v2.k8s.name}",
+                        "default" ]
+>>>>>>> 1263936... Adding bastion and private network provisioning for openstack terraform
     floating_ip = "${element(openstack_networking_floatingip_v2.k8s_master.*.address, count.index)}"
     metadata = {
         ssh_user = "${var.ssh_user}"
         kubespray_groups = "etcd,kube-master,kube-node,k8s-cluster,vault"
     }
-    
+
 }
 
 resource "openstack_compute_instance_v2" "k8s_master_no_etcd" {
@@ -89,7 +151,7 @@ resource "openstack_compute_instance_v2" "k8s_master_no_etcd" {
         ssh_user = "${var.ssh_user}"
         kubespray_groups = "kube-master,kube-node,k8s-cluster,vault"
     }
-    
+
 }
 
 resource "openstack_compute_instance_v2" "etcd" {
@@ -108,9 +170,12 @@ resource "openstack_compute_instance_v2" "etcd" {
     }
     provisioner "local-exec" {
         command = "sed s/USER/${var.ssh_user}/ contrib/terraform/openstack/ansible_bastion_template.txt | sed s/BASTION_ADDRESS/${element(openstack_networking_floatingip_v2.k8s_master.*.address, 0)}/ > contrib/terraform/openstack/group_vars/no-floating.yml"
-    } 
+    }
 }
+    user_data = "#cloud-config\nmanage_etc_hosts: localhost\npackage_update: true\npackage_upgrade: true"
 
+    depends_on = [ "openstack_networking_network_v2.k8s" ]
+}
 
 resource "openstack_compute_instance_v2" "k8s_master_no_floating_ip" {
     name = "${var.cluster_name}-k8s-master-nf-${count.index+1}"
@@ -122,14 +187,15 @@ resource "openstack_compute_instance_v2" "k8s_master_no_floating_ip" {
         name = "${var.network_name}"
     }
     security_groups = [ "${openstack_compute_secgroup_v2.k8s_master.name}",
-                        "${openstack_compute_secgroup_v2.k8s.name}" ]
+                        "${openstack_compute_secgroup_v2.k8s.name}",
+                        "default" ]
     metadata = {
         ssh_user = "${var.ssh_user}"
         kubespray_groups = "etcd,kube-master,kube-node,k8s-cluster,vault,no-floating"
     }
-    provisioner "local-exec" {
-        command = "sed s/USER/${var.ssh_user}/ contrib/terraform/openstack/ansible_bastion_template.txt | sed s/BASTION_ADDRESS/${element(openstack_networking_floatingip_v2.k8s_master.*.address, 0)}/ > contrib/terraform/openstack/group_vars/no-floating.yml"
-    }
+    user_data = "#cloud-config\nmanage_etc_hosts: localhost\npackage_update: true\npackage_upgrade: true"
+
+    depends_on = [ "openstack_networking_network_v2.k8s" ]
 }
 
 resource "openstack_compute_instance_v2" "k8s_master_no_floating_ip_no_etcd" {
@@ -162,12 +228,16 @@ resource "openstack_compute_instance_v2" "k8s_node" {
     network {
         name = "${var.network_name}"
     }
-    security_groups = ["${openstack_compute_secgroup_v2.k8s.name}" ]
+    security_groups = [ "${openstack_compute_secgroup_v2.k8s.name}",
+                        "default" ]
     floating_ip = "${element(openstack_networking_floatingip_v2.k8s_node.*.address, count.index)}"
     metadata = {
         ssh_user = "${var.ssh_user}"
-        kubespray_groups = "kube-node,k8s-cluster,vault"
+        kubespray_groups = "kube-node,k8s-cluster"
     }
+    user_data = "#cloud-config\nmanage_etc_hosts: localhost\npackage_update: true\npackage_upgrade: true"
+
+    depends_on = [ "openstack_networking_network_v2.k8s" ]
 }
 
 resource "openstack_compute_instance_v2" "k8s_node_no_floating_ip" {
@@ -179,14 +249,15 @@ resource "openstack_compute_instance_v2" "k8s_node_no_floating_ip" {
     network {
         name = "${var.network_name}"
     }
-    security_groups = ["${openstack_compute_secgroup_v2.k8s.name}" ]
+    security_groups = [ "${openstack_compute_secgroup_v2.k8s.name}",
+                        "default" ]
     metadata = {
         ssh_user = "${var.ssh_user}"
-        kubespray_groups = "kube-node,k8s-cluster,vault,no-floating"
+        kubespray_groups = "kube-node,k8s-cluster,no-floating"
     }
-    provisioner "local-exec" {
-	command = "sed s/USER/${var.ssh_user}/ contrib/terraform/openstack/ansible_bastion_template.txt | sed s/BASTION_ADDRESS/${element(openstack_networking_floatingip_v2.k8s_master.*.address, 0)}/ > contrib/terraform/openstack/group_vars/no-floating.yml"        
-    }
+    user_data = "#cloud-config\nmanage_etc_hosts: localhost\npackage_update: true\npackage_upgrade: true"
+
+    depends_on = [ "openstack_networking_network_v2.k8s" ]
 }
 
 resource "openstack_blockstorage_volume_v2" "glusterfs_volume" {
@@ -205,22 +276,21 @@ resource "openstack_compute_instance_v2" "glusterfs_node_no_floating_ip" {
     network {
         name = "${var.network_name}"
     }
-    security_groups = ["${openstack_compute_secgroup_v2.k8s.name}" ]
+    security_groups = ["${openstack_compute_secgroup_v2.k8s.name}",
+                        "default" ]
     metadata = {
         ssh_user = "${var.ssh_user_gfs}"
         kubespray_groups = "gfs-cluster,network-storage"
     }
+    user_data = "#cloud-config\nmanage_etc_hosts: localhost\npackage_update: true\npackage_upgrade: true"
+
+    depends_on = [ "openstack_networking_network_v2.k8s" ]
     volume {
         volume_id = "${element(openstack_blockstorage_volume_v2.glusterfs_volume.*.id, count.index)}"
-    }
-    provisioner "local-exec" {
-	command = "sed s/USER/${var.ssh_user}/ contrib/terraform/openstack/ansible_bastion_template.txt | sed s/BASTION_ADDRESS/${element(openstack_networking_floatingip_v2.k8s_master.*.address, 0)}/ > contrib/terraform/openstack/group_vars/gfs-cluster.yml"        
     }
 }
 
 
-
-
-#output "msg" {
-#    value = "Your hosts are ready to go!\nYour ssh hosts are: ${join(", ", openstack_networking_floatingip_v2.k8s_master.*.address )}"
-#}
+output "msg" {
+    value = "Your hosts are ready to go!\nYour ssh hosts are: ${join(", ", openstack_networking_floatingip_v2.k8s_master.*.address, openstack_networking_floatingip_v2.bastion.*.address )}"
+}

--- a/contrib/terraform/openstack/kubespray.tf
+++ b/contrib/terraform/openstack/kubespray.tf
@@ -5,6 +5,7 @@ module "network" {
   external_net = "${var.external_net}"
   network_name = "${var.network_name}"
   cluster_name = "${var.cluster_name}"
+  dns_nameservers = "${var.dns_nameservers}"
 }
 
 

--- a/contrib/terraform/openstack/kubespray.tf
+++ b/contrib/terraform/openstack/kubespray.tf
@@ -310,7 +310,7 @@ resource "openstack_compute_instance_v2" "glusterfs_node_no_floating_ip" {
                         "default" ]
     metadata = {
         ssh_user = "${var.ssh_user_gfs}"
-        kubespray_groups = "gfs-cluster,network-storage"
+        kubespray_groups = "gfs-cluster,network-storage,no-floating"
     }
     user_data = "#cloud-config\nmanage_etc_hosts: localhost\npackage_update: true\npackage_upgrade: true"
 

--- a/contrib/terraform/openstack/kubespray.tf
+++ b/contrib/terraform/openstack/kubespray.tf
@@ -4,6 +4,7 @@ module "network" {
 
   external_net = "${var.external_net}"
   network_name = "${var.network_name}"
+  cluster_name = "${var.cluster_name}"
 }
 
 

--- a/contrib/terraform/openstack/kubespray.tf
+++ b/contrib/terraform/openstack/kubespray.tf
@@ -1,326 +1,53 @@
 
+module "network" {
+  source = "modules/network"
 
-resource "openstack_networking_router_v2" "k8s" {
-  name             = "internal"
-  admin_state_up   = "true"
-  external_gateway = "${var.external_net}"
-}
-
-resource "openstack_networking_network_v2" "k8s" {
-  name           = "${var.network_name}"
-  admin_state_up = "true"
-}
-
-resource "openstack_networking_subnet_v2" "k8s" {
-  name            = "internal"
-  network_id      = "${openstack_networking_network_v2.k8s.id}"
-  cidr            = "10.0.0.0/24"
-  ip_version      = 4
-  dns_nameservers = ["8.8.8.8", "8.8.4.4"]
-}
-
-resource "openstack_networking_router_interface_v2" "k8s" {
-  router_id = "${openstack_networking_router_v2.k8s.id}"
-  subnet_id = "${openstack_networking_subnet_v2.k8s.id}"
-}
-
-resource "openstack_compute_keypair_v2" "k8s" {
-    name = "kubernetes-${var.cluster_name}"
-    public_key = "${chomp(file(var.public_key_path))}"
-}
-
-resource "openstack_compute_secgroup_v2" "k8s_master" {
-    name = "${var.cluster_name}-k8s-master"
-    description = "${var.cluster_name} - Kubernetes Master"
-    rule {
-        ip_protocol = "tcp"
-        from_port = "6443"
-        to_port = "6443"
-        cidr = "0.0.0.0/0"
-    }
-}
-
-resource "openstack_compute_secgroup_v2" "bastion" {
-    name = "${var.cluster_name}-bastion"
-    description = "${var.cluster_name} - Bastion Server"
-    rule {
-        ip_protocol = "tcp"
-        from_port = "22"
-        to_port = "22"
-        cidr = "0.0.0.0/0"
-    }
-}
-
-resource "openstack_compute_secgroup_v2" "k8s" {
-    name = "${var.cluster_name}-k8s"
-    description = "${var.cluster_name} - Kubernetes"
-    rule {
-        ip_protocol = "icmp"
-        from_port = "-1"
-        to_port = "-1"
-        cidr = "0.0.0.0/0"
-    }
-    rule {
-        ip_protocol = "tcp"
-        from_port = "1"
-        to_port = "65535"
-        self = true
-    }
-    rule {
-        ip_protocol = "udp"
-        from_port = "1"
-        to_port = "65535"
-        self = true
-    }
-    rule {
-        ip_protocol = "icmp"
-        from_port = "-1"
-        to_port = "-1"
-        self = true
-    }
-}
-
-resource "openstack_networking_floatingip_v2" "k8s_master" {
-    count = "${var.number_of_k8s_masters}"
-    pool = "${var.floatingip_pool}"
-    depends_on = ["openstack_networking_router_interface_v2.k8s"]
-}
-
-resource "openstack_networking_floatingip_v2" "k8s_node" {
-    count = "${var.number_of_k8s_nodes}"
-    pool = "${var.floatingip_pool}"
-    depends_on = ["openstack_networking_router_interface_v2.k8s"]
-}
-
-resource "openstack_compute_instance_v2" "bastion" {
-    name = "${var.cluster_name}-bastion-${count.index+1}"
-    count = "${var.number_of_bastions}"
-    image_name = "${var.image}"
-    flavor_id = "${var.flavor_bastion}"
-    key_pair = "${openstack_compute_keypair_v2.k8s.name}"
-    network {
-        name = "${var.network_name}"
-    }
-    security_groups = [ "${openstack_compute_secgroup_v2.k8s.name}",
-                        "${openstack_compute_secgroup_v2.bastion.name}",
-                        "default" ]
-    metadata = {
-        ssh_user = "${var.ssh_user}"
-        kubespray_groups = "bastion"
-    }
-
-    provisioner "local-exec" {
-	command = "sed s/USER/${var.ssh_user}/ contrib/terraform/openstack/ansible_bastion_template.txt | sed s/BASTION_ADDRESS/${element(openstack_networking_floatingip_v2.bastion.*.address, 0)}/ > contrib/terraform/openstack/group_vars/no-floating.yml"
-    }
-
-    user_data = "#cloud-config\nmanage_etc_hosts: localhost\npackage_update: true\npackage_upgrade: true"
-    depends_on = [ "openstack_networking_network_v2.k8s" ]
-}
-
-resource "openstack_networking_floatingip_v2" "bastion" {
-    count = "${var.number_of_bastions}"
-    pool = "${var.floatingip_pool}"
-    depends_on = ["openstack_networking_router_interface_v2.k8s"]
+  external_net = "${var.external_net}"
+  network_name = "${var.network_name}"
 }
 
 
-resource "openstack_compute_floatingip_associate_v2" "bastion" {
-    count = "${var.number_of_bastions}"
-    floating_ip = "${element(openstack_networking_floatingip_v2.bastion.*.address, count.index)}"
-    instance_id = "${element(openstack_compute_instance_v2.bastion.*.id, count.index)}"
+module "ips" {
+  source = "modules/ips"
+
+  number_of_k8s_masters = "${var.number_of_k8s_masters}"
+  number_of_k8s_masters_no_etcd = "${var.number_of_k8s_masters_no_etcd}"
+  number_of_k8s_nodes = "${var.number_of_k8s_nodes}"
+  floatingip_pool = "${var.floatingip_pool}"
+  number_of_bastions = "${var.number_of_bastions}"
+  external_net = "${var.external_net}"
+  network_name = "${var.network_name}"
+  router_id = "${module.network.router_id}"
 }
 
-resource "openstack_compute_floatingip_associate_v2" "k8s_master" {
-    count = "${var.number_of_k8s_masters}"
-    floating_ip = "${element(openstack_networking_floatingip_v2.k8s_master.*.address, count.index)}"
-    instance_id = "${element(openstack_compute_instance_v2.k8s_master.*.id, count.index)}"
-}
+module "compute" {
+  source = "modules/compute"
 
-resource "openstack_compute_instance_v2" "k8s_master" {
-    name = "${var.cluster_name}-k8s-master-${count.index+1}"
-    count = "${var.number_of_k8s_masters}"
-    image_name = "${var.image}"
-    flavor_id = "${var.flavor_k8s_master}"
-    key_pair = "${openstack_compute_keypair_v2.k8s.name}"
-    network {
-        name = "${var.network_name}"
-    }
-    security_groups = [ "${openstack_compute_secgroup_v2.k8s_master.name}",
-                        "${openstack_compute_secgroup_v2.bastion.name}",
-                        "${openstack_compute_secgroup_v2.k8s.name}",
-                        "default" ]
-    metadata = {
-        ssh_user = "${var.ssh_user}"
-        kubespray_groups = "etcd,kube-master,kube-node,k8s-cluster,vault"
-    }
-    user_data = "#cloud-config\nmanage_etc_hosts: localhost\npackage_update: true\npackage_upgrade: true"
+  cluster_name = "${var.cluster_name}"
+  number_of_k8s_masters = "${var.number_of_k8s_masters}"
+  number_of_k8s_masters_no_etcd = "${var.number_of_k8s_masters_no_etcd}"
+  number_of_etcd = "${var.number_of_etcd}"
+  number_of_k8s_masters_no_floating_ip = "${var.number_of_k8s_masters_no_floating_ip}"
+  number_of_k8s_masters_no_floating_ip_no_etcd = "${var.number_of_k8s_masters_no_floating_ip_no_etcd}"
+  number_of_k8s_nodes = "${var.number_of_k8s_nodes}"
+  number_of_bastions = "${var.number_of_bastions}"
+  number_of_k8s_nodes_no_floating_ip = "${var.number_of_k8s_nodes_no_floating_ip}"
+  number_of_gfs_nodes_no_floating_ip = "${var.number_of_gfs_nodes_no_floating_ip}"
+  gfs_volume_size_in_gb = "${var.gfs_volume_size_in_gb}"
+  public_key_path = "${var.public_key_path}"
+  image = "${var.image}"
+  image_gfs = "${var.image_gfs}"
+  ssh_user = "${var.ssh_user}"
+  ssh_user_gfs = "${var.ssh_user_gfs}"
+  flavor_k8s_master = "${var.flavor_k8s_master}"
+  flavor_k8s_node = "${var.flavor_k8s_node}"
+  flavor_etcd = "${var.flavor_etcd}"
+  flavor_gfs_node = "${var.flavor_gfs_node}"
+  network_name = "${var.network_name}"
+  flavor_bastion = "${var.flavor_bastion}"
+  k8s_master_fips = "${module.ips.k8s_master_fips}"
+  k8s_node_fips = "${module.ips.k8s_node_fips}"
+  bastion_fips = "${module.ips.bastion_fips}"
 
-    depends_on = [ "openstack_networking_network_v2.k8s" ]
-}
-
-resource "openstack_compute_instance_v2" "k8s_master_no_etcd" {
-    name = "${var.cluster_name}-k8s-master-ne-${count.index+1}"
-    count = "${var.number_of_k8s_masters_no_etcd}"
-    image_name = "${var.image}"
-    flavor_id = "${var.flavor_k8s_master}"
-    key_pair = "${openstack_compute_keypair_v2.k8s.name}"
-    network {
-        name = "${var.network_name}"
-    }
-    security_groups = [ "${openstack_compute_secgroup_v2.k8s_master.name}",
-                        "${openstack_compute_secgroup_v2.k8s.name}" ]
-    floating_ip = "${element(openstack_networking_floatingip_v2.k8s_master.*.address, count.index + var.number_of_k8s_masters)}"
-    metadata = {
-        ssh_user = "${var.ssh_user}"
-        kubespray_groups = "kube-master,kube-node,k8s-cluster,vault"
-    }
-
-}
-
-resource "openstack_compute_instance_v2" "etcd" {
-    name = "${var.cluster_name}-etcd-${count.index+1}"
-    count = "${var.number_of_etcd}"
-    image_name = "${var.image}"
-    flavor_id = "${var.flavor_etcd}"
-    key_pair = "${openstack_compute_keypair_v2.k8s.name}"
-    network {
-        name = "${var.network_name}"
-    }
-    security_groups = [ "${openstack_compute_secgroup_v2.k8s.name}" ]
-    metadata = {
-        ssh_user = "${var.ssh_user}"
-        kubespray_groups = "etcd,vault,no-floating"
-    }
-    provisioner "local-exec" {
-        command = "sed s/USER/${var.ssh_user}/ contrib/terraform/openstack/ansible_bastion_template.txt | sed s/BASTION_ADDRESS/${element(openstack_networking_floatingip_v2.k8s_master.*.address, 0)}/ > contrib/terraform/openstack/group_vars/no-floating.yml"
-    }
-    user_data = "#cloud-config\nmanage_etc_hosts: localhost\npackage_update: true\npackage_upgrade: true"
-
-    depends_on = [ "openstack_networking_network_v2.k8s" ]
-
-}
-
-
-resource "openstack_compute_instance_v2" "k8s_master_no_floating_ip" {
-    name = "${var.cluster_name}-k8s-master-nf-${count.index+1}"
-    count = "${var.number_of_k8s_masters_no_floating_ip}"
-    image_name = "${var.image}"
-    flavor_id = "${var.flavor_k8s_master}"
-    key_pair = "${openstack_compute_keypair_v2.k8s.name}"
-    network {
-        name = "${var.network_name}"
-    }
-    security_groups = [ "${openstack_compute_secgroup_v2.k8s_master.name}",
-                        "${openstack_compute_secgroup_v2.k8s.name}",
-                        "default" ]
-    metadata = {
-        ssh_user = "${var.ssh_user}"
-        kubespray_groups = "etcd,kube-master,kube-node,k8s-cluster,vault,no-floating"
-    }
-    user_data = "#cloud-config\nmanage_etc_hosts: localhost\npackage_update: true\npackage_upgrade: true"
-
-    depends_on = [ "openstack_networking_network_v2.k8s" ]
-}
-
-resource "openstack_compute_instance_v2" "k8s_master_no_floating_ip_no_etcd" {
-    name = "${var.cluster_name}-k8s-master-ne-nf-${count.index+1}"
-    count = "${var.number_of_k8s_masters_no_floating_ip_no_etcd}"
-    image_name = "${var.image}"
-    flavor_id = "${var.flavor_k8s_master}"
-    key_pair = "${openstack_compute_keypair_v2.k8s.name}"
-    network {
-        name = "${var.network_name}"
-    }
-    security_groups = [ "${openstack_compute_secgroup_v2.k8s_master.name}",
-                        "${openstack_compute_secgroup_v2.k8s.name}" ]
-    metadata = {
-        ssh_user = "${var.ssh_user}"
-        kubespray_groups = "kube-master,kube-node,k8s-cluster,vault,no-floating"
-    }
-    provisioner "local-exec" {
-        command = "sed s/USER/${var.ssh_user}/ contrib/terraform/openstack/ansible_bastion_template.txt | sed s/BASTION_ADDRESS/${element(openstack_networking_floatingip_v2.k8s_master.*.address, 0)}/ > contrib/terraform/openstack/group_vars/no-floating.yml"
-    }
-}
-
-
-resource "openstack_compute_instance_v2" "k8s_node" {
-    name = "${var.cluster_name}-k8s-node-${count.index+1}"
-    count = "${var.number_of_k8s_nodes}"
-    image_name = "${var.image}"
-    flavor_id = "${var.flavor_k8s_node}"
-    key_pair = "${openstack_compute_keypair_v2.k8s.name}"
-    network {
-        name = "${var.network_name}"
-    }
-    security_groups = [ "${openstack_compute_secgroup_v2.k8s.name}",
-                        "${openstack_compute_secgroup_v2.bastion.name}",
-                        "default" ]
-    metadata = {
-        ssh_user = "${var.ssh_user}"
-        kubespray_groups = "kube-node,k8s-cluster"
-    }
-    user_data = "#cloud-config\nmanage_etc_hosts: localhost\npackage_update: true\npackage_upgrade: true"
-
-    depends_on = [ "openstack_networking_network_v2.k8s" ]
-}
-
-resource "openstack_compute_floatingip_associate_v2" "k8s_node" {
-    count = "${var.number_of_k8s_masters}"
-    floating_ip = "${element(openstack_networking_floatingip_v2.k8s_node.*.address, count.index)}"
-    instance_id = "${element(openstack_compute_instance_v2.k8s_node.*.id, count.index)}"
-}
-
-resource "openstack_compute_instance_v2" "k8s_node_no_floating_ip" {
-    name = "${var.cluster_name}-k8s-node-nf-${count.index+1}"
-    count = "${var.number_of_k8s_nodes_no_floating_ip}"
-    image_name = "${var.image}"
-    flavor_id = "${var.flavor_k8s_node}"
-    key_pair = "${openstack_compute_keypair_v2.k8s.name}"
-    network {
-        name = "${var.network_name}"
-    }
-    security_groups = [ "${openstack_compute_secgroup_v2.k8s.name}",
-                        "default" ]
-    metadata = {
-        ssh_user = "${var.ssh_user}"
-        kubespray_groups = "kube-node,k8s-cluster,no-floating"
-    }
-    user_data = "#cloud-config\nmanage_etc_hosts: localhost\npackage_update: true\npackage_upgrade: true"
-
-    depends_on = [ "openstack_networking_network_v2.k8s" ]
-}
-
-resource "openstack_blockstorage_volume_v2" "glusterfs_volume" {
-  name = "${var.cluster_name}-gfs-nephe-vol-${count.index+1}"
-  count = "${var.number_of_gfs_nodes_no_floating_ip}"
-  description = "Non-ephemeral volume for GlusterFS"
-  size = "${var.gfs_volume_size_in_gb}"
-}
-
-resource "openstack_compute_instance_v2" "glusterfs_node_no_floating_ip" {
-    name = "${var.cluster_name}-gfs-node-nf-${count.index+1}"
-    count = "${var.number_of_gfs_nodes_no_floating_ip}"
-    image_name = "${var.image_gfs}"
-    flavor_id = "${var.flavor_gfs_node}"
-    key_pair = "${openstack_compute_keypair_v2.k8s.name}"
-    network {
-        name = "${var.network_name}"
-    }
-    security_groups = ["${openstack_compute_secgroup_v2.k8s.name}",
-                        "default" ]
-    metadata = {
-        ssh_user = "${var.ssh_user_gfs}"
-        kubespray_groups = "gfs-cluster,network-storage,no-floating"
-    }
-    user_data = "#cloud-config\nmanage_etc_hosts: localhost\npackage_update: true\npackage_upgrade: true"
-
-    depends_on = [ "openstack_networking_network_v2.k8s" ]
-    volume {
-        volume_id = "${element(openstack_blockstorage_volume_v2.glusterfs_volume.*.id, count.index)}"
-    }
-}
-
-
-output "msg" {
-    value = "Your hosts are ready to go!\nYour ssh hosts are: ${join(", ", openstack_networking_floatingip_v2.k8s_master.*.address, openstack_networking_floatingip_v2.bastion.*.address )}"
+  network_id = "${module.network.router_id}"
 }

--- a/contrib/terraform/openstack/modules/compute/main.tf
+++ b/contrib/terraform/openstack/modules/compute/main.tf
@@ -1,0 +1,280 @@
+
+
+variable user_data  {
+  type    = "string"
+  default = <<EOF
+#cloud-config
+manage_etc_hosts: localhost
+package_update: true
+package_upgrade: true
+EOF
+}
+resource "openstack_compute_keypair_v2" "k8s" {
+    name = "kubernetes-${var.cluster_name}"
+    public_key = "${chomp(file(var.public_key_path))}"
+}
+
+resource "openstack_compute_secgroup_v2" "k8s_master" {
+    name = "${var.cluster_name}-k8s-master"
+    description = "${var.cluster_name} - Kubernetes Master"
+    rule {
+        ip_protocol = "tcp"
+        from_port = "6443"
+        to_port = "6443"
+        cidr = "0.0.0.0/0"
+    }
+}
+
+resource "openstack_compute_secgroup_v2" "bastion" {
+    name = "${var.cluster_name}-bastion"
+    description = "${var.cluster_name} - Bastion Server"
+    rule {
+        ip_protocol = "tcp"
+        from_port = "22"
+        to_port = "22"
+        cidr = "0.0.0.0/0"
+    }
+}
+
+resource "openstack_compute_secgroup_v2" "k8s" {
+    name = "${var.cluster_name}-k8s"
+    description = "${var.cluster_name} - Kubernetes"
+    rule {
+        ip_protocol = "icmp"
+        from_port = "-1"
+        to_port = "-1"
+        cidr = "0.0.0.0/0"
+    }
+    rule {
+        ip_protocol = "tcp"
+        from_port = "1"
+        to_port = "65535"
+        self = true
+    }
+    rule {
+        ip_protocol = "udp"
+        from_port = "1"
+        to_port = "65535"
+        self = true
+    }
+    rule {
+        ip_protocol = "icmp"
+        from_port = "-1"
+        to_port = "-1"
+        self = true
+    }
+}
+
+resource "openstack_compute_instance_v2" "bastion" {
+    name = "${var.cluster_name}-bastion-${count.index+1}"
+    count = "${var.number_of_bastions}"
+    image_name = "${var.image}"
+    flavor_id = "${var.flavor_bastion}"
+    key_pair = "${openstack_compute_keypair_v2.k8s.name}"
+    network {
+        name = "${var.network_name}"
+    }
+    security_groups = [ "${openstack_compute_secgroup_v2.k8s.name}",
+                        "${openstack_compute_secgroup_v2.bastion.name}",
+                        "default" ]
+    metadata = {
+        ssh_user = "${var.ssh_user}"
+        kubespray_groups = "bastion"
+        depends_on = "${var.network_id}"
+    }
+
+    provisioner "local-exec" {
+	     command = "sed s/USER/${var.ssh_user}/ contrib/terraform/openstack/ansible_bastion_template.txt | sed s/BASTION_ADDRESS/${var.bastion_fips[0]}/ > contrib/terraform/openstack/group_vars/no-floating.yml"
+    }
+
+    user_data = "${var.user_data}"
+}
+
+resource "openstack_compute_instance_v2" "k8s_master" {
+    name = "${var.cluster_name}-k8s-master-${count.index+1}"
+    count = "${var.number_of_k8s_masters}"
+    image_name = "${var.image}"
+    flavor_id = "${var.flavor_k8s_master}"
+    key_pair = "${openstack_compute_keypair_v2.k8s.name}"
+    network {
+        name = "${var.network_name}"
+    }
+    security_groups = [ "${openstack_compute_secgroup_v2.k8s_master.name}",
+                        "${openstack_compute_secgroup_v2.bastion.name}",
+                        "${openstack_compute_secgroup_v2.k8s.name}",
+                        "default" ]
+    metadata = {
+        ssh_user = "${var.ssh_user}"
+        kubespray_groups = "etcd,kube-master,kube-node,k8s-cluster,vault"
+        depends_on = "${var.network_id}"
+    }
+    user_data = "${var.user_data}"
+}
+
+resource "openstack_compute_instance_v2" "k8s_master_no_etcd" {
+    name = "${var.cluster_name}-k8s-master-ne-${count.index+1}"
+    count = "${var.number_of_k8s_masters_no_etcd}"
+    image_name = "${var.image}"
+    flavor_id = "${var.flavor_k8s_master}"
+    key_pair = "${openstack_compute_keypair_v2.k8s.name}"
+    network {
+        name = "${var.network_name}"
+    }
+    security_groups = [ "${openstack_compute_secgroup_v2.k8s_master.name}",
+                        "${openstack_compute_secgroup_v2.k8s.name}" ]
+    metadata = {
+        ssh_user = "${var.ssh_user}"
+        kubespray_groups = "kube-master,kube-node,k8s-cluster,vault"
+        depends_on = "${var.network_id}"
+    }
+    user_data = "${var.user_data}"
+}
+
+resource "openstack_compute_instance_v2" "etcd" {
+    name = "${var.cluster_name}-etcd-${count.index+1}"
+    count = "${var.number_of_etcd}"
+    image_name = "${var.image}"
+    flavor_id = "${var.flavor_etcd}"
+    key_pair = "${openstack_compute_keypair_v2.k8s.name}"
+    network {
+        name = "${var.network_name}"
+    }
+    security_groups = [ "${openstack_compute_secgroup_v2.k8s.name}" ]
+    metadata = {
+        ssh_user = "${var.ssh_user}"
+        kubespray_groups = "etcd,vault,no-floating"
+        depends_on = "${var.network_id}"
+    }
+    user_data = "${var.user_data}"
+}
+
+
+resource "openstack_compute_instance_v2" "k8s_master_no_floating_ip" {
+    name = "${var.cluster_name}-k8s-master-nf-${count.index+1}"
+    count = "${var.number_of_k8s_masters_no_floating_ip}"
+    image_name = "${var.image}"
+    flavor_id = "${var.flavor_k8s_master}"
+    key_pair = "${openstack_compute_keypair_v2.k8s.name}"
+    network {
+        name = "${var.network_name}"
+    }
+    security_groups = [ "${openstack_compute_secgroup_v2.k8s_master.name}",
+                        "${openstack_compute_secgroup_v2.k8s.name}",
+                        "default" ]
+    metadata = {
+        ssh_user = "${var.ssh_user}"
+        kubespray_groups = "etcd,kube-master,kube-node,k8s-cluster,vault,no-floating"
+        depends_on = "${var.network_id}"
+    }
+    user_data = "${var.user_data}"
+}
+
+resource "openstack_compute_instance_v2" "k8s_master_no_floating_ip_no_etcd" {
+    name = "${var.cluster_name}-k8s-master-ne-nf-${count.index+1}"
+    count = "${var.number_of_k8s_masters_no_floating_ip_no_etcd}"
+    image_name = "${var.image}"
+    flavor_id = "${var.flavor_k8s_master}"
+    key_pair = "${openstack_compute_keypair_v2.k8s.name}"
+    network {
+        name = "${var.network_name}"
+    }
+    security_groups = [ "${openstack_compute_secgroup_v2.k8s_master.name}",
+                        "${openstack_compute_secgroup_v2.k8s.name}" ]
+    metadata = {
+        ssh_user = "${var.ssh_user}"
+        kubespray_groups = "kube-master,kube-node,k8s-cluster,vault,no-floating"
+        depends_on = "${var.network_id}"
+    }
+    user_data = "${var.user_data}"
+}
+
+
+resource "openstack_compute_instance_v2" "k8s_node" {
+    name = "${var.cluster_name}-k8s-node-${count.index+1}"
+    count = "${var.number_of_k8s_nodes}"
+    image_name = "${var.image}"
+    flavor_id = "${var.flavor_k8s_node}"
+    key_pair = "${openstack_compute_keypair_v2.k8s.name}"
+    network {
+        name = "${var.network_name}"
+    }
+    security_groups = [ "${openstack_compute_secgroup_v2.k8s.name}",
+                        "${openstack_compute_secgroup_v2.bastion.name}",
+                        "default" ]
+    metadata = {
+        ssh_user = "${var.ssh_user}"
+        kubespray_groups = "kube-node,k8s-cluster"
+        depends_on = "${var.network_id}"
+    }
+    user_data = "${var.user_data}"
+}
+
+resource "openstack_compute_instance_v2" "k8s_node_no_floating_ip" {
+    name = "${var.cluster_name}-k8s-node-nf-${count.index+1}"
+    count = "${var.number_of_k8s_nodes_no_floating_ip}"
+    image_name = "${var.image}"
+    flavor_id = "${var.flavor_k8s_node}"
+    key_pair = "${openstack_compute_keypair_v2.k8s.name}"
+    network {
+        name = "${var.network_name}"
+    }
+    security_groups = [ "${openstack_compute_secgroup_v2.k8s.name}",
+                        "default" ]
+    metadata = {
+        ssh_user = "${var.ssh_user}"
+        kubespray_groups = "kube-node,k8s-cluster,no-floating"
+        depends_on = "${var.network_id}"
+    }
+    user_data = "${var.user_data}"
+}
+
+resource "openstack_compute_floatingip_associate_v2" "bastion" {
+    count = "${var.number_of_bastions}"
+    floating_ip = "${var.bastion_fips[count.index]}"
+    instance_id = "${element(openstack_compute_instance_v2.bastion.*.id, count.index)}"
+}
+
+resource "openstack_compute_floatingip_associate_v2" "k8s_master" {
+    count = "${var.number_of_k8s_masters}"
+    instance_id = "${element(openstack_compute_instance_v2.k8s_master.*.id, count.index)}"
+    floating_ip = "${var.k8s_master_fips[count.index]}"
+}
+
+resource "openstack_compute_floatingip_associate_v2" "k8s_node" {
+    count = "${var.number_of_k8s_nodes}"
+    floating_ip = "${var.k8s_node_fips[count.index]}"
+    instance_id = "${element(openstack_compute_instance_v2.k8s_node.*.id, count.index)}"
+}
+
+
+resource "openstack_blockstorage_volume_v2" "glusterfs_volume" {
+  name = "${var.cluster_name}-glusterfs_volume-${count.index+1}"
+  count = "${var.number_of_gfs_nodes_no_floating_ip}"
+  description = "Non-ephemeral volume for GlusterFS"
+  size = "${var.gfs_volume_size_in_gb}"
+}
+
+resource "openstack_compute_instance_v2" "glusterfs_node_no_floating_ip" {
+    name = "${var.cluster_name}-gfs-node-nf-${count.index+1}"
+    count = "${var.number_of_gfs_nodes_no_floating_ip}"
+    image_name = "${var.image_gfs}"
+    flavor_id = "${var.flavor_gfs_node}"
+    key_pair = "${openstack_compute_keypair_v2.k8s.name}"
+    network {
+        name = "${var.network_name}"
+    }
+    security_groups = ["${openstack_compute_secgroup_v2.k8s.name}",
+                        "default" ]
+    metadata = {
+        ssh_user = "${var.ssh_user_gfs}"
+        kubespray_groups = "gfs-cluster,network-storage,no-floating"
+        depends_on = "${var.network_id}"
+    }
+    user_data = "#cloud-config\nmanage_etc_hosts: localhost\npackage_update: true\npackage_upgrade: true"
+}
+
+resource "openstack_compute_volume_attach_v2" "glusterfs_volume" {
+  count = "${var.number_of_gfs_nodes_no_floating_ip}"
+  instance_id = "${element(openstack_compute_instance_v2.glusterfs_node_no_floating_ip.*.id, count.index)}"
+  volume_id   = "${element(openstack_blockstorage_volume_v2.glusterfs_volume.*.id, count.index)}"
+}

--- a/contrib/terraform/openstack/modules/compute/variables.tf
+++ b/contrib/terraform/openstack/modules/compute/variables.tf
@@ -1,0 +1,83 @@
+variable "cluster_name" {
+}
+
+variable "number_of_k8s_masters" {
+}
+
+variable "number_of_k8s_masters_no_etcd" {
+}
+
+variable "number_of_etcd" {
+}
+
+variable "number_of_k8s_masters_no_floating_ip" {
+}
+
+variable "number_of_k8s_masters_no_floating_ip_no_etcd" {
+}
+
+variable "number_of_k8s_nodes" {
+}
+
+variable "number_of_k8s_nodes_no_floating_ip" {
+}
+
+variable "number_of_bastions" {
+}
+
+variable "number_of_gfs_nodes_no_floating_ip" {
+}
+
+variable "gfs_volume_size_in_gb" {
+}
+
+variable "public_key_path" {
+}
+
+variable "image" {
+}
+
+variable "image_gfs" {
+}
+
+variable "ssh_user" {
+}
+
+variable "ssh_user_gfs" {
+}
+
+variable "flavor_k8s_master" {
+}
+
+variable "flavor_k8s_node" {
+}
+
+variable "flavor_etcd" {
+}
+
+variable "flavor_gfs_node" {
+}
+
+variable "network_name" {
+}
+
+variable "flavor_bastion" {
+}
+
+
+variable "network_id"{
+
+}
+
+
+variable "k8s_master_fips" {
+  type = "list"
+}
+
+variable "k8s_node_fips" {
+  type = "list"
+}
+
+variable "bastion_fips" {
+  type = "list"
+}

--- a/contrib/terraform/openstack/modules/ips/main.tf
+++ b/contrib/terraform/openstack/modules/ips/main.tf
@@ -1,0 +1,24 @@
+
+resource "null_resource" "dummy_dependency" {
+  triggers {
+    dependency_id = "${var.router_id}"
+  }
+}
+
+resource "openstack_networking_floatingip_v2" "k8s_master" {
+    count = "${var.number_of_k8s_masters}"
+    pool = "${var.floatingip_pool}"
+    depends_on = ["null_resource.dummy_dependency"]
+}
+
+resource "openstack_networking_floatingip_v2" "k8s_node" {
+    count = "${var.number_of_k8s_nodes}"
+    pool = "${var.floatingip_pool}"
+    depends_on = ["null_resource.dummy_dependency"]
+}
+
+resource "openstack_networking_floatingip_v2" "bastion" {
+    count = "${var.number_of_bastions}"
+    pool = "${var.floatingip_pool}"
+    depends_on = ["null_resource.dummy_dependency"]
+}

--- a/contrib/terraform/openstack/modules/ips/outputs.tf
+++ b/contrib/terraform/openstack/modules/ips/outputs.tf
@@ -1,0 +1,11 @@
+output "k8s_master_fips" {
+    value = ["${openstack_networking_floatingip_v2.k8s_master.*.address}"]
+}
+
+output "k8s_node_fips" {
+    value = ["${openstack_networking_floatingip_v2.k8s_node.*.address}"]
+}
+
+output "bastion_fips" {
+    value = ["${openstack_networking_floatingip_v2.bastion.*.address}"]
+}

--- a/contrib/terraform/openstack/modules/ips/variables.tf
+++ b/contrib/terraform/openstack/modules/ips/variables.tf
@@ -1,0 +1,26 @@
+variable "number_of_k8s_masters" {
+}
+
+variable "number_of_k8s_masters_no_etcd" {
+}
+
+variable "number_of_k8s_nodes" {
+}
+
+variable "floatingip_pool" {
+}
+
+variable "number_of_bastions" {
+
+ }
+
+variable "external_net" {
+
+}
+
+variable "network_name" {
+}
+
+variable "router_id"{
+
+}

--- a/contrib/terraform/openstack/modules/network/main.tf
+++ b/contrib/terraform/openstack/modules/network/main.tf
@@ -15,7 +15,7 @@ resource "openstack_networking_subnet_v2" "k8s" {
   network_id      = "${openstack_networking_network_v2.k8s.id}"
   cidr            = "10.0.0.0/24"
   ip_version      = 4
-  dns_nameservers = ["8.8.8.8", "8.8.4.4"]
+  dns_nameservers = "${var.dns_nameservers}"
 }
 
 resource "openstack_networking_router_interface_v2" "k8s" {

--- a/contrib/terraform/openstack/modules/network/main.tf
+++ b/contrib/terraform/openstack/modules/network/main.tf
@@ -1,0 +1,24 @@
+
+resource "openstack_networking_router_v2" "k8s" {
+  name             = "internal"
+  admin_state_up   = "true"
+  external_gateway = "${var.external_net}"
+}
+
+resource "openstack_networking_network_v2" "k8s" {
+  name           = "${var.network_name}"
+  admin_state_up = "true"
+}
+
+resource "openstack_networking_subnet_v2" "k8s" {
+  name            = "internal"
+  network_id      = "${openstack_networking_network_v2.k8s.id}"
+  cidr            = "10.0.0.0/24"
+  ip_version      = 4
+  dns_nameservers = ["8.8.8.8", "8.8.4.4"]
+}
+
+resource "openstack_networking_router_interface_v2" "k8s" {
+  router_id = "${openstack_networking_router_v2.k8s.id}"
+  subnet_id = "${openstack_networking_subnet_v2.k8s.id}"
+}

--- a/contrib/terraform/openstack/modules/network/main.tf
+++ b/contrib/terraform/openstack/modules/network/main.tf
@@ -1,6 +1,6 @@
 
 resource "openstack_networking_router_v2" "k8s" {
-  name             = "internal"
+  name             = "${var.cluster_name}-router"
   admin_state_up   = "true"
   external_gateway = "${var.external_net}"
 }
@@ -11,7 +11,7 @@ resource "openstack_networking_network_v2" "k8s" {
 }
 
 resource "openstack_networking_subnet_v2" "k8s" {
-  name            = "internal"
+  name            = "${var.cluster_name}-internal-network"
   network_id      = "${openstack_networking_network_v2.k8s.id}"
   cidr            = "10.0.0.0/24"
   ip_version      = 4

--- a/contrib/terraform/openstack/modules/network/outputs.tf
+++ b/contrib/terraform/openstack/modules/network/outputs.tf
@@ -1,0 +1,7 @@
+output "router_id" {
+    value = "${openstack_networking_router_interface_v2.k8s.id}"
+}
+
+output "network_id" {
+    value = "${openstack_networking_subnet_v2.k8s.id}"
+}

--- a/contrib/terraform/openstack/modules/network/variables.tf
+++ b/contrib/terraform/openstack/modules/network/variables.tf
@@ -4,3 +4,6 @@ variable "external_net" {
 
 variable "network_name" {
 }
+
+variable "cluster_name" {
+}

--- a/contrib/terraform/openstack/modules/network/variables.tf
+++ b/contrib/terraform/openstack/modules/network/variables.tf
@@ -7,3 +7,7 @@ variable "network_name" {
 
 variable "cluster_name" {
 }
+
+variable "dns_nameservers"{
+  type = "list"
+}

--- a/contrib/terraform/openstack/modules/network/variables.tf
+++ b/contrib/terraform/openstack/modules/network/variables.tf
@@ -1,0 +1,6 @@
+variable "external_net" {
+
+}
+
+variable "network_name" {
+}

--- a/contrib/terraform/openstack/variables.tf
+++ b/contrib/terraform/openstack/variables.tf
@@ -2,6 +2,10 @@ variable "cluster_name" {
   default = "example"
 }
 
+variable "number_of_bastions" {
+  default = 1
+}
+
 variable "number_of_k8s_masters" {
   default = 2
 }
@@ -63,6 +67,10 @@ variable "ssh_user_gfs" {
   default = "ubuntu"
 }
 
+variable "flavor_bastion" {
+  default = 3
+}
+
 variable "flavor_k8s_master" {
   default = 3
 }
@@ -87,6 +95,10 @@ variable "network_name" {
 variable "floatingip_pool" {
   description = "name of the floating ip pool to use"
   default = "external"
+}
+
+variable "external_net" {
+  description = "uuid of the external/public network"
 }
 
 variable "username" {

--- a/contrib/terraform/openstack/variables.tf
+++ b/contrib/terraform/openstack/variables.tf
@@ -68,22 +68,27 @@ variable "ssh_user_gfs" {
 }
 
 variable "flavor_bastion" {
+  description = "Use 'nova flavor-list' command to see what your OpenStack instance uses for IDs"
   default = 3
 }
 
 variable "flavor_k8s_master" {
+  description = "Use 'nova flavor-list' command to see what your OpenStack instance uses for IDs"
   default = 3
 }
 
 variable "flavor_k8s_node" {
+  description = "Use 'nova flavor-list' command to see what your OpenStack instance uses for IDs"
   default = 3
 }
 
 variable "flavor_etcd" {
+  description = "Use 'nova flavor-list' command to see what your OpenStack instance uses for IDs"
   default = 3
 }
 
 variable "flavor_gfs_node" {
+  description = "Use 'nova flavor-list' command to see what your OpenStack instance uses for IDs"
   default = 3
 }
 

--- a/contrib/terraform/openstack/variables.tf
+++ b/contrib/terraform/openstack/variables.tf
@@ -97,6 +97,12 @@ variable "network_name" {
   default = "internal"
 }
 
+variable "dns_nameservers"{
+  description = "An array of DNS name server names used by hosts in this subnet."
+  type = "list"
+  default = []
+}
+
 variable "floatingip_pool" {
   description = "name of the floating ip pool to use"
   default = "external"


### PR DESCRIPTION
# Problem
The latest version of [contrib/terraform/openstack](https://github.com/kubernetes-incubator/kubespray/tree/master/contrib/terraform/openstack) doesn't work with current versions of OpenStack since the `floating_ip` property is no longer supported on the `openstack_compute_instance_v2` resource. There are a few PRs and commits floating around the repo that fix this as well as some other issues with the OpenStack terraform. This PR pulls all of them together into a comprehensive update of this contrib.

# Approach
This PR brings together some new approaches for provisioning OpenStack via terraform:
- Nodes are all created in a private subnet
- The configuration allows for the provisioning of a bastion node to allow access to private nodes inside the cluster
- The configuration has been broken up into modules to make it easier to override the allocation of new floating IPs
- Replace the obsolete `floating_ip` properties with `openstack_compute_floatingip_associate_v2` resources
- Cleaned up generated security groups
- Fixed the generation of gluster nodes
- Refreshed the README to bring everything up to date

# PRs this is Based On
- @bradbeam PR #1353 created the private network and bastion host
- @manics PR #1837 refactored the terraform config into modules
- @manics also fixed how the terraform.py script figures out the floating IP addresses of the hosts from the `openstack_compute_floatingip_associate_v2` resources in 3e109be1640f6255bd0ce6b26324b7b239594811 

# How to test
Just check out the branch and follow the instructions in the README to construct desired kubernetes cluster in a current OpenStack installation