### PR TITLE
Use access_ip_v4 instead of access_ip

### DIFF
--- a/roles/etcd/templates/openssl.conf.j2
+++ b/roles/etcd/templates/openssl.conf.j2
@@ -32,7 +32,7 @@ DNS.{{ 1 + loop.index }} = {{ host }}
 DNS.{{ idx | string }} = {{ apiserver_loadbalancer_domain_name }}
 {% endif %}
 {% for host in groups['etcd'] %}
-IP.{{ 2 * loop.index - 1 }} = {{ hostvars[host]['access_ip'] | default(hostvars[host]['ansible_default_ipv4']['address']) }}
+IP.{{ 2 * loop.index - 1 }} = {{ hostvars[host]['access_ip_v4'] | default(hostvars[host]['ansible_default_ipv4']['address']) }}
 IP.{{ 2 * loop.index }} = {{ hostvars[host]['ip'] | default(hostvars[host]['ansible_default_ipv4']['address']) }}
 {% endfor %}
 {% set idx =  groups['etcd'] | length | int * 2 + 1 %}

--- a/roles/kubernetes/client/tasks/main.yml
+++ b/roles/kubernetes/client/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Set first kube master
   set_fact:
-    first_kube_master: "{{ hostvars[groups['kube-master'][0]]['access_ip'] | default(hostvars[groups['kube-master'][0]]['ip'] | default(hostvars[groups['kube-master'][0]]['ansible_default_ipv4']['address'])) }}"
+    first_kube_master: "{{ hostvars[groups['kube-master'][0]]['access_ip_v4'] | default(hostvars[groups['kube-master'][0]]['ip'] | default(hostvars[groups['kube-master'][0]]['ansible_default_ipv4']['address'])) }}"
 
 - name: Set external kube-apiserver endpoint
   set_fact:

--- a/roles/kubernetes/secrets/templates/openssl.conf.j2
+++ b/roles/kubernetes/secrets/templates/openssl.conf.j2
@@ -20,7 +20,7 @@ DNS.{{ 5 + loop.index }} = {{ host }}
 DNS.{{ idx | string }} = {{ apiserver_loadbalancer_domain_name }}
 {% endif %}
 {% for host in groups['kube-master'] %}
-IP.{{ 2 * loop.index - 1 }} = {{ hostvars[host]['access_ip'] | default(hostvars[host]['ansible_default_ipv4']['address']) }}
+IP.{{ 2 * loop.index - 1 }} = {{ hostvars[host]['access_ip_v4'] | default(hostvars[host]['ansible_default_ipv4']['address']) }}
 IP.{{ 2 * loop.index }} = {{ hostvars[host]['ip'] | default(hostvars[host]['ansible_default_ipv4']['address']) }}
 {% endfor %}
 {% set idx =  groups['kube-master'] | length | int * 2 + 1 %}


### PR DESCRIPTION
For certificate generation and kubeconfig, change `access_ip` to
access_ip_v4. When instances have an EIP/FIP/etc, `access_ip_v4` is
generally the public IP and `ip` is the private.

With this, the public IP is added to the TLS certs and the generated
client kubeconfig in `artifact/admin.conf` also has the right IP and can
be used out of the box.