### PR TITLE
Change OpenStack inventory to python2

### DIFF
--- a/contrib/terraform/terraform.py
+++ b/contrib/terraform/terraform.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # Copyright 2015 Cisco Systems, Inc.
 #


### PR DESCRIPTION
For distribution who ship python3 as default python, it breaks the
inventory script as it is not compatible with python3.