### PR TITLE
Fix auto-evaluated API access endpoint for bind IP 

### DIFF
--- a/docs/ha-mode.md
+++ b/docs/ha-mode.md
@@ -92,22 +92,27 @@ localhost LB configuration.
   the each node in the `k8s-cluster` group as well, but require no VIP, thus
   no VIP management.
 
-Access endpoints are evaluated automagically, as the following:
+Access API endpoints are evaluated automagically, as the following:
 
-| Endpoint type                | kube-master   | non-master          |
-|------------------------------|---------------|---------------------|
-| Local LB (default)           | http://lc:p   | https://lc:nsp      |
-| External LB, no internal     | https://lb:lp | https://lb:lp       |
-| No ext/int LB                | http://lc:p   | https://m[0].aip:sp |
+| Endpoint type                | kube-master    | non-master          |
+|------------------------------|----------------|---------------------|
+| Local LB (default)           | https://lc:sp  | https://lc:nsp      |
+| External LB, no internal     | https://lb:lp  | https://lb:lp       |
+| No ext/int LB, bind 0.0.0.0  | https://lc:sp  | https://m[0].aip:sp |
+| No ext/int LB, a custom bind | https://bip:sp | https://m[0].aip:sp |
 
 Where:
 * `m[0]` - the first node in the `kube-master` group;
 * `lb` - LB FQDN, `apiserver_loadbalancer_domain_name`;
 * `lc` - localhost;
-* `p` - insecure port, `kube_apiserver_insecure_port`
-* `nsp` - nginx secure port, `nginx_kube_apiserver_port`;
+* `bip` - a custom bind IP value (defaults to '0.0.0.0');
+* `nsp` - nginx secure port, `nginx_kube_apiserver_port`, defers to `sp`;
 * `sp` - secure port, `kube_apiserver_port`;
 * `lp` - LB port, `loadbalancer_apiserver.port`, defers to the secure port;
 * `ip` - the node IP, defers to the ansible IP;
 * `aip` - `access_ip`, defers to the ip.
 
+**Note** that for some cases, like healthchecks of applications deployed by
+Kubespray, the masters' APIs are accessed via the insecure endpoint, which
+consists of the local `kube_apiserver_insecure_bind_address` and
+`kube_apiserver_insecure_port`.

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -98,8 +98,12 @@ kube_pods_subnet: 10.233.64.0/18
 # room for 4096 nodes with 254 pods per node.
 kube_network_node_prefix: 24
 
-# The port the API Server will be listening on.
+# The virtual cluster IP, real host IPs and ports the API Server will be
+# listening on.
+# NOTE: loadbalancer_apiserver_localhost somewhat alters the final API enpdoint
+# access IP value (automatically evaluated below)
 kube_apiserver_ip: "{{ kube_service_addresses|ipaddr('net')|ipaddr(1)|ipaddr('address') }}"
+kube_apiserver_bind_address: 0.0.0.0
 # https
 kube_apiserver_port: 6443
 # http
@@ -210,7 +214,7 @@ kube_apiserver_endpoint: |-
   {% if not is_kube_master and loadbalancer_apiserver_localhost -%}
        https://localhost:{{ nginx_kube_apiserver_port|default(kube_apiserver_port) }}
   {%- elif is_kube_master -%}
-       https://127.0.0.1:{{ kube_apiserver_port }}
+       https://{{ kube_apiserver_bind_address | regex_replace('0\.0\.0\.0','127.0.0.1') }}:{{ kube_apiserver_port }}
   {%- else -%}
   {%-   if loadbalancer_apiserver is defined and loadbalancer_apiserver.port is defined -%}
        https://{{ apiserver_loadbalancer_domain_name|default('lb-apiserver.kubernetes.local') }}:{{ loadbalancer_apiserver.port|default(kube_apiserver_port) }}


### PR DESCRIPTION
* Auto configure API access endpoint with a custom bind IP, if provided.          
* Fix HA docs' http URLs are https in fact, clarify the insecure vs secure        
  API access modes as well. 

Closes https://github.com/kubernetes-incubator/kubespray/issues/2051

Signed-off-by: Bogdan Dobrelya <bogdando@mail.ru>
  