### PR TITLE
Retry kube container removal during upgrade

### DIFF
--- a/roles/kubernetes/master/handlers/main.yml
+++ b/roles/kubernetes/master/handlers/main.yml
@@ -41,12 +41,24 @@
 
 - name: Master | Remove apiserver container
   shell: "docker ps -af name=k8s_kube-apiserver* -q | xargs --no-run-if-empty docker rm -f"
+  register: remove_apiserver_container
+  retries: 4
+  until: remove_apiserver_container.rc == 0
+  delay: 5
 
 - name: Master | Remove scheduler container
   shell: "docker ps -af name=k8s_kube-scheduler* -q | xargs --no-run-if-empty docker rm -f"
+  register: remove_scheduler_container
+  retries: 4
+  until: remove_scheduler_container.rc == 0
+  delay: 5
 
 - name: Master | Remove controller manager container
   shell: "docker ps -af name=k8s_kube-controller-manager* -q | xargs --no-run-if-empty docker rm -f"
+  register: remove_cm_container
+  retries: 4
+  until: remove_cm_container.rc == 0
+  delay: 5
 
 - name: Master | wait for kube-scheduler
   uri:

--- a/roles/kubernetes/node/tasks/pre_upgrade.yml
+++ b/roles/kubernetes/node/tasks/pre_upgrade.yml
@@ -22,4 +22,8 @@
   command: docker rm -fv kubelet
   failed_when: false
   changed_when: false
+  register: remove_kubelet_container
+  retries: 4
+  until: remove_kubelet_container.rc == 0
+  delay: 5
   when: kubelet_deployment_type == 'host' and kubelet_container_check.rc == 0


### PR DESCRIPTION
As we have seen with other containers, sometimes container removal fails on the first attempt due to some Docker bugs. Retrying typically corrects the issue.