### PR TITLE
fix fluentd template

### DIFF
--- a/roles/kubernetes-apps/efk/fluentd/templates/fluentd-ds.yml.j2
+++ b/roles/kubernetes-apps/efk/fluentd/templates/fluentd-ds.yml.j2
@@ -39,8 +39,8 @@ spec:
         volumeMounts:
         - name: varlog
           mountPath: /var/log
-        - name: varlibdockercontainers
-          mountPath: /var/lib/docker/containers
+        - name: dockercontainers
+          mountPath: "{{ docker_daemon_graph }}/containers"
           readOnly: true
         - name: config
           mountPath: "{{ fluentd_config_dir }}"
@@ -49,9 +49,9 @@ spec:
       - name: varlog
         hostPath:
           path: /var/log
-      - name: varlibdockercontainers
+      - name: dockercontainers
         hostPath:
-          path: /var/lib/docker/containers
+          path: {{ docker_daemon_graph }}/containers
       - name: config
         configMap: 
           name: fluentd-config


### PR DESCRIPTION
The fluentd template assumes constant container dir, even though kubespray allows setting different roots.