### PR TITLE
Enable flannel hairpin mode

### DIFF
--- a/roles/network_plugin/flannel/templates/cni-flannel.yml.j2
+++ b/roles/network_plugin/flannel/templates/cni-flannel.yml.j2
@@ -17,6 +17,7 @@ data:
           "type":"flannel",
           "delegate":{
             "forceAddress":true,
+            "hairpinMode": true,
             "isDefaultGateway":true
           }
         },


### PR DESCRIPTION
Pods are not able to connect to themselves via a service IP that corresponds to them when using flannel.

There's several issues about whether this should be handled by the flannel config, by CNI, or something else, e.g. https://github.com/containernetworking/cni/issues/320 but I haven't found a definitive statement.

This commit is copied from the CoreOS Flannel repo: https://github.com/coreos/flannel/pull/849/files

Closes #1991