### PR TITLE
fix etcd startup args when running on aarch64

### DIFF
--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -5,6 +5,18 @@
     - etcd-secrets
     - facts
 
+- name: gather os specific variables
+  include_vars: "{{ item }}"
+  with_first_found:
+    - files:
+        - "{{ ansible_architecture }}.yml"
+        - defaults.yml
+      paths:
+        - ../vars
+      skip: true
+  tags:
+    - facts
+
 - include_tasks: "gen_certs_{{ cert_management }}.yml"
   tags:
     - etcd-secrets

--- a/roles/etcd/templates/etcd.j2
+++ b/roles/etcd/templates/etcd.j2
@@ -3,6 +3,9 @@
   --restart=on-failure:5 \
   --env-file=/etc/etcd.env \
   --net=host \
+  {% if ansible_architecture == "aarch64" -%}
+  -e ETCD_UNSUPPORTED_ARCH=arm64 \
+  {%- endif %}
   -v /etc/ssl/certs:/etc/ssl/certs:ro \
   -v {{ etcd_cert_dir }}:{{ etcd_cert_dir }}:ro \
   -v {{ etcd_data_dir }}:{{ etcd_data_dir }}:rw \

--- a/roles/etcd/vars/aarch64.yaml
+++ b/roles/etcd/vars/aarch64.yaml
@@ -1,0 +1,1 @@
+etcd_image_tag: {{ etcd_image_tag }}-arm64

--- a/roles/etcd/vars/ppc64le.yaml
+++ b/roles/etcd/vars/ppc64le.yaml
@@ -1,0 +1,1 @@
+etcd_image_tag: {{ etcd_image_tag }}-ppc64le


### PR DESCRIPTION
To avoid inadvertently running a possibly unstable etcd server,
etcd on unstable or unsupported architectures will print a warning message
and immediately exit if the environment variable
ETCD_UNSUPPORTED_ARCH is not set to the target architecture.

Currently only amd64 and ppc64le architectures are officially
supported by etcd. To make it running on aarch64, extra
environment variable ETCD_UNSUPPORTED_ARCH has to be set.