### PR TITLE
append newline char to vault generated certs

### DIFF
--- a/roles/vault/tasks/bootstrap/ca_trust.yml
+++ b/roles/vault/tasks/bootstrap/ca_trust.yml
@@ -19,7 +19,7 @@
 
 - name: bootstrap/ca_trust | add CA to trusted CA dir
   copy:
-    content: "{{ vault_cert_file_cat.get('stdout') }}"
+    content: "{{ vault_cert_file_cat.get('stdout') }}\n"
     dest: "{{ ca_cert_path }}"
   register: vault_ca_cert
 

--- a/roles/vault/tasks/shared/issue_cert.yml
+++ b/roles/vault/tasks/shared/issue_cert.yml
@@ -83,7 +83,7 @@
 
 - name: "issue_cert | Copy {{ issue_cert_path }} cert to all hosts"
   copy:
-    content: "{{ issue_cert_result['json']['data']['certificate'] }}"
+    content: "{{ issue_cert_result['json']['data']['certificate'] }}\n"
     dest: "{{ issue_cert_path }}"
     group: "{{ issue_cert_file_group | d('root' )}}"
     mode: "{{ issue_cert_file_mode | d('0644') }}"
@@ -99,7 +99,7 @@
 
 - name: issue_cert | Copy issuing CA cert
   copy:
-    content: "{{ issue_cert_result['json']['data']['issuing_ca'] }}"
+    content: "{{ issue_cert_result['json']['data']['issuing_ca'] }}\n"
     dest: "{{ issue_cert_path | dirname }}/ca.pem"
     group: "{{ issue_cert_file_group | d('root' )}}"
     mode: "{{ issue_cert_file_mode | d('0644') }}"


### PR DESCRIPTION
Fixes #2049  

This appends newline char to etcd-ca, kube-ca and vault-ca, allowing them to be bundled by `update-ca-certificates` on CoreOS.

I tested this on a setup sending strings instead of list when submitting CSR to Vault (something like #2043), so this might not work until #2039 is fixed.

(I did not test on centos or ubuntu, but i think the CI will do that?)
