### PR TITLE
fix broken variable when using route reflectors in ansible 2.4.1.0

### DIFF
--- a/cluster.yml
+++ b/cluster.yml
@@ -34,7 +34,7 @@
     - { role: download, tags: download, skip_downloads: false }
   environment: "{{proxy_env}}"
 
-- hosts: etcd:k8s-cluster:vault
+- hosts: etcd:k8s-cluster:vault:calico-rr
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   roles:
     - { role: kubespray-defaults, when: "cert_management == 'vault'" }
@@ -47,13 +47,13 @@
     - { role: kubespray-defaults}
     - { role: etcd, tags: etcd, etcd_cluster_setup: true }
 
-- hosts: k8s-cluster
+- hosts: k8s-cluster:calico-rr
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   roles:
     - { role: kubespray-defaults}
     - { role: etcd, tags: etcd, etcd_cluster_setup: false }
 
-- hosts: etcd:k8s-cluster:vault
+- hosts: etcd:k8s-cluster:vault:calico-rr
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   roles:
     - { role: kubespray-defaults}

--- a/roles/network_plugin/calico/tasks/main.yml
+++ b/roles/network_plugin/calico/tasks/main.yml
@@ -170,7 +170,7 @@
    "apiVersion": "v1",
    "metadata": {"node": "{{ inventory_hostname }}",
      "scope": "node",
-     "peerIP": "{{ hostvars[item]["calico_rr_ip"]|default(hostvars[item]["ip"])|default(hostvars[item]["ansible_default_ipv4.address"]) }}"}
+     "peerIP": "{{ hostvars[item]["calico_rr_ip"]|default(hostvars[item]["ip"])|default(hostvars[item]["ansible_default_ipv4"]["address"]) }}"}
    }'
    | {{ bin_dir }}/calicoctl create --skip-exists -f -
   with_items: "{{ groups['calico-rr'] | default([]) }}"


### PR DESCRIPTION
When doing our deployments with ansible 2.4.1.0, we've run into an issue with accessing the variable shown here. It only occurs when making use of route reflectors, but it seems like addressing it like `hostvars[item]["ansible_default_ipv4.address"]` is not cool with this version of ansible. What's a bit more curious is that we're using that hostvar in other places without issue, but I'm wondering if it's just not hitting the default case in the other spots. 

Regardless, updating this to `hostvars[item]["ansible_default_ipv4"]["address"]` solves the issue. Additionally, there are some changes here to cluster.yml that ensure calico-rr nodes are part of the necessary groups to get certs provisioned from vault.