### PR TITLE
etcd2 fix for undefined variable

### DIFF
--- a/roles/kubernetes/master/tasks/pre-upgrade.yml
+++ b/roles/kubernetes/master/tasks/pre-upgrade.yml
@@ -12,7 +12,7 @@
 - name: "Pre-upgrade | etcd3 upgrade | use etcd2 unless forced to etcd3"
   set_fact:
     kube_apiserver_storage_backend: "etcd2"
-  when: old_data_exists.rc == 0 and not force_etcd3|bool
+  when: old_data_exists.rc is defined and old_data_exists.rc == 0 and not force_etcd3|bool
 
 - name: "Pre-upgrade | Delete master manifests"
   file:


### PR DESCRIPTION
When choosing 'kube_apiserver_storage_backend: "etcd2"' the ansible fails. I fixed that by adding a defined check to the script.