### PR TITLE
Add support for flex volumes plugins.

### DIFF
--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -62,6 +62,8 @@ nginx_image_tag: 1.13
 
 etcd_config_dir: /etc/ssl/etcd
 
+kubelet_flexvolumes_plugins_dir: /var/lib/kubelet/volume-plugins
+
 # A port range to reserve for services with NodePort visibility.
 # Inclusive at both ends of the range.
 kube_apiserver_node_port_range: "30000-32767"

--- a/roles/kubernetes/node/templates/kubelet.docker.service.j2
+++ b/roles/kubernetes/node/templates/kubelet.docker.service.j2
@@ -17,10 +17,14 @@ ExecStart={{ bin_dir }}/kubelet \
 		$KUBELET_ARGS \
 		$DOCKER_SOCKET \
 		$KUBELET_NETWORK_PLUGIN \
+		$KUBELET_VOLUME_PLUGIN \
 		$KUBELET_CLOUDPROVIDER
 Restart=always
 RestartSec=10s
 ExecStartPre=-{{ docker_bin_dir }}/docker rm -f kubelet
+{% if kubelet_flexvolumes_plugins_dir is defined %}
+ExecStartPre=-/bin/mkdir -p {{ kubelet_flexvolumes_plugins_dir }}
+{% endif %}
 ExecReload={{ docker_bin_dir }}/docker restart kubelet
 
 

--- a/roles/kubernetes/node/templates/kubelet.host.service.j2
+++ b/roles/kubernetes/node/templates/kubelet.host.service.j2
@@ -6,6 +6,9 @@ Wants=docker.socket
 
 [Service]
 EnvironmentFile=-{{kube_config_dir}}/kubelet.env
+{% if kubelet_flexvolumes_plugins_dir is defined %}
+ExecStartPre=-/bin/mkdir -p {{ kubelet_flexvolumes_plugins_dir }}
+{% endif %}
 ExecStart={{ bin_dir }}/kubelet \
 		$KUBE_LOGTOSTDERR \
 		$KUBE_LOG_LEVEL \
@@ -17,6 +20,7 @@ ExecStart={{ bin_dir }}/kubelet \
 		$KUBELET_ARGS \
 		$DOCKER_SOCKET \
 		$KUBELET_NETWORK_PLUGIN \
+		$KUBELET_VOLUME_PLUGIN \
 		$KUBELET_CLOUDPROVIDER
 Restart=always
 RestartSec=10s

--- a/roles/kubernetes/node/templates/kubelet.rkt.service.j2
+++ b/roles/kubernetes/node/templates/kubelet.rkt.service.j2
@@ -12,6 +12,10 @@ LimitNOFILE=40000
 ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/run/kubelet.uuid
 ExecStartPre=-/bin/mkdir -p /var/lib/kubelet
 
+{% if kubelet_flexvolumes_plugins_dir is defined %}
+ExecStartPre=-/bin/mkdir -p {{ kubelet_flexvolumes_plugins_dir }}
+{% endif %}
+
 EnvironmentFile={{kube_config_dir}}/kubelet.env
 # stage1-fly mounts /proc /sys /dev so no need to duplicate the mounts
 ExecStart=/usr/bin/rkt run \
@@ -39,6 +43,9 @@ ExecStart=/usr/bin/rkt run \
         --volume etc-cni,kind=host,source=/etc/cni,readOnly=true \
         --volume opt-cni,kind=host,source=/opt/cni,readOnly=true \
         --volume var-lib-cni,kind=host,source=/var/lib/cni,readOnly=false \
+{% if kubelet_flexvolumes_plugins_dir is defined %}
+        --volume flexvolumes,kind=host,source={{ kubelet_flexvolumes_plugins_dir }},readOnly=false \
+{% endif %}
 {% if kubelet_load_modules == true %}
         --mount volume=modprobe,target=/usr/sbin/modprobe \
         --mount volume=lib-modules,target=/lib/modules \
@@ -63,6 +70,9 @@ ExecStart=/usr/bin/rkt run \
 {% if local_volumes_enabled == true %}
         --mount volume=local-volume-base-dir,target={{ local_volume_base_dir }} \
 {% endif %}
+{% if kubelet_flexvolumes_plugins_dir is defined %}
+        --mount volume=flexvolumes,target={{ kubelet_flexvolumes_plugins_dir }} \
+{% endif %}
         --stage1-from-dir=stage1-fly.aci \
 {% if kube_hyperkube_image_repo == "docker" %}
         --insecure-options=image \
@@ -83,6 +93,7 @@ ExecStart=/usr/bin/rkt run \
                 $DOCKER_SOCKET \
                 $KUBELET_REGISTER_NODE \
                 $KUBELET_NETWORK_PLUGIN \
+                $KUBELET_VOLUME_PLUGIN \
                 $KUBELET_CLOUDPROVIDER
 
 ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/kubelet.uuid

--- a/roles/kubernetes/node/templates/kubelet.standard.env.j2
+++ b/roles/kubernetes/node/templates/kubelet.standard.env.j2
@@ -83,6 +83,11 @@ DOCKER_SOCKET="--docker-endpoint=unix:/var/run/weave/weave.sock"
 {% elif kube_network_plugin is defined and kube_network_plugin == "cloud" %}
 KUBELET_NETWORK_PLUGIN="--hairpin-mode=promiscuous-bridge --network-plugin=kubenet"
 {% endif %}
+
+{% if kubelet_flexvolumes_plugins_dir is defined %}
+KUBELET_VOLUME_PLUGIN="--volume-plugin-dir={{ kubelet_flexvolumes_plugins_dir }}"
+{% endif %}
+
 # Should this cluster be allowed to run privileged docker containers
 KUBE_ALLOW_PRIV="--allow-privileged=true"
 {% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere"] %}


### PR DESCRIPTION
This commit add support for flex volumes, especially for containerized deployments of kubelets.
I have tested only with rkt deployment under ContainerLinux. Should work on other platforms.

Use case: installing a storage system like rook needs support for flex volumes.