### PR TITLE
Make spliting system_search_domains more robust

### DIFF
--- a/roles/docker/tasks/set_facts_dns.yml
+++ b/roles/docker/tasks/set_facts_dns.yml
@@ -47,7 +47,7 @@
 
 - name: add system search domains to docker options
   set_fact:
-    docker_dns_search_domains: "{{ docker_dns_search_domains | union(system_search_domains.stdout.split(' ')|default([])) | unique }}"
+    docker_dns_search_domains: "{{ docker_dns_search_domains | union(system_search_domains.stdout.split()|default([])) | unique }}"
   when: system_search_domains.stdout != ""
 
 - name: check number of nameservers


### PR DESCRIPTION
The search line in /etc/resolv.conf could have multiple spaces or tabs between domains. `system_search_domains.stdout.split()` will give wrong results in some case. We could use split() without argument instead.

e.g.
```
>>> 'domain.tld	cluster.tld '.split(' ')
['domain.tld\tcluster.tld', '']
>>> 'domain.tld cluster.tld '.split()
['domain.tld', 'cluster.tld']

```
It will set wrong options for /etc/systemd/system/docker.service.d/docker-dns.conf and make docker service fail to start.
for example, if the search line is 'search domain.tld '(There is one space after domain.tld), then the resulting docker-dns.conf will be

cat /etc/systemd/system/docker.service.d/docker-dns.conf 
[Service]
Environment="DOCKER_DNS_OPTIONS=\
    --dns 10.233.0.3 --dns 10.10.1.2  \
    --dns-search default.svc.cluster.local --dns-search svc.cluster.local --dns-search domain.tld --dns-search   \
    --dns-opt ndots:2 --dns-opt timeout:2 --dns-opt attempts:2  \
"
Parameter of last '--dns-search' is missing.