### PR TITLE
Fix: always only one container got synced after download

### DIFF
--- a/roles/download/tasks/sync_container.yml
+++ b/roles/download/tasks/sync_container.yml
@@ -1,4 +1,15 @@
 ---
+- name: container_download | Make download decision if pull is required by tag or sha256
+  include: set_docker_image_facts.yml
+  delegate_to: "{{ download_delegate if download_run_once or omit }}"
+  delegate_facts: no
+  run_once: "{{ download_run_once }}"
+  when:
+    - download.enabled
+    - download.container
+  tags:
+    - facts
+
 - set_fact:
     fname: "{{local_release_dir}}/containers/{{download.repo|regex_replace('/|\0|:', '_')}}:{{download.tag|default(download.sha256)|regex_replace('/|\0|:', '_')}}.tar"
   run_once: true


### PR DESCRIPTION
I found one problem in the playbook, when we setting these vars in the group_vars:
```yml
download_run_once: True
download_localhost: True
```

We will experience that there be will only one docker image got synced, because the code in [sync_container.yml#L49](https://github.com/kubernetes-incubator/kubespray/blob/79417e07ca4033d162eb94d8c66a82bf8f44f9ce/roles/download/tasks/sync_container.yml#L49)

```yml
shell: "{{ docker_bin_dir }}/docker save {{ pull_args }} | gzip -{{ download_compress }} > {{ fname }}"
```

use the `pull_args` defined in [set_docker_image_facts.yml#L7](https://github.com/kubernetes-incubator/kubespray/blob/79417e07ca4033d162eb94d8c66a82bf8f44f9ce/roles/download/tasks/set_docker_image_facts.yml#L7)

```yml
- set_fact:
    pull_args: >-
      {%- if pull_by_digest %}{{download.repo}}@sha256:{{download.sha256}}{%- else -%}{{download.repo}}:{{download.tag}}{%- endif -%}
```

Also the relationships in [main.yml](https://github.com/kubernetes-incubator/kubespray/blob/79417e07ca4033d162eb94d8c66a82bf8f44f9ce/roles/download/tasks/main.yml):
- download_prep.yml
- download item **(loop with with_dict)**
    - download_file.yml
    - download_container.yml
        - set_docker_image_facts.yml **(define pull_args !!!)**
- sync_container.yml  **(loop with with_dict, use pull_args!!!)**

Tells that  `sync_container.yml` use the `pull_args` from the last iteration in `download_container.yml`, which is the last downloaded image, so it will cause the problem that we can only sync the last downloaded image.

The solution to solve the problem is simple, just put `set_docker_image_facts.yml` in `sync_container.yml` for every iteration to sync all the images.
