### PR TITLE
replace ansible.sudo by ansible.become for vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,7 @@
 
 require 'fileutils'
 
-Vagrant.require_version ">= 1.9.0"
+Vagrant.require_version ">= 2.0.0"
 
 CONFIG = File.join(File.dirname(__FILE__), "vagrant/config.rb")
 
@@ -134,12 +134,6 @@ Vagrant.configure("2") do |config|
       }
 
       config.vm.network :private_network, ip: ip
-
-      # workaround for Vagrant 1.9.1 and centos vm
-      # https://github.com/hashicorp/vagrant/issues/8096
-      if Vagrant::VERSION == "1.9.1" && $os == "centos"
-        config.vm.provision "shell", inline: "service network restart", run: "always"
-      end
 
       # Disable swap for each vm
       config.vm.provision "shell", inline: "swapoff -a"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -164,7 +164,7 @@ Vagrant.configure("2") do |config|
           if File.exist?(File.join(File.dirname($inventory), "hosts"))
             ansible.inventory_path = $inventory
           end
-          ansible.sudo = true
+          ansible.become = true
           ansible.limit = "all"
           ansible.host_key_checking = false
           ansible.raw_arguments = ["--forks=#{$num_instances}", "--flush-cache"]

--- a/docs/vagrant.md
+++ b/docs/vagrant.md
@@ -1,7 +1,7 @@
 Vagrant Install
 =================
 
-Assuming you have Vagrant (1.9+) installed with virtualbox (it may work
+Assuming you have Vagrant (2.0+) installed with virtualbox (it may work
 with vmware, but is untested) you should be able to launch a 3 node
 Kubernetes cluster by simply running `$ vagrant up`.<br />
 


### PR DESCRIPTION
change to avoid this message with Ansible 2.4.2.0 (vagrant 2.0.1)

```
DEPRECATION: The 'sudo' option for the Ansible provisioner is deprecated.
Please use the 'become' option instead.
The 'sudo' option will be removed in a future release of Vagrant.
```