### PR TITLE
Always set net.bridge.bridge-nf-call-* sysctl

### DIFF
--- a/roles/kubernetes/node/tasks/main.yml
+++ b/roles/kubernetes/node/tasks/main.yml
@@ -98,7 +98,7 @@
     state: present
     value: 1
     reload: yes
-  when: modinfo_br_netfilter.rc == 1 and sysctl_bridge_nf_call_iptables.rc == 0
+  when: sysctl_bridge_nf_call_iptables.rc == 0
   with_items:
     - net.bridge.bridge-nf-call-iptables
     - net.bridge.bridge-nf-call-arptables


### PR DESCRIPTION
On CentOS 7.4.1708 `br_netfilter` is a kernel module but `net.bridge.bridge-nf-call-*` are set to `0`:
```
[vagrant@localhost ~]$ sudo sysctl -a |grep net.bridge

[vagrant@localhost ~]$ sudo modprobe -v br_netfilter
insmod /lib/modules/3.10.0-693.5.2.el7.x86_64/kernel/net/llc/llc.ko.xz
insmod /lib/modules/3.10.0-693.5.2.el7.x86_64/kernel/net/802/stp.ko.xz
insmod /lib/modules/3.10.0-693.5.2.el7.x86_64/kernel/net/bridge/bridge.ko.xz
insmod /lib/modules/3.10.0-693.5.2.el7.x86_64/kernel/net/bridge/br_netfilter.ko.xz

[vagrant@localhost ~]$ sudo sysctl -a |grep net.bridge
net.bridge.bridge-nf-call-arptables = 0
net.bridge.bridge-nf-call-ip6tables = 0
net.bridge.bridge-nf-call-iptables = 0
net.bridge.bridge-nf-filter-pppoe-tagged = 0
net.bridge.bridge-nf-filter-vlan-tagged = 0
net.bridge.bridge-nf-pass-vlan-input-dev = 0
```

Since the existence of `net.bridge.bridge-nf-call-iptables` is checked there should be no disadvantage to always setting these properties to `1`.

Closes #1930