### PR TITLE
Fix domain id for OpenStack provider

### DIFF
--- a/roles/kubernetes/preinstall/defaults/main.yml
+++ b/roles/kubernetes/preinstall/defaults/main.yml
@@ -32,7 +32,8 @@ openstack_username: "{{ lookup('env','OS_USERNAME')  }}"
 openstack_password: "{{ lookup('env','OS_PASSWORD')  }}"
 openstack_region: "{{ lookup('env','OS_REGION_NAME')  }}"
 openstack_tenant_id: "{{ lookup('env','OS_TENANT_ID')|default(lookup('env','OS_PROJECT_ID'),true)  }}"
-openstack_domain_name: "{{ lookup('env','OS_USER_DOMAIN_NAME')  }}"
+openstack_domain_name: "{{ lookup('env','OS_USER_DOMAIN_NAME') }}"
+openstack_domain_id: "{{ lookup('env','OS_USER_DOMAIN_ID') }}"
 
 # For the vsphere integration, kubelet will need credentials to access
 # vsphere apis

--- a/roles/kubernetes/preinstall/templates/openstack-cloud-config.j2
+++ b/roles/kubernetes/preinstall/templates/openstack-cloud-config.j2
@@ -6,6 +6,8 @@ region="{{ openstack_region }}"
 tenant-id="{{ openstack_tenant_id }}"
 {% if openstack_domain_name is defined and openstack_domain_name != "" %}
 domain-name="{{ openstack_domain_name }}"
+{% elif openstack_domain_id is defined and openstack_domain_id != "" %}
+domain-id ="{{ openstack_domain_id }}"
 {% endif %}
 
 {% if openstack_blockstorage_version is defined %}


### PR DESCRIPTION
OpenStack authentication does not support using a mix of DomainID and
DomainName, only one or the other should be used.