### PR TITLE
Master label should be `node-role.kubernetes.io/master: ""`

### DIFF
--- a/roles/kubernetes/node/templates/kubelet.standard.env.j2
+++ b/roles/kubernetes/node/templates/kubelet.standard.env.j2
@@ -67,7 +67,7 @@ KUBELET_HOSTNAME="--hostname-override={{ kube_override_hostname }}"
 
 {# Kubelet node labels #}
 {% if inventory_hostname in groups['kube-master'] %}
-{%   set node_labels %}--node-labels=node-role.kubernetes.io/master=true{% endset %}
+{%   set node_labels %}--node-labels=node-role.kubernetes.io/master=""{% endset %}
 {%   if not standalone_kubelet|bool %}
 {%     set node_labels %}{{ node_labels }},node-role.kubernetes.io/node=true{% endset %}
 {%   endif %}


### PR DESCRIPTION
Master label should be `node-role.kubernetes.io/master: ""`
fix #2108