### PR TITLE
use init container to install cni on flannel daemonset

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -35,7 +35,6 @@ calico_cni_version: "v1.11.0"
 calico_policy_version: "v1.0.0"
 calico_rr_version: "v0.4.0"
 flannel_version: "v0.9.1"
-flannel_cni_version: "v0.3.0"
 weave_version: 2.0.5
 pod_infra_version: 3.0
 
@@ -62,8 +61,6 @@ etcd_image_repo: "quay.io/coreos/etcd"
 etcd_image_tag: "{{ etcd_version }}"
 flannel_image_repo: "quay.io/coreos/flannel"
 flannel_image_tag: "{{ flannel_version }}"
-flannel_cni_image_repo: "quay.io/coreos/flannel-cni"
-flannel_cni_image_tag: "{{ flannel_cni_version }}"
 calicoctl_image_repo: "quay.io/calico/ctl"
 calicoctl_image_tag: "{{ calico_ctl_version }}"
 calico_node_image_repo: "quay.io/calico/node"
@@ -176,12 +173,6 @@ downloads:
     repo: "{{ flannel_image_repo }}"
     tag: "{{ flannel_image_tag }}"
     sha256: "{{ flannel_digest_checksum|default(None) }}"
-  flannel_cni:
-    enabled: "{{ kube_network_plugin == 'flannel' }}"
-    container: true
-    repo: "{{ flannel_cni_image_repo }}"
-    tag: "{{ flannel_cni_image_tag }}"
-    sha256: "{{ flannel_cni_digest_checksum|default(None) }}"
   calicoctl:
     enabled: "{{ kube_network_plugin == 'calico' or kube_network_plugin == 'canal' }}"
     container: true

--- a/roles/network_plugin/flannel/templates/cni-flannel.yml.j2
+++ b/roles/network_plugin/flannel/templates/cni-flannel.yml.j2
@@ -54,6 +54,20 @@ spec:
 {% if rbac_enabled %}
       serviceAccountName: flannel
 {% endif %}
+      initContainers:
+      - name: install-cni
+        image: {{ flannel_image_repo }}:{{ flannel_image_tag }}
+        command:
+        - cp
+        args:
+        - -f
+        - /etc/kube-flannel/cni-conf.json
+        - /etc/cni/net.d/10-flannel.conf
+        volumeMounts:
+        - name: cni
+          mountPath: /etc/cni/net.d
+        - name: flannel-cfg
+          mountPath: /etc/kube-flannel/
       containers:
       - name: kube-flannel
         image: {{ flannel_image_repo }}:{{ flannel_image_tag }}
@@ -80,27 +94,8 @@ spec:
         volumeMounts:
         - name: run
           mountPath: /run
-        - name: cni
-          mountPath: /etc/cni/net.d
         - name: flannel-cfg
           mountPath: /etc/kube-flannel/
-      - name: install-cni
-        image: {{ flannel_cni_image_repo }}:{{ flannel_cni_image_tag }}
-        command: ["/install-cni.sh"]
-        env:
-        # The CNI network config to install on each node.
-        - name: CNI_NETWORK_CONFIG
-          valueFrom:
-            configMapKeyRef:
-              name: kube-flannel-cfg
-              key: cni-conf.json
-        - name: CNI_CONF_NAME
-          value: "10-flannel.conflist"
-        volumeMounts:
-        - name: cni
-          mountPath: /host/etc/cni/net.d
-        - name: host-cni-bin
-          mountPath: /host/opt/cni/bin/
       hostNetwork: true
       tolerations:
       - key: node-role.kubernetes.io/master
@@ -116,9 +111,6 @@ spec:
         - name: flannel-cfg
           configMap:
             name: kube-flannel-cfg
-        - name: host-cni-bin
-          hostPath:
-            path: /opt/cni/bin
   updateStrategy:
     rollingUpdate:
       maxUnavailable: {{ serial | default('20%') }}


### PR DESCRIPTION
Seems weird to have a container that only does copy and sleep. Use initContainer instead.