### PR TITLE
update nginx tag to use multi-arch docker image

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -91,7 +91,7 @@ weave_npc_image_repo: "weaveworks/weave-npc"
 weave_npc_image_tag: "{{ weave_version }}"
 
 nginx_image_repo: nginx
-nginx_image_tag: 1.11.4-alpine
+nginx_image_tag: 1.13
 dnsmasq_version: 2.78
 dnsmasq_image_repo: "andyshinn/dnsmasq"
 dnsmasq_image_tag: "{{ dnsmasq_version }}"

--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -58,7 +58,7 @@ nginx_cpu_requests: 25m
 #   - extensions/v1beta1/deployments=true
 
 nginx_image_repo: nginx
-nginx_image_tag: 1.11.4-alpine
+nginx_image_tag: 1.13
 
 etcd_config_dir: /etc/ssl/etcd
 


### PR DESCRIPTION
Current nginx image `1.11.4-alpine` does not support multi-arch.

Update to `1.13` to enable multi-arch.