### PR TITLE
Fixes to reset

### DIFF
--- a/reset.yml
+++ b/reset.yml
@@ -1,6 +1,9 @@
 ---
 
 - hosts: all
+  gather_facts: true
+
+- hosts: etcd:k8s-cluster:vault:calico-rr
   vars_prompt:
     name: "reset_confirmation"
     prompt: "Are you sure you want to reset cluster state? Type 'yes' to reset your cluster."

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -124,6 +124,9 @@
     - "{{ bin_dir }}/helm"
     - "{{ bin_dir }}/calicoctl"
     - "{{ bin_dir }}/weave"
+    - /var/lib/rkt
+    - /etc/vault
+  ignore_errors: yes
   tags:
     - files
 


### PR DESCRIPTION
- adding additional directories to cleanup (rkt/vault)
- targeting kubespray ansible groups instead of all