### PR TITLE
fix template for apiserver.manifest

### DIFF
--- a/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
@@ -78,9 +78,9 @@ spec:
 {%   endfor %}
 {% endif %}
 {% if enable_network_policy %}
-  {% if kube_version | version_compare('v1.8', '<')  %}
+{%   if kube_version | version_compare('v1.8', '<')  %}
     - --runtime-config=extensions/v1beta1/networkpolicies=true
-  {% endif %}
+{%   endif %}
 {% endif %}
     - --v={{ kube_log_level }}
     - --allow-privileged=true


### PR DESCRIPTION
There are spaces included, which break YAML syntax when network policies are enabled