### PR TITLE
Support for disabling apiserver insecure port (the sequel)

### DIFF
--- a/inventory/group_vars/k8s-cluster.yml
+++ b/inventory/group_vars/k8s-cluster.yml
@@ -20,7 +20,7 @@ kube_token_dir: "{{ kube_config_dir }}/tokens"
 # This is where to save basic auth file
 kube_users_dir: "{{ kube_config_dir }}/users"
 
-kube_api_anonymous_auth: false
+kube_api_anonymous_auth: true
 
 ## Change this to use another Kubernetes version, e.g. a current beta release
 kube_version: v1.8.4
@@ -106,6 +106,8 @@ kube_network_node_prefix: 24
 kube_apiserver_ip: "{{ kube_service_addresses|ipaddr('net')|ipaddr(1)|ipaddr('address') }}"
 kube_apiserver_port: 6443 # (https)
 kube_apiserver_insecure_port: 8080 # (http)
+# Set to 0 to disable insecure port - Requires RBAC in authorization_modes and kube_api_anonymous_auth: true
+#kube_apiserver_insecure_port: 0 # (disabled)
 
 # DNS configuration.
 # Kubernetes cluster name, also will be used as DNS domain

--- a/roles/kubernetes-apps/ansible/tasks/main.yml
+++ b/roles/kubernetes-apps/ansible/tasks/main.yml
@@ -1,7 +1,10 @@
 ---
 - name: Kubernetes Apps | Wait for kube-apiserver
   uri:
-    url: "{{ kube_apiserver_insecure_endpoint }}/healthz"
+    url: "{{ kube_apiserver_endpoint }}/healthz"
+    validate_certs: no
+    client_cert: "{{ kube_apiserver_client_cert }}"
+    client_key: "{{ kube_apiserver_client_key }}"
   register: result
   until: result.status == 200
   retries: 10

--- a/roles/kubernetes-apps/cluster_roles/tasks/main.yml
+++ b/roles/kubernetes-apps/cluster_roles/tasks/main.yml
@@ -1,7 +1,10 @@
 ---
 - name: Kubernetes Apps | Wait for kube-apiserver
   uri:
-    url: "{{ kube_apiserver_insecure_endpoint }}/healthz"
+    url: "{{ kube_apiserver_endpoint }}/healthz"
+    validate_certs: no
+    client_cert: "{{ kube_apiserver_client_cert }}"
+    client_key: "{{ kube_apiserver_client_key }}"
   register: result
   until: result.status == 200
   retries: 10

--- a/roles/kubernetes/master/handlers/main.yml
+++ b/roles/kubernetes/master/handlers/main.yml
@@ -66,7 +66,10 @@
 
 - name: Master | wait for the apiserver to be running
   uri:
-    url: "{{ kube_apiserver_insecure_endpoint }}/healthz"
+    url: "{{ kube_apiserver_endpoint }}/healthz"
+    validate_certs: no
+    client_cert: "{{ kube_apiserver_client_cert }}"
+    client_key: "{{ kube_apiserver_client_key }}"
   register: result
   until: result.status == 200
   retries: 20

--- a/roles/kubernetes/master/tasks/kubeadm-migrate-certs.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-migrate-certs.yml
@@ -6,7 +6,7 @@
     remote_src: yes
   with_items:
     - {src: apiserver.pem, dest: apiserver.crt}
-    - {src: apiserver.pem, dest: apiserver.key}
+    - {src: apiserver-key.pem, dest: apiserver.key}
     - {src: ca.pem, dest: ca.crt}
     - {src: ca-key.pem, dest: ca.key}
   register: kubeadm_copy_old_certs

--- a/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
@@ -111,9 +111,17 @@ spec:
       httpGet:
         host: 127.0.0.1
         path: /healthz
+{% if kube_apiserver_insecure_port == 0 %}
+        port: {{ kube_apiserver_port }}
+        scheme: HTTPS
+{% else %}
         port: {{ kube_apiserver_insecure_port }}
-      initialDelaySeconds: 30
-      timeoutSeconds: 10
+{% endif %}
+      failureThreshold: 8
+      initialDelaySeconds: 15
+      periodSeconds: 10
+      successThreshold: 1
+      timeoutSeconds: 15
     volumeMounts:
     - mountPath: {{ kube_config_dir }}
       name: kubernetes-config

--- a/roles/kubernetes/preinstall/tasks/verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/verify-settings.yml
@@ -79,9 +79,14 @@
   when: kubelet_fail_swap_on|default(true)
   ignore_errors: "{{ ignore_assert_errors }}"
 
-
 - name: Stop if RBAC is not enabled when dashboard is enabled
   assert:
     that: rbac_enabled
   when: dashboard_enabled
+  ignore_errors: "{{ ignore_assert_errors }}"
+
+- name: Stop if RBAC and anonymous-auth are not enabled when insecure port is disabled
+  assert:
+    that: rbac_enabled and kube_api_anonymous_auth
+  when: kube_apiserver_insecure_port == 0
   ignore_errors: "{{ ignore_assert_errors }}"

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -220,6 +220,18 @@ kube_apiserver_endpoint: |-
   {%- endif %}
 kube_apiserver_insecure_endpoint: >-
   http://{{ kube_apiserver_insecure_bind_address | regex_replace('0\.0\.0\.0','127.0.0.1') }}:{{ kube_apiserver_insecure_port }}
+kube_apiserver_client_cert: |-
+  {% if kubeadm_enabled -%}
+  {{ kube_cert_dir }}/ca.crt
+  {%- else -%}
+  {{ kube_cert_dir }}/apiserver.pem
+  {%- endif %}
+kube_apiserver_client_key: |-
+  {% if kubeadm_enabled -%}
+  {{ kube_cert_dir }}/ca.key
+  {%- else -%}
+  {{ kube_cert_dir }}/apiserver-key.pem
+  {%- endif %}
 
 # Vars for pointing to etcd endpoints
 is_etcd_master: "{{ inventory_hostname in groups['etcd'] }}"


### PR DESCRIPTION
This allows `kube_apiserver_insecure_port` to be set to 0 (disabled).

Rework of #1937 with kubeadm support

Also, fixed an issue in `kubeadm-migrate-certs` where the old apiserver cert was copied as the kubeadm key