### PR TITLE
Adding changes to handle updation of yum Management cache in rhel.

### DIFF
--- a/roles/kubernetes/preinstall/tasks/main.yml
+++ b/roles/kubernetes/preinstall/tasks/main.yml
@@ -132,7 +132,7 @@
     - ansible_distribution == 'RedHat'
     - not is_atomic
   tags: bootstrap-os
-  
+
 - name: Update package management cache (YUM) - Redhat
   shell: yum makecache
   register: make_cache_output

--- a/roles/kubernetes/preinstall/tasks/main.yml
+++ b/roles/kubernetes/preinstall/tasks/main.yml
@@ -117,9 +117,35 @@
   delay: "{{ retry_stagger | random + 3 }}"
   when:
     - ansible_pkg_mgr == 'yum'
+    - ansible_distribution != 'RedHat'
     - not is_atomic
-  tags:
-    - bootstrap-os
+  tags: bootstrap-os
+
+- name: Expire management cache (YUM) for Updation - Redhat
+  shell: yum clean expire-cache
+  register: expire_cache_output
+  until: expire_cache_output|succeeded
+  retries: 4
+  delay: "{{ retry_stagger | random + 3 }}"
+  when:
+    - ansible_pkg_mgr == 'yum'
+    - ansible_distribution == 'RedHat'
+    - not is_atomic
+  tags: bootstrap-os
+  
+- name: Update package management cache (YUM) - Redhat
+  shell: yum makecache
+  register: make_cache_output
+  until: make_cache_output|succeeded
+  retries: 4
+  delay: "{{ retry_stagger | random + 3 }}"
+  when:
+    - ansible_pkg_mgr == 'yum'
+    - ansible_distribution == 'RedHat'
+    - expire_cache_output.rc == 0
+    - not is_atomic
+  tags: bootstrap-os
+
 
 - name: Install latest version of python-apt for Debian distribs
   apt:


### PR DESCRIPTION
This issue is happening with Ansible 2.4.0.0+ wherein the playbook hangs for hours while updating yum management cache and ultimately fails. 

This is happening only with RHEL, in CENTOS it works fine.