### PR TITLE
Update to k8s 1.8.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Versions of supported components
 --------------------------------
 
 
-[kubernetes](https://github.com/kubernetes/kubernetes/releases) v1.8.2 <br>
+[kubernetes](https://github.com/kubernetes/kubernetes/releases) v1.8.3 <br>
 [etcd](https://github.com/coreos/etcd/releases) v3.2.4 <br>
 [flanneld](https://github.com/coreos/flannel/releases) v0.8.0 <br>
 [calico](https://docs.projectcalico.org/v2.5/releases/) v2.5.0 <br>

--- a/inventory/group_vars/k8s-cluster.yml
+++ b/inventory/group_vars/k8s-cluster.yml
@@ -23,7 +23,7 @@ kube_users_dir: "{{ kube_config_dir }}/users"
 kube_api_anonymous_auth: true
 
 ## Change this to use another Kubernetes version, e.g. a current beta release
-kube_version: v1.8.2
+kube_version: v1.8.3
 
 # Where the binaries will be downloaded.
 # Note: ensure that you've enough disk space (about 1G)

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -24,7 +24,7 @@ download_always_pull: False
 download_delegate: "{% if download_localhost %}localhost{% else %}{{groups['kube-master'][0]}}{% endif %}"
 
 # Versions
-kube_version: v1.8.2
+kube_version: v1.8.3
 kubeadm_version: "{{ kube_version }}"
 etcd_version: v3.2.4
 # TODO(mattymo): Move calico versions to roles/network_plugins/calico/defaults

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -13,7 +13,7 @@ kube_api_anonymous_auth: false
 is_atomic: false
 
 ## Change this to use another Kubernetes version, e.g. a current beta release
-kube_version: v1.8.2
+kube_version: v1.8.3
 
 # Set to true to allow pre-checks to fail and continue deployment
 ignore_assert_errors: false


### PR DESCRIPTION
Looks like the new [hyperkube image](https://quay.io/repository/coreos/hyperkube?tab=tags) was pushed today