### PR TITLE
Simplify and update OpenStack cloud provider

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -74,12 +74,17 @@ bin_dir: /usr/local/bin
 #azure_vnet_name:
 #azure_route_table_name:
 
-## When OpenStack is used, Cinder version can be explicitly specified if autodetection fails (https://github.com/kubernetes/kubernetes/issues/50461)
+## When OpenStack is used, Cinder version can be explicitly specified if autodetection fails (Fixed in 1.9: https://github.com/kubernetes/kubernetes/issues/50461)
 #openstack_blockstorage_version: "v1/v2/auto (default)"
-## When OpenStack is used, if LBaaSv2 is available you can enable it with the following variables.
+## When OpenStack is used, if LBaaSv2 is available you can enable it with the following 2 variables.
 #openstack_lbaas_enabled: True
 #openstack_lbaas_subnet_id: "Neutron subnet ID (not network ID) to create LBaaS VIP"
+## To enable automatic floating ip provisioning, specify a subnet.
 #openstack_lbaas_floating_network_id: "Neutron network ID (not subnet ID) to get floating IP from, disabled by default"
+## Override default LBaaS behavior
+#openstack_lbaas_use_octavia: False
+#openstack_lbaas_method: "ROUND_ROBIN"
+#openstack_lbaas_provider: "haproxy"
 #openstack_lbaas_create_monitor: "yes"
 #openstack_lbaas_monitor_delay: "1m"
 #openstack_lbaas_monitor_timeout: "30s"

--- a/roles/kubernetes/preinstall/templates/openstack-cloud-config.j2
+++ b/roles/kubernetes/preinstall/templates/openstack-cloud-config.j2
@@ -15,12 +15,22 @@ domain-id ="{{ openstack_domain_id }}"
 bs-version={{ openstack_blockstorage_version }}
 {% endif %}
 
-{% if openstack_lbaas_enabled and openstack_lbaas_subnet_id %}
+{% if openstack_lbaas_enabled and openstack_lbaas_subnet_id is defined %}
 [LoadBalancer]
 subnet-id={{ openstack_lbaas_subnet_id }}
 {% if openstack_lbaas_floating_network_id is defined %}
 floating-network-id={{ openstack_lbaas_floating_network_id }}
 {% endif %}
+{% if openstack_lbaas_use_octavia is defined %}
+use-octavia={{ openstack_lbaas_use_octavia }}
+{% endif %}
+{% if openstack_lbaas_method is defined %}
+lb-method={{ openstack_lbaas_method }}
+{% endif %}
+{% if openstack_lbaas_provider is defined %}
+lb-provider={{ openstack_lbaas_provider }}
+{% endif %}
+
 create-monitor={{ openstack_lbaas_create_monitor }}
 monitor-delay={{ openstack_lbaas_monitor_delay }}
 monitor-timeout={{ openstack_lbaas_monitor_timeout }}

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -153,16 +153,21 @@ persistent_volumes_enabled: false
 # Base path for local volume provisioner addon
 local_volume_base_dir: /mnt/disks
 
-## When OpenStack is used, Cinder version can be explicitly specified if autodetection fails (https://github.com/kubernetes/kubernetes/issues/50461)
+## When OpenStack is used, Cinder version can be explicitly specified if autodetection fails (Fixed in 1.9: https://github.com/kubernetes/kubernetes/issues/50461)
 # openstack_blockstorage_version: "v1/v2/auto (default)"
-## When OpenStack is used, if LBaaSv2 is available you can enable it with the following variables.
+## When OpenStack is used, if LBaaSv2 is available you can enable it with the following 2 variables.
 openstack_lbaas_enabled: false
 # openstack_lbaas_subnet_id: "Neutron subnet ID (not network ID) to create LBaaS VIP"
+## To enable automatic floating ip provisioning, specify a subnet.
 # openstack_lbaas_floating_network_id: "Neutron network ID (not subnet ID) to get floating IP from, disabled by default"
-# openstack_lbaas_create_monitor: "yes"
-# openstack_lbaas_monitor_delay: false
-# openstack_lbaas_monitor_timeout: false
-# openstack_lbaas_monitor_max_retries: false
+## Override default LBaaS behavior
+# openstack_lbaas_use_octavia: False
+# openstack_lbaas_method: "ROUND_ROBIN"
+# openstack_lbaas_provider: "haproxy"
+openstack_lbaas_create_monitor: "yes"
+openstack_lbaas_monitor_delay: "1m"
+openstack_lbaas_monitor_timeout: "30s"
+openstack_lbaas_monitor_max_retries: "3"
 
 ## List of authorization modes that must be configured for
 ## the k8s cluster. Only 'AlwaysAllow', 'AlwaysDeny', 'Node' and


### PR DESCRIPTION
Simplify the number of variables necessary to "just" enable OpenStack
cloud provider. Also add the new options available in K8s 1.9.