### PR TITLE
allow alt names for etcd certs

### DIFF
--- a/roles/vault/defaults/main.yml
+++ b/roles/vault/defaults/main.yml
@@ -90,6 +90,7 @@ vault_ca_options:
     format: pem
     ttl: "{{ vault_max_lease_ttl }}"
     exclude_cn_from_sans: true
+    alt_names: "etcd.{{ system_namespace }}.svc.{{ dns_domain }},etcd.{{ system_namespace }}.svc,etcd.{{ system_namespace }},etcd"
   kube:
     common_name: kube
     format: pem


### PR DESCRIPTION
This PR would generate alt names for etcd, similar to what we're already doing with vault's certificates a few lines above. This simply allows creation of kubernetes services that point to these alt names. e.g. `etcd.kube-system.svc.cluster.local`.