### PR TITLE
Upgrade local-volume-provisioner

### DIFF
--- a/roles/kubernetes-apps/local_volume_provisioner/defaults/main.yml
+++ b/roles/kubernetes-apps/local_volume_provisioner/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 local_volume_provisioner_bootstrap_image_repo: quay.io/external_storage/local-volume-provisioner-bootstrap
-local_volume_provisioner_bootstrap_image_tag: v1.0.0
+local_volume_provisioner_bootstrap_image_tag: v2.0.0
 
 local_volume_provisioner_image_repo: quay.io/external_storage/local-volume-provisioner
-local_volume_provisioner_image_tag: v1.0.0
+local_volume_provisioner_image_tag: v2.0.0

--- a/roles/kubernetes-apps/local_volume_provisioner/tasks/main.yml
+++ b/roles/kubernetes-apps/local_volume_provisioner/tasks/main.yml
@@ -26,6 +26,7 @@
     - {name: local-storage-provisioner-pv-binding, file: provisioner-admin-account.yml, type: clusterrolebinding}
     - {name: local-volume-config, file: volume-config.yml, type: configmap}
     - {name: local-volume-provisioner, file: provisioner-ds.yml, type: daemonset}
+    - {name: local-volume-storageclass, file: storageclass.yml, type: storageclass}
   register: local_volume_manifests
   when: inventory_hostname == groups['kube-master'][0]
 

--- a/roles/kubernetes-apps/local_volume_provisioner/templates/storageclass.yml.j2
+++ b/roles/kubernetes-apps/local_volume_provisioner/templates/storageclass.yml.j2
@@ -1,0 +1,8 @@
+{%- if kube_version | version_compare('v1.9', '>=') -%}
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local-storage
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer
+{%- endif -%}

--- a/roles/kubernetes-apps/local_volume_provisioner/templates/volume-config.yml.j2
+++ b/roles/kubernetes-apps/local_volume_provisioner/templates/volume-config.yml.j2
@@ -9,4 +9,4 @@ data:
   storageClassMap: |
     local-storage:
       hostDir: "{{ local_volume_base_dir }}"
-      mountDir: "/mnt/local-storage/"
+      mountDir: "/local-disks"

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -172,7 +172,11 @@ rbac_enabled: "{{ 'RBAC' in authorization_modes or kubeadm_enabled }}"
 
 ## List of key=value pairs that describe feature gates for
 ## the k8s cluster.
+{%- if kube_version | version_compare('v1.9', '>=') -%}
+kube_feature_gates: ['Initializers={{ istio_enabled|string }}', 'PersistentLocalVolumes={{ local_volumes_enabled|string }}', 'VolumeScheduling={{ local_volumes_enabled|string }}', 'MountPropagation={{ local_volumes_enabled|string }}']
+{%- else -%}
 kube_feature_gates: ['Initializers={{ istio_enabled|string }}', 'PersistentLocalVolumes={{ local_volumes_enabled|string }}']
+{%- endif -%}
 
 # Vault data dirs.
 vault_base_dir: /etc/vault

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -172,7 +172,7 @@ rbac_enabled: "{{ 'RBAC' in authorization_modes or kubeadm_enabled }}"
 
 ## List of key=value pairs that describe feature gates for
 ## the k8s cluster.
-kube_feature_gates: >- 
+kube_feature_gates: >-
   {%- if kube_version | version_compare('v1.9', '>=') -%}
   ['Initializers={{ istio_enabled|string }}', 'PersistentLocalVolumes={{ local_volumes_enabled|string }}', 'VolumeScheduling={{ local_volumes_enabled|string }}', 'MountPropagation={{ local_volumes_enabled|string }}']
   {%- else -%}

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -172,11 +172,12 @@ rbac_enabled: "{{ 'RBAC' in authorization_modes or kubeadm_enabled }}"
 
 ## List of key=value pairs that describe feature gates for
 ## the k8s cluster.
-{%- if kube_version | version_compare('v1.9', '>=') -%}
-kube_feature_gates: ['Initializers={{ istio_enabled|string }}', 'PersistentLocalVolumes={{ local_volumes_enabled|string }}', 'VolumeScheduling={{ local_volumes_enabled|string }}', 'MountPropagation={{ local_volumes_enabled|string }}']
-{%- else -%}
-kube_feature_gates: ['Initializers={{ istio_enabled|string }}', 'PersistentLocalVolumes={{ local_volumes_enabled|string }}']
-{%- endif -%}
+kube_feature_gates: >- 
+  {%- if kube_version | version_compare('v1.9', '>=') -%}
+  ['Initializers={{ istio_enabled|string }}', 'PersistentLocalVolumes={{ local_volumes_enabled|string }}', 'VolumeScheduling={{ local_volumes_enabled|string }}', 'MountPropagation={{ local_volumes_enabled|string }}']
+  {%- else -%}
+  ['Initializers={{ istio_enabled|string }}', 'PersistentLocalVolumes={{ local_volumes_enabled|string }}']
+  {%- endif -%}
 
 # Vault data dirs.
 vault_base_dir: /etc/vault


### PR DESCRIPTION
For Kubernetes >= 1.9, we need to open the `VolumeScheduling` and `MountPropagation` feature-gates and install a storage-class that sets `volumeBindingMode` to `WaitForFirstConsumer` to avoid binding volumes on nodes that the consumer cannot run on.

Also, upgrade local-volume-provisioner to latest (v2.0.0) version.
  