### PR TITLE
Additional flush for static pod master upgrade

### DIFF
--- a/roles/kubernetes/master/tasks/static-pod-setup.yml
+++ b/roles/kubernetes/master/tasks/static-pod-setup.yml
@@ -38,3 +38,5 @@
   notify: Master | Restart kube-controller-manager
   tags:
     - kube-controller-manager
+
+- meta: flush_handlers


### PR DESCRIPTION
Thought this wasn't required at first, but I forgot there's no auto flush at the end of these tasks since the `kubernetes/master` role is not the end of the play.