### PR TITLE
Allow setting --bind-address for apiserver hyperkube

### DIFF
--- a/docs/ha-mode.md
+++ b/docs/ha-mode.md
@@ -74,6 +74,12 @@ loadbalancer_apiserver:
   port: 8383
 ```
 
+  Note: The default kubernetes apiserver configuration binds to all interfaces,
+  so you will need to use a different port for the vip from that the API is
+  listening on, or set the kube_apiserver_bind_address so that the API only
+  listens on a specific interface (to avoid conflict with haproxy binding the
+  port on the VIP adddress)
+
 This domain name, or default "lb-apiserver.kubernetes.local", will be inserted
 into the `/etc/hosts` file of all servers in the `k8s-cluster` group. Note that
 the HAProxy service should as well be HA and requires a VIP management, which

--- a/roles/kubernetes/master/defaults/main.yml
+++ b/roles/kubernetes/master/defaults/main.yml
@@ -6,6 +6,10 @@ kube_hostpath_dynamic_provisioner: "false"
 # change to 0.0.0.0 to enable insecure access from anywhere (not recommended)
 kube_apiserver_insecure_bind_address: 127.0.0.1
 
+# By default the external API listens on all interfaces, this can be changed to
+# listen on a specific address/interface.
+kube_apiserver_bind_address: 0.0.0.0
+
 # A port range to reserve for services with NodePort visibility.
 # Inclusive at both ends of the range.
 kube_apiserver_node_port_range: "30000-32767"

--- a/roles/kubernetes/master/templates/kubeadm-config.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.yaml.j2
@@ -25,6 +25,7 @@ token: {{ kubeadm_token }}
 tokenTTL: "{{ kubeadm_token_ttl }}"
 selfHosted: false
 apiServerExtraArgs:
+  bind-address: {{ kube_apiserver_bind_address }}
   insecure-bind-address: {{ kube_apiserver_insecure_bind_address }}
   insecure-port: "{{ kube_apiserver_insecure_port }}"
   admission-control: {{ kube_apiserver_admission_control | join(',') }}

--- a/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
@@ -35,6 +35,9 @@ spec:
     - --etcd-certfile={{ etcd_cert_dir }}/node-{{ inventory_hostname }}.pem
     - --etcd-keyfile={{ etcd_cert_dir }}/node-{{ inventory_hostname }}-key.pem
     - --insecure-bind-address={{ kube_apiserver_insecure_bind_address }}
+{% if kube_apiserver_bind_address is defined  %}
+    - --bind-address={{kube_apiserver_bind_address}}
+{% endif %}
     - --apiserver-count={{ kube_apiserver_count }}
     - --admission-control={{ kube_apiserver_admission_control | join(',') }}
     - --service-cluster-ip-range={{ kube_service_addresses }}

--- a/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
@@ -35,7 +35,7 @@ spec:
     - --etcd-certfile={{ etcd_cert_dir }}/node-{{ inventory_hostname }}.pem
     - --etcd-keyfile={{ etcd_cert_dir }}/node-{{ inventory_hostname }}-key.pem
     - --insecure-bind-address={{ kube_apiserver_insecure_bind_address }}
-    - --bind-address={{kube_apiserver_bind_address}}
+    - --bind-address={{ kube_apiserver_bind_address }}
     - --apiserver-count={{ kube_apiserver_count }}
     - --admission-control={{ kube_apiserver_admission_control | join(',') }}
     - --service-cluster-ip-range={{ kube_service_addresses }}

--- a/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
@@ -35,9 +35,7 @@ spec:
     - --etcd-certfile={{ etcd_cert_dir }}/node-{{ inventory_hostname }}.pem
     - --etcd-keyfile={{ etcd_cert_dir }}/node-{{ inventory_hostname }}-key.pem
     - --insecure-bind-address={{ kube_apiserver_insecure_bind_address }}
-{% if kube_apiserver_bind_address is defined  %}
     - --bind-address={{kube_apiserver_bind_address}}
-{% endif %}
     - --apiserver-count={{ kube_apiserver_count }}
     - --admission-control={{ kube_apiserver_admission_control | join(',') }}
     - --service-cluster-ip-range={{ kube_service_addresses }}


### PR DESCRIPTION
This is required if you wish to configure a loadbalancer (e.g haproxy)
running on the master nodes without choosing a different port for the
vip from that used by the API - in this case you need the API to bind to
a specific interface, then haproxy can bind the same port on the VIP:

root@overcloud-controller-0 ~]# netstat -taupen | grep 6443
tcp        0      0 192.168.24.6:6443       0.0.0.0:*               LISTEN      0          680613     134504/haproxy
tcp        0      0 192.168.24.16:6443      0.0.0.0:*               LISTEN      0          653329     131423/hyperkube
tcp        0      0 192.168.24.16:6443      192.168.24.16:58404     ESTABLISHED 0          652991     131423/hyperkube
tcp        0      0 192.168.24.16:58404     192.168.24.16:6443      ESTABLISHED 0          652986     131423/hyperkube

This can be achieved e.g via:

kube_apiserver_bind_address: 192.168.24.16

Closes https://github.com/kubernetes-incubator/kubespray/issues/1131