### PR TITLE
Fix upgrade-only-k8s for etcd_client_cert_serial

### DIFF
--- a/extra_playbooks/upgrade-only-k8s.yml
+++ b/extra_playbooks/upgrade-only-k8s.yml
@@ -31,6 +31,9 @@
   vars:
     ansible_ssh_pipelining: true
   gather_facts: true
+  roles:
+    - { role: kubespray-defaults }
+    - { role: etcd, tags: facts }
 
 - hosts: k8s-cluster:etcd:calico-rr
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"

--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -18,11 +18,15 @@
   register: "etcd_client_cert_serial_result"
   changed_when: false
   when: inventory_hostname in groups['k8s-cluster']|union(groups['etcd'])|union(groups['calico-rr']|default([]))|unique|sort
+  tags:
+    - facts
 
 - name: Set etcd_client_cert_serial
   set_fact:
     etcd_client_cert_serial: "{{ etcd_client_cert_serial_result.stdout }}"
   when: inventory_hostname in groups['k8s-cluster']|union(groups['etcd'])|union(groups['calico-rr']|default([]))|unique|sort
+  tags:
+    - facts
 
 - include: "install_{{ etcd_deployment_type }}.yml"
   when: is_etcd_master


### PR DESCRIPTION
This fixes the following error when running the upgrade-only-k8s playbook:

```
TASK [kubernetes/master : Write kube-apiserver manifest] 
fatal: FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: 'etcd_client_cert_serial' is undefined"}
```