### PR TITLE
contrib/terraform/aws: Tag instances and remove loadbalancer ip

### DIFF
--- a/contrib/terraform/aws/create-infrastructure.tf
+++ b/contrib/terraform/aws/create-infrastructure.tf
@@ -175,7 +175,6 @@ data "template_file" "inventory" {
         list_node = "${join("\n",aws_instance.k8s-worker.*.tags.Name)}"
         list_etcd = "${join("\n",aws_instance.k8s-etcd.*.tags.Name)}"
         elb_api_fqdn = "apiserver_loadbalancer_domain_name=\"${module.aws-elb.aws_elb_api_fqdn}\""
-        elb_api_server = "loadbalancer_apiserver={\"port\": ${var.aws_elb_api_port}, \"address\": \"${var.loadbalancer_apiserver_address}\"}"
     }
 
 }

--- a/contrib/terraform/aws/create-infrastructure.tf
+++ b/contrib/terraform/aws/create-infrastructure.tf
@@ -98,7 +98,7 @@ resource "aws_instance" "k8s-master" {
 
     tags = "${merge(var.default_tags, map(
       "Name", "kubernetes-${var.aws_cluster_name}-master${count.index}",
-      "Cluster", "${var.aws_cluster_name}",
+      "kubernetes.io/cluster/${var.aws_cluster_name}", "member",
       "Role", "master"
     ))}"
 }
@@ -127,7 +127,7 @@ resource "aws_instance" "k8s-etcd" {
 
     tags = "${merge(var.default_tags, map(
       "Name", "kubernetes-${var.aws_cluster_name}-etcd${count.index}",
-      "Cluster", "${var.aws_cluster_name}",
+      "kubernetes.io/cluster/${var.aws_cluster_name}", "member",
       "Role", "etcd"
     ))}"
 
@@ -151,7 +151,7 @@ resource "aws_instance" "k8s-worker" {
 
     tags = "${merge(var.default_tags, map(
       "Name", "kubernetes-${var.aws_cluster_name}-worker${count.index}",
-      "Cluster", "${var.aws_cluster_name}",
+      "kubernetes.io/cluster/${var.aws_cluster_name}", "member",
       "Role", "worker"
     ))}"
 

--- a/contrib/terraform/aws/modules/elb/main.tf
+++ b/contrib/terraform/aws/modules/elb/main.tf
@@ -43,7 +43,7 @@ resource "aws_elb" "aws-elb-api" {
     healthy_threshold = 2
     unhealthy_threshold = 2
     timeout = 3
-    target = "HTTP:8080/"
+    target = "TCP:${var.k8s_secure_api_port}"
     interval = 30
   }
 

--- a/contrib/terraform/aws/modules/vpc/main.tf
+++ b/contrib/terraform/aws/modules/vpc/main.tf
@@ -34,7 +34,8 @@ resource "aws_subnet" "cluster-vpc-subnets-public" {
     cidr_block = "${element(var.aws_cidr_subnets_public, count.index)}"
 
     tags = "${merge(var.default_tags, map(
-      "Name", "kubernetes-${var.aws_cluster_name}-${element(var.aws_avail_zones, count.index)}-public"
+      "Name", "kubernetes-${var.aws_cluster_name}-${element(var.aws_avail_zones, count.index)}-public",
+      "kubernetes.io/cluster/${var.aws_cluster_name}", "member"
     ))}"
 }
 

--- a/contrib/terraform/aws/templates/inventory.tpl
+++ b/contrib/terraform/aws/templates/inventory.tpl
@@ -25,4 +25,3 @@ kube-master
 
 [k8s-cluster:vars]
 ${elb_api_fqdn}
-${elb_api_server}

--- a/contrib/terraform/aws/variables.tf
+++ b/contrib/terraform/aws/variables.tf
@@ -99,10 +99,6 @@ variable "k8s_secure_api_port" {
     description = "Secure Port of K8S API Server"
 }
 
-variable "loadbalancer_apiserver_address" {
-    description= "Bind Address for ELB of K8s API Server"
-}
-
 variable "default_tags" {
   description = "Default tags for all resources"
   type = "map"


### PR DESCRIPTION
Kubernetes now requires nodes and subnets to be properly tagged with `kubernetes.io/cluster/$clustername` to support multiple clusters in the same vpc / az.

This also removes the cunfusing and unneeded variable `loadbalancer_apiserver_address`