### PR TITLE
Do not override kubelet hostname if cloud_provider is used

### DIFF
--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -78,7 +78,12 @@ kubelet_custom_flags: []
 kube_hyperkube_image_repo: ""
 
 # If non-empty, will use this string as identification instead of the actual hostname
-kube_override_hostname: "{{ ansible_hostname }}"
+kube_override_hostname: >-
+  {% if cloud_provider is defined %}
+  false
+  {% else %}
+  {{ ansible_hostname }}
+  {% endif %}
 
 # cAdvisor port
 kube_cadvisor_port: 0


### PR DESCRIPTION
Starting with Kubernetes v1.8.4, kubelet ignores the AWS cloud
provider string and uses the override hostname, which fails
Node admission checks.

Fixes #2094