### PR TITLE
Adding retries for vault-temp to come online

### DIFF
--- a/roles/vault/tasks/bootstrap/start_vault_temp.yml
+++ b/roles/vault/tasks/bootstrap/start_vault_temp.yml
@@ -25,6 +25,9 @@
     body:
       secret_shares: 1
       secret_threshold: 1
+  until: "vault_temp_init|succeeded"
+  retries: 4
+  delay: "{{ retry_stagger | random + 3 }}"
   register: vault_temp_init
 
 # NOTE: vault_headers and vault_url are used by subsequent issue calls


### PR DESCRIPTION
In some instances vault-temp can take a moment or two to come online.