### PR TITLE
Rename runtime docker_version

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -76,7 +76,7 @@
 
 - name: set fact for docker_version
   command: "docker version -f '{{ '{{' }}.Client.Version{{ '}}' }}'"
-  register: docker_version
+  register: installed_docker_version
   changed_when: false
 
 - name: check minimum docker version for docker_dns mode. You need at least docker version >= 1.12 for resolvconf_mode=docker_dns
@@ -85,7 +85,7 @@
   when: >
         dns_mode != 'none' and
         resolvconf_mode == 'docker_dns' and
-        docker_version.stdout|version_compare('1.12', '<')
+        installed_docker_version.stdout|version_compare('1.12', '<')
 
 - name: Set docker systemd config
   include: systemd.yml

--- a/roles/docker/templates/docker.service.j2
+++ b/roles/docker/templates/docker.service.j2
@@ -18,7 +18,7 @@ Environment=GOTRACEBACK=crash
 ExecReload=/bin/kill -s HUP $MAINPID
 Delegate=yes
 KillMode=process
-ExecStart={{ docker_bin_dir }}/docker{% if docker_version.stdout|version_compare('17.03', '<') %} daemon{% else %}d{% endif %} \
+ExecStart={{ docker_bin_dir }}/docker{% if installed_docker_version.stdout|version_compare('17.03', '<') %} daemon{% else %}d{% endif %} \
           $DOCKER_OPTS \
           $DOCKER_STORAGE_OPTIONS \
           $DOCKER_NETWORK_OPTIONS \


### PR DESCRIPTION
Renaming runtime docker_version to prevent setting that
value on the command line from breaking the play run.

This fixes #2081