### PR TITLE
Update docker package info for aarch64

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -7,6 +7,7 @@
         - "{{ ansible_distribution|lower }}-{{ ansible_distribution_release }}.yml"
         - "{{ ansible_distribution|lower }}-{{ ansible_distribution_major_version|lower|replace('/', '_') }}.yml"
         - "{{ ansible_distribution|lower }}.yml"
+        - "{{ ansible_os_family|lower }}-{{ ansible_architecture }}.yml"
         - "{{ ansible_os_family|lower }}.yml"
         - defaults.yml
       paths:

--- a/roles/docker/vars/redhat-aarch64.yml
+++ b/roles/docker/vars/redhat-aarch64.yml
@@ -1,0 +1,28 @@
+---
+docker_kernel_min_version: '0'
+
+# overide defaults, missing 17.03 for aarch64
+docker_version: '1.13'
+
+# http://mirror.centos.org/altarch/7/extras/aarch64/Packages/
+# or do 'yum --showduplicates list docker'
+docker_versioned_pkg:
+  'latest': docker
+  '1.12': docker-1.12.6-48.git0fdc778.el7
+  '1.13': docker-1.13.1-63.git94f4240.el7
+
+# https://docs.docker.com/engine/installation/linux/centos/#install-from-a-package
+# http://mirror.centos.org/altarch/7/extras/aarch64/Packages/
+
+docker_package_info:
+  pkg_mgr: yum
+  pkgs:
+    - name: "{{ docker_versioned_pkg[docker_version | string] }}"
+
+docker_repo_key_info:
+  pkg_key: ''
+  repo_keys: []
+
+docker_repo_info:
+  pkg_repo: ''
+  repos: []


### PR DESCRIPTION
Missing corresponding package docker-engine on aarch64, use docker instead.