### PR TITLE
Turn Swap off

### DIFF
--- a/roles/bootstrap-os/tasks/main.yml
+++ b/roles/bootstrap-os/tasks/main.yml
@@ -41,3 +41,13 @@
     gather_subset: '!all'
     filter: ansible_hostname
   when: ansible_os_family in ['CoreOS', 'Container Linux by CoreOS'] and hostname_changed.changed
+  
+- name: Remove swapfile from /etc/fstab
+  mount:
+    name: swap
+    fstype: swap
+    state: absent
+  
+- name: Disable swap
+  command: swapoff -a
+  when: ansible_swaptotal_mb > 0

--- a/roles/bootstrap-os/tasks/main.yml
+++ b/roles/bootstrap-os/tasks/main.yml
@@ -50,4 +50,3 @@
   
 - name: Disable swap
   command: swapoff -a
-  when: ansible_swaptotal_mb > 0


### PR DESCRIPTION
Kubespray is returning swap enabled error since on most of the OS by default Swapp is on,
Turing Swapp off as a part of OS provisioning,