### PR TITLE
set docker_version fact regardless of docker_dns in use

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -71,12 +71,21 @@
   notify: restart docker
   when: not (ansible_os_family in ["CoreOS", "Container Linux by CoreOS"] or is_atomic) and (docker_package_info.pkgs|length > 0)
 
-- name: check minimum docker version for docker_dns mode. You need at least docker version >= 1.12 for resolvconf_mode=docker_dns
+- name: flush handlers so we can wait for docker to come up
+  meta: flush_handlers
+
+- name: set fact for docker_version
   command: "docker version -f '{{ '{{' }}.Client.Version{{ '}}' }}'"
   register: docker_version
-  failed_when: docker_version.stdout|version_compare('1.12', '<')
   changed_when: false
-  when: dns_mode != 'none' and resolvconf_mode == 'docker_dns'
+
+- name: check minimum docker version for docker_dns mode. You need at least docker version >= 1.12 for resolvconf_mode=docker_dns
+  fail:
+    msg: "You need at least docker version >= 1.12 for resolvconf_mode=docker_dns"
+  when: >
+        dns_mode != 'none' and
+        resolvconf_mode == 'docker_dns' and
+        docker_version.stdout|version_compare('1.12', '<')
 
 - name: Set docker systemd config
   include: systemd.yml


### PR DESCRIPTION
In some testing, we've found that things other than the docker_dns setup in the docker role depend on the docker_version fact. As such, we should set this fact regardless and then simply do a fail if the version doesn't meet the criteria required for docker-based dns.