### PR TITLE
Terraform - Remove the need for region specific reference data

### DIFF
--- a/contrib/terraform/aws/create-infrastructure.tf
+++ b/contrib/terraform/aws/create-infrastructure.tf
@@ -20,7 +20,7 @@ module "aws-vpc" {
 
   aws_cluster_name = "${var.aws_cluster_name}"
   aws_vpc_cidr_block = "${var.aws_vpc_cidr_block}"
-  aws_avail_zones="${data.aws_availability_zones.available.names}"
+  aws_avail_zones="${slice(data.aws_availability_zones.available.names,0,2)}"
   aws_cidr_subnets_private="${var.aws_cidr_subnets_private}"
   aws_cidr_subnets_public="${var.aws_cidr_subnets_public}"
   default_tags="${var.default_tags}"
@@ -33,7 +33,7 @@ module "aws-elb" {
 
   aws_cluster_name="${var.aws_cluster_name}"
   aws_vpc_id="${module.aws-vpc.aws_vpc_id}"
-  aws_avail_zones="${data.aws_availability_zones.available.names}"
+  aws_avail_zones="${slice(data.aws_availability_zones.available.names,0,2)}"
   aws_subnet_ids_public="${module.aws-vpc.aws_subnet_ids_public}"
   aws_elb_api_port = "${var.aws_elb_api_port}"
   k8s_secure_api_port = "${var.k8s_secure_api_port}"
@@ -72,7 +72,7 @@ resource "aws_instance" "bastion-server" {
     instance_type = "${var.aws_bastion_size}"
     count = "${length(var.aws_cidr_subnets_public)}"
     associate_public_ip_address = true
-    availability_zone  = "${element(data.aws_availability_zones.available.names,count.index)}"
+    availability_zone  = "${element(slice(data.aws_availability_zones.available.names,0,2),count.index)}"
     subnet_id = "${element(module.aws-vpc.aws_subnet_ids_public,count.index)}"
 
 
@@ -100,7 +100,7 @@ resource "aws_instance" "k8s-master" {
     count = "${var.aws_kube_master_num}"
 
 
-    availability_zone  = "${element(data.aws_availability_zones.available.names,count.index)}"
+    availability_zone  = "${element(slice(data.aws_availability_zones.available.names,0,2),count.index)}"
     subnet_id = "${element(module.aws-vpc.aws_subnet_ids_private,count.index)}"
 
 
@@ -132,7 +132,7 @@ resource "aws_instance" "k8s-etcd" {
     count = "${var.aws_etcd_num}"
 
 
-    availability_zone = "${element(data.aws_availability_zones.available.names,count.index)}"
+    availability_zone = "${element(slice(data.aws_availability_zones.available.names,0,2),count.index)}"
     subnet_id = "${element(module.aws-vpc.aws_subnet_ids_private,count.index)}"
 
 
@@ -155,7 +155,7 @@ resource "aws_instance" "k8s-worker" {
 
     count = "${var.aws_kube_worker_num}"
 
-    availability_zone  = "${element(data.aws_availability_zones.available.names,count.index)}"
+    availability_zone  = "${element(slice(data.aws_availability_zones.available.names,0,2),count.index)}"
     subnet_id = "${element(module.aws-vpc.aws_subnet_ids_private,count.index)}"
 
     vpc_security_group_ids = [ "${module.aws-vpc.aws_security_group}" ]

--- a/contrib/terraform/aws/create-infrastructure.tf
+++ b/contrib/terraform/aws/create-infrastructure.tf
@@ -64,7 +64,7 @@ data "aws_ami" "coreos" {
     values = ["hvm"]
   }
 
-  owners = ["595879546273"]
+  owners = ["595879546273"] #CoreOS
 }
 
 resource "aws_instance" "bastion-server" {
@@ -94,7 +94,7 @@ resource "aws_instance" "bastion-server" {
 */
 
 resource "aws_instance" "k8s-master" {
-    ami = "${var.aws_cluster_ami}"
+    ami = "${data.aws_ami.coreos.id}"
     instance_type = "${var.aws_kube_master_size}"
 
     count = "${var.aws_kube_master_num}"
@@ -126,7 +126,7 @@ resource "aws_elb_attachment" "attach_master_nodes" {
 
 
 resource "aws_instance" "k8s-etcd" {
-    ami = "${var.aws_cluster_ami}"
+    ami = "${data.aws_ami.coreos.id}"
     instance_type = "${var.aws_etcd_size}"
 
     count = "${var.aws_etcd_num}"
@@ -150,7 +150,7 @@ resource "aws_instance" "k8s-etcd" {
 
 
 resource "aws_instance" "k8s-worker" {
-    ami = "${var.aws_cluster_ami}"
+    ami = "${data.aws_ami.coreos.id}"
     instance_type = "${var.aws_kube_worker_size}"
 
     count = "${var.aws_kube_worker_num}"

--- a/contrib/terraform/aws/create-infrastructure.tf
+++ b/contrib/terraform/aws/create-infrastructure.tf
@@ -8,6 +8,8 @@ provider "aws" {
     region = "${var.AWS_DEFAULT_REGION}"
 }
 
+data "aws_availability_zones" "available" {}
+
 /*
 * Calling modules who create the initial AWS VPC / AWS ELB
 * and AWS IAM Roles for Kubernetes Deployment
@@ -18,7 +20,7 @@ module "aws-vpc" {
 
   aws_cluster_name = "${var.aws_cluster_name}"
   aws_vpc_cidr_block = "${var.aws_vpc_cidr_block}"
-  aws_avail_zones="${var.aws_avail_zones}"
+  aws_avail_zones="${data.aws_availability_zones.available.names}"
   aws_cidr_subnets_private="${var.aws_cidr_subnets_private}"
   aws_cidr_subnets_public="${var.aws_cidr_subnets_public}"
   default_tags="${var.default_tags}"
@@ -31,7 +33,7 @@ module "aws-elb" {
 
   aws_cluster_name="${var.aws_cluster_name}"
   aws_vpc_id="${module.aws-vpc.aws_vpc_id}"
-  aws_avail_zones="${var.aws_avail_zones}"
+  aws_avail_zones="${data.aws_availability_zones.available.names}"
   aws_subnet_ids_public="${module.aws-vpc.aws_subnet_ids_public}"
   aws_elb_api_port = "${var.aws_elb_api_port}"
   k8s_secure_api_port = "${var.k8s_secure_api_port}"
@@ -70,7 +72,7 @@ resource "aws_instance" "bastion-server" {
     instance_type = "${var.aws_bastion_size}"
     count = "${length(var.aws_cidr_subnets_public)}"
     associate_public_ip_address = true
-    availability_zone  = "${element(var.aws_avail_zones,count.index)}"
+    availability_zone  = "${element(data.aws_availability_zones.available.names,count.index)}"
     subnet_id = "${element(module.aws-vpc.aws_subnet_ids_public,count.index)}"
 
 
@@ -98,7 +100,7 @@ resource "aws_instance" "k8s-master" {
     count = "${var.aws_kube_master_num}"
 
 
-    availability_zone  = "${element(var.aws_avail_zones,count.index)}"
+    availability_zone  = "${element(data.aws_availability_zones.available.names,count.index)}"
     subnet_id = "${element(module.aws-vpc.aws_subnet_ids_private,count.index)}"
 
 
@@ -130,7 +132,7 @@ resource "aws_instance" "k8s-etcd" {
     count = "${var.aws_etcd_num}"
 
 
-    availability_zone = "${element(var.aws_avail_zones,count.index)}"
+    availability_zone = "${element(data.aws_availability_zones.available.names,count.index)}"
     subnet_id = "${element(module.aws-vpc.aws_subnet_ids_private,count.index)}"
 
 
@@ -153,7 +155,7 @@ resource "aws_instance" "k8s-worker" {
 
     count = "${var.aws_kube_worker_num}"
 
-    availability_zone  = "${element(var.aws_avail_zones,count.index)}"
+    availability_zone  = "${element(data.aws_availability_zones.available.names,count.index)}"
     subnet_id = "${element(module.aws-vpc.aws_subnet_ids_private,count.index)}"
 
     vpc_security_group_ids = [ "${module.aws-vpc.aws_security_group}" ]

--- a/contrib/terraform/aws/terraform.tfvars
+++ b/contrib/terraform/aws/terraform.tfvars
@@ -8,7 +8,6 @@ aws_cidr_subnets_public = ["10.250.224.0/20","10.250.240.0/20"]
 aws_avail_zones = ["us-west-2a","us-west-2b"]
 
 #Bastion Host
-aws_bastion_ami = "ami-db56b9a3"
 aws_bastion_size = "t2.medium"
 
 

--- a/contrib/terraform/aws/terraform.tfvars
+++ b/contrib/terraform/aws/terraform.tfvars
@@ -5,7 +5,6 @@ aws_cluster_name = "devtest"
 aws_vpc_cidr_block = "10.250.192.0/18"
 aws_cidr_subnets_private = ["10.250.192.0/20","10.250.208.0/20"]
 aws_cidr_subnets_public = ["10.250.224.0/20","10.250.240.0/20"]
-aws_avail_zones = ["us-west-2a","us-west-2b"]
 
 #Bastion Host
 aws_bastion_size = "t2.medium"

--- a/contrib/terraform/aws/terraform.tfvars
+++ b/contrib/terraform/aws/terraform.tfvars
@@ -21,8 +21,6 @@ aws_etcd_size = "t2.medium"
 aws_kube_worker_num = 4
 aws_kube_worker_size = "t2.medium"
 
-aws_cluster_ami = "ami-db56b9a3"
-
 #Settings AWS ELB
 
 aws_elb_api_port = 6443

--- a/contrib/terraform/aws/variables.tf
+++ b/contrib/terraform/aws/variables.tf
@@ -27,11 +27,6 @@ variable "aws_vpc_cidr_block" {
   description = "CIDR Block for VPC"
 }
 
-variable "aws_avail_zones" {
-  description = "Availability Zones Used"
-  type = "list"
-}
-
 variable "aws_cidr_subnets_private" {
   description = "CIDR Blocks for private subnets in Availability Zones"
   type = "list"

--- a/contrib/terraform/aws/variables.tf
+++ b/contrib/terraform/aws/variables.tf
@@ -44,10 +44,6 @@ variable "aws_cidr_subnets_public" {
 
 //AWS EC2 Settings
 
-variable "aws_bastion_ami" {
-    description = "AMI ID for Bastion Host in chosen AWS Region"
-}
-
 variable "aws_bastion_size" {
     description = "EC2 Instance Size of Bastion Host"
 }

--- a/contrib/terraform/aws/variables.tf
+++ b/contrib/terraform/aws/variables.tf
@@ -72,9 +72,6 @@ variable "aws_kube_worker_size" {
     description = "Instance size of Kubernetes Worker Nodes"
 }
 
-variable "aws_cluster_ami" {
-    description = "AMI ID for Kubernetes Cluster"
-}
 /*
 * AWS ELB Settings
 *


### PR DESCRIPTION
Currently the Terraform code requires reference data (AMI ids, Availability zones) which are specific to a region. This pull request removes that need, by using terraform data sources (aws_availability_zones for availability zones and aws_ami for the ami).