### PR TITLE
 Change "pause while Docker restarts" to use wait_for

### DIFF
--- a/roles/docker/handlers/main.yml
+++ b/roles/docker/handlers/main.yml
@@ -23,9 +23,8 @@
     state: restarted
 
 - name: Docker | pause while Docker restarts
-  pause:
-    seconds: 10
-    prompt: "Waiting for docker restart"
+  wait_for:
+    timeout: 10
 
 - name: Docker | wait for docker
   command: "{{ docker_bin_dir }}/docker images"


### PR DESCRIPTION
This task fails on gitlab-ci as it expects manual intervention and will fatal on the server that it is run on. The server is then skipped for all subsequent tasks necessitating re-running of kubespray on the stack

RUNNING HANDLER [docker : Docker | pause while Docker restarts] ****************
Thursday 23 November 2017 15:16:00 +0000 (0:00:05.111) 0:05:48.289 *****
Pausing for 10 seconds
(ctrl+C then 'C' = continue early, ctrl+C then 'A' = abort)
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: AttributeError: 'str' object has no attribute 'buffer'
fatal: [feature-kubespray-etcd-2]: FAILED! => {"failed": true, "msg": "Unexpected failure during module execution.", "stdout": ""}

The wait_for module works correctly