### PR TITLE
Replace "equalto" with "match" for compatibility with pre-2.8 Jinja2.

### DIFF
--- a/roles/etcd/tasks/check_certs.yml
+++ b/roles/etcd/tasks/check_certs.yml
@@ -62,7 +62,7 @@
       {% if gen_node_certs[inventory_hostname] or
         (not etcdcert_node.results[0].stat.exists|default(False)) or
           (not etcdcert_node.results[1].stat.exists|default(False)) or
-            (etcdcert_node.results[1].stat.checksum|default('') != etcdcert_master.files|selectattr("path", "equalto", etcdcert_node.results[1].stat.path)|map(attribute="checksum")|first|default('')) -%}
+            (etcdcert_node.results[1].stat.checksum|default('') != etcdcert_master.files|selectattr("path", "match", "^" ~ etcdcert_node.results[1].stat.path ~ "$")|map(attribute="checksum")|first|default('')) -%}
               {%- set _ = certs.update({'sync': True}) -%}
       {% endif %}
       {{ certs.sync }}

--- a/roles/kubernetes/secrets/tasks/check-certs.yml
+++ b/roles/kubernetes/secrets/tasks/check-certs.yml
@@ -101,7 +101,7 @@
       {% if gen_node_certs[inventory_hostname] or
         (not kubecert_node.results[0].stat.exists|default(False)) or
           (not kubecert_node.results[10].stat.exists|default(False)) or
-            (kubecert_node.results[10].stat.checksum|default('') != kubecert_master.files|selectattr("path", "equalto", kubecert_node.results[10].stat.path)|map(attribute="checksum")|first|default('')) -%}
+            (kubecert_node.results[10].stat.checksum|default('') != kubecert_master.files|selectattr("path", "match", "^" ~ kubecert_node.results[10].stat.path ~ "$")|map(attribute="checksum")|first|default('')) -%}
               {%- set _ = certs.update({'sync': True}) -%}
       {% endif %}
       {{ certs.sync }}


### PR DESCRIPTION
Fixes #1126 for Jinja older than 2.8.

Jinja2 version 2.7.2 does not support "equalto". It's the latest version of Jinja2 available in e.g. RHEL7, and it's likely to stay so in certain conservative industries for a long time, effectively rendering Kubespray unusable without a fix.
See a related OpenShift patch: openshift/openshift-ansible/issues/3463

This PR enables compatibility with Jinja versions < 2.8 by replacing occurences of `equalto <pattern>` with `match "^pattern$"` for file paths. 

Please note that the regex is not escaped and dots and other regex-specific syntax in the path can confuse it. Please advise me on a way to make a more robust fix, if possible.