### PR TITLE
Replace the raw rsync command with the synchronize module

### DIFF
--- a/roles/kubernetes/node/tasks/install.yml
+++ b/roles/kubernetes/node/tasks/install.yml
@@ -7,8 +7,13 @@
     - kubeadm
 
 - name: install | Copy kubeadm binary from download dir
-  command: rsync -piu "{{ local_release_dir }}/kubeadm" "{{ bin_dir }}/kubeadm"
-  changed_when: false
+  synchronize:
+    src: "{{ local_release_dir }}/kubeadm"
+    dest: "{{ bin_dir }}/kubeadm"
+    compress: no
+    owner: no
+    group: no
+  delegate_to: "{{ inventory_hostname }}"
   when: kubeadm_enabled
   tags:
     - kubeadm


### PR DESCRIPTION
To copy a local folder, the command-module was used with rsync.
This can be also archived with the `synchronize` module (which is a wrapper of rsync).
Always good to eliminate the command module if it is somehow possible. Now also changes are tracked (before, the `changed_when` just was `false`)