### PR TITLE
Defaults for apiserver_loadbalancer_domain_name

### DIFF
--- a/docs/ha-mode.md
+++ b/docs/ha-mode.md
@@ -27,19 +27,21 @@ non-master Kubernetes node. This is referred to as localhost loadbalancing. It
 is less efficient than a dedicated load balancer because it creates extra
 health checks on the Kubernetes apiserver, but is more practical for scenarios
 where an external LB or virtual IP management is inconvenient.  This option is
-configured by the variable `loadbalancer_apiserver_localhost` (defaults to `True`).
+configured by the variable `loadbalancer_apiserver_localhost` (defaults to
+`True`. Or `False`, if there is an external `loadbalancer_apiserver` defined).
 You may also define the port the local internal loadbalancer uses by changing,
-`nginx_kube_apiserver_port`.  This defaults to the value of `kube_apiserver_port`.
-It is also important to note that Kubespray will only configure kubelet and kube-proxy
-on non-master nodes to use the local internal loadbalancer.
+`nginx_kube_apiserver_port`.  This defaults to the value of
+`kube_apiserver_port`. It is also important to note that Kubespray will only
+configure kubelet and kube-proxy on non-master nodes to use the local internal
+loadbalancer.
 
-If you choose to NOT use the local internal loadbalancer, you will need to configure
-your own loadbalancer to achieve HA. Note that deploying a loadbalancer is up to
-a user and is not covered by ansible roles in Kubespray. By default, it only configures
-a non-HA endpoint, which points to the `access_ip` or IP address of the first server
-node in the `kube-master` group. It can also configure clients to use endpoints
-for a given loadbalancer type. The following diagram shows how traffic to the
-apiserver is directed.
+If you choose to NOT use the local internal loadbalancer, you will need to
+configure your own loadbalancer to achieve HA. Note that deploying a
+loadbalancer is up to a user and is not covered by ansible roles in Kubespray.
+By default, it only configures a non-HA endpoint, which points to the
+`access_ip` or IP address of the first server node in the `kube-master` group.
+It can also configure clients to use endpoints for a given loadbalancer type.
+The following diagram shows how traffic to the apiserver is directed.
 
 ![Image](figures/loadbalancer_localhost.png?raw=true)
 
@@ -68,7 +70,7 @@ listen kubernetes-apiserver-https
 
 And the corresponding example global vars config:
 ```
-apiserver_loadbalancer_domain_name: "lb-apiserver.kubernetes.local"
+apiserver_loadbalancer_domain_name: "my-apiserver-lb.example.com"
 loadbalancer_apiserver:
   address: <VIP>
   port: 8383

--- a/roles/etcd/templates/openssl.conf.j2
+++ b/roles/etcd/templates/openssl.conf.j2
@@ -29,7 +29,7 @@ DNS.{{ 1 + loop.index }} = {{ host }}
 {% endfor %}
 {% if loadbalancer_apiserver is defined %}
 {% set idx =  groups['etcd'] | length | int + 2 %}
-DNS.{{ idx | string }} = {{ apiserver_loadbalancer_domain_name| default('lb-apiserver.kubernetes.local') }}
+DNS.{{ idx | string }} = {{ apiserver_loadbalancer_domain_name }}
 {% endif %}
 {% for host in groups['etcd'] %}
 IP.{{ 2 * loop.index - 1 }} = {{ hostvars[host]['access_ip'] | default(hostvars[host]['ansible_default_ipv4']['address']) }}

--- a/roles/etcd/templates/openssl.conf.j2
+++ b/roles/etcd/templates/openssl.conf.j2
@@ -27,9 +27,9 @@ DNS.1 = localhost
 {% for host in groups['etcd'] %}
 DNS.{{ 1 + loop.index }} = {{ host }}
 {% endfor %}
-{% if loadbalancer_apiserver is defined  and apiserver_loadbalancer_domain_name is defined %}
+{% if loadbalancer_apiserver is defined %}
 {% set idx =  groups['etcd'] | length | int + 2 %}
-DNS.{{ idx | string }} = {{ apiserver_loadbalancer_domain_name }}
+DNS.{{ idx | string }} = {{ apiserver_loadbalancer_domain_name| default('lb-apiserver.kubernetes.local') }}
 {% endif %}
 {% for host in groups['etcd'] %}
 IP.{{ 2 * loop.index - 1 }} = {{ hostvars[host]['access_ip'] | default(hostvars[host]['ansible_default_ipv4']['address']) }}

--- a/roles/kubernetes/client/tasks/main.yml
+++ b/roles/kubernetes/client/tasks/main.yml
@@ -7,7 +7,7 @@
   set_fact:
     external_apiserver_endpoint: >-
       {%- if loadbalancer_apiserver is defined and loadbalancer_apiserver.port is defined -%}
-      https://{{ apiserver_loadbalancer_domain_name|default('lb-apiserver.kubernetes.local') }}:{{ loadbalancer_apiserver.port|default(kube_apiserver_port) }}
+      https://{{ apiserver_loadbalancer_domain_name }}:{{ loadbalancer_apiserver.port|default(kube_apiserver_port) }}
       {%- else -%}
       https://{{ first_kube_master }}:{{ kube_apiserver_port }}
       {%- endif -%}

--- a/roles/kubernetes/master/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-setup.yml
@@ -47,8 +47,8 @@
       localhost
       127.0.0.1
       {{ ' '.join(groups['kube-master']) }}
-      {%- if loadbalancer_apiserver is defined and apiserver_loadbalancer_domain_name is defined %}
-      {{ apiserver_loadbalancer_domain_name }}
+      {%- if loadbalancer_apiserver is defined %}
+      {{ apiserver_loadbalancer_domain_name| default('lb-apiserver.kubernetes.local') }}
       {%- endif %}
       {%- for host in groups['kube-master'] -%}
       {%- if hostvars[host]['access_ip'] is defined %}{{ hostvars[host]['access_ip'] }}{% endif %}

--- a/roles/kubernetes/master/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-setup.yml
@@ -48,7 +48,7 @@
       127.0.0.1
       {{ ' '.join(groups['kube-master']) }}
       {%- if loadbalancer_apiserver is defined %}
-      {{ apiserver_loadbalancer_domain_name| default('lb-apiserver.kubernetes.local') }}
+      {{ apiserver_loadbalancer_domain_name }}
       {%- endif %}
       {%- for host in groups['kube-master'] -%}
       {%- if hostvars[host]['access_ip'] is defined %}{{ hostvars[host]['access_ip'] }}{% endif %}

--- a/roles/kubernetes/node/tasks/main.yml
+++ b/roles/kubernetes/node/tasks/main.yml
@@ -18,7 +18,7 @@
     - kubelet
 
 - include: nginx-proxy.yml
-  when: is_kube_master == false and loadbalancer_apiserver_localhost|default(true)
+  when: is_kube_master == false and loadbalancer_apiserver_localhost
   tags:
     - nginx
 

--- a/roles/kubernetes/preinstall/tasks/etchosts.yml
+++ b/roles/kubernetes/preinstall/tasks/etchosts.yml
@@ -21,7 +21,6 @@
   when:
     - loadbalancer_apiserver is defined
     - loadbalancer_apiserver.address is defined
-    - apiserver_loadbalancer_domain_name is defined
 
 - name: Hosts | localhost ipv4 in hosts file
   lineinfile:

--- a/roles/kubernetes/preinstall/tasks/etchosts.yml
+++ b/roles/kubernetes/preinstall/tasks/etchosts.yml
@@ -15,7 +15,7 @@
   lineinfile:
     dest: /etc/hosts
     regexp: ".*{{ apiserver_loadbalancer_domain_name }}$"
-    line: "{{ loadbalancer_apiserver.address }} {{ apiserver_loadbalancer_domain_name| default('lb-apiserver.kubernetes.local') }}"
+    line: "{{ loadbalancer_apiserver.address }} {{ apiserver_loadbalancer_domain_name }}"
     state: present
     backup: yes
   when:

--- a/roles/kubernetes/secrets/tasks/gen_certs_vault.yml
+++ b/roles/kubernetes/secrets/tasks/gen_certs_vault.yml
@@ -32,8 +32,8 @@
 
 - name: gen_certs_vault | Add external load balancer domain name to certificate alt names
   set_fact:
-    kube_cert_alt_names: "{{ kube_cert_alt_names + [apiserver_loadbalancer_domain_name] }}"
-  when: loadbalancer_apiserver is defined and apiserver_loadbalancer_domain_name is defined
+    kube_cert_alt_names: "{{ kube_cert_alt_names + [apiserver_loadbalancer_domain_name| default('lb-apiserver.kubernetes.local')] }}"
+  when: loadbalancer_apiserver is defined
   run_once: true
 
 # Issue master components certs to kube-master hosts

--- a/roles/kubernetes/secrets/tasks/gen_certs_vault.yml
+++ b/roles/kubernetes/secrets/tasks/gen_certs_vault.yml
@@ -32,7 +32,7 @@
 
 - name: gen_certs_vault | Add external load balancer domain name to certificate alt names
   set_fact:
-    kube_cert_alt_names: "{{ kube_cert_alt_names + [apiserver_loadbalancer_domain_name| default('lb-apiserver.kubernetes.local')] }}"
+    kube_cert_alt_names: "{{ kube_cert_alt_names + [apiserver_loadbalancer_domain_name] }}"
   when: loadbalancer_apiserver is defined
   run_once: true
 

--- a/roles/kubernetes/secrets/templates/openssl.conf.j2
+++ b/roles/kubernetes/secrets/templates/openssl.conf.j2
@@ -15,9 +15,9 @@ DNS.5 = localhost
 {% for host in groups['kube-master'] %}
 DNS.{{ 5 + loop.index }} = {{ host }}
 {% endfor %}
-{% if loadbalancer_apiserver is defined  and apiserver_loadbalancer_domain_name is defined %}
+{% if loadbalancer_apiserver is defined  %}
 {% set idx =  groups['kube-master'] | length | int + 5 + 1 %}
-DNS.{{ idx | string }} = {{ apiserver_loadbalancer_domain_name }}
+DNS.{{ idx | string }} = {{ apiserver_loadbalancer_domain_name| default('lb-apiserver.kubernetes.local') }}
 {% endif %}
 {% for host in groups['kube-master'] %}
 IP.{{ 2 * loop.index - 1 }} = {{ hostvars[host]['access_ip'] | default(hostvars[host]['ansible_default_ipv4']['address']) }}

--- a/roles/kubernetes/secrets/templates/openssl.conf.j2
+++ b/roles/kubernetes/secrets/templates/openssl.conf.j2
@@ -17,7 +17,7 @@ DNS.{{ 5 + loop.index }} = {{ host }}
 {% endfor %}
 {% if loadbalancer_apiserver is defined  %}
 {% set idx =  groups['kube-master'] | length | int + 5 + 1 %}
-DNS.{{ idx | string }} = {{ apiserver_loadbalancer_domain_name| default('lb-apiserver.kubernetes.local') }}
+DNS.{{ idx | string }} = {{ apiserver_loadbalancer_domain_name }}
 {% endif %}
 {% for host in groups['kube-master'] %}
 IP.{{ 2 * loop.index - 1 }} = {{ hostvars[host]['access_ip'] | default(hostvars[host]['ansible_default_ipv4']['address']) }}

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -204,8 +204,10 @@ kube_apiserver_address: "{{ ip | default(ansible_default_ipv4['address']) }}"
 kube_apiserver_access_address: "{{ access_ip | default(kube_apiserver_address) }}"
 first_kube_master: "{{ hostvars[groups['kube-master'][0]]['access_ip'] | default(hostvars[groups['kube-master'][0]]['ip'] | default(hostvars[groups['kube-master'][0]]['ansible_default_ipv4']['address'])) }}"
 loadbalancer_apiserver_localhost: "{{ loadbalancer_apiserver is not defined }}"
+# applied if only external loadbalancer_apiserver is defined, otherwise ignored
+apiserver_loadbalancer_domain_name: "lb-apiserver.kubernetes.local"
 kube_apiserver_endpoint: |-
-  {% if not is_kube_master and loadbalancer_apiserver_localhost|default(true) -%}
+  {% if not is_kube_master and loadbalancer_apiserver_localhost -%}
        https://localhost:{{ nginx_kube_apiserver_port|default(kube_apiserver_port) }}
   {%- elif is_kube_master -%}
        https://127.0.0.1:{{ kube_apiserver_port }}


### PR DESCRIPTION
When loadbalancer_apiserver is defined, use the
apiserver_loadbalancer_domain_name with a given default value.

Fix unconsistencies for checking if apiserver_loadbalancer_domain_name
is defined AND using it with a default value provided at once.

Adjust the defaults for apiserver_loadbalancer_domain_name and
loadbalancer_apiserver_localhost to come from a single source, which is
kubespray-defaults. Removes some confusion and simplefies the code.

Related https://github.com/kubernetes-incubator/kubespray/issues/1131

Signed-off-by: Bogdan Dobrelya <bogdando@mail.ru>