### PR TITLE
Updated with correct syntax to access default_tags variable.

### DIFF
--- a/contrib/terraform/aws/modules/vpc/outputs.tf
+++ b/contrib/terraform/aws/modules/vpc/outputs.tf
@@ -16,6 +16,6 @@ output "aws_security_group" {
 }
 
 output "default_tags" {
-    value = "${default_tags}"
+    value = "${var.default_tags}"
 
 }

--- a/contrib/terraform/aws/output.tf
+++ b/contrib/terraform/aws/output.tf
@@ -24,5 +24,5 @@ output "inventory" {
 }
 
 output "default_tags" {
-    value = "${default_tags}"
+    value = "${var.default_tags}"
 }


### PR DESCRIPTION
While running `terraform apply --var-file="credentials.tfvars"`, the following errors are being returned:

```
Error: output.default_tags: invalid variable syntax: "default_tags". Did you mean 'var.default_tags'? If this is part of inline `template` parameter
then you must escape the interpolation with two dollar signs. For
example: ${a} becomes $${a}.

Error: module.aws-vpc.output.default_tags: invalid variable syntax: "default_tags". Did you mean 'var.default_tags'? If this is part of inline `template` parameter
then you must escape the interpolation with two dollar signs. For
example: ${a} becomes $${a}.
```

This appears to be due to the incorrect access to the default_tags variable.

Applying the changes in this PR fixes the issue.