### PR TITLE
Fix 'no such host' problem

### DIFF
--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -79,7 +79,7 @@ kube_hyperkube_image_repo: ""
 
 # If non-empty, will use this string as identification instead of the actual hostname
 kube_override_hostname: >-
-  {%- if cloud_provider is defined -%}
+  {%- if cloud_provider is defined and cloud_provider in [ 'aws' ] -%}
   {%- else -%}
   {{ ansible_hostname }}
   {%- endif -%}

--- a/roles/kubernetes/node/templates/kubelet.kubeadm.env.j2
+++ b/roles/kubernetes/node/templates/kubelet.kubeadm.env.j2
@@ -8,8 +8,8 @@ KUBE_LOG_LEVEL="--v={{ kube_log_level }}"
 KUBELET_ADDRESS="--address={{ kubelet_bind_address }} --node-ip={{ kubelet_address }}"
 # The port for the info server to serve on
 # KUBELET_PORT="--port=10250"
-# You may leave this blank to use the actual hostname
 {% if kube_override_hostname|default('') %}
+# You may leave this blank to use the actual hostname
 KUBELET_HOSTNAME="--hostname-override={{ kube_override_hostname }}"
 {% endif %}
 {# Base kubelet args #}

--- a/roles/kubernetes/node/templates/kubelet.standard.env.j2
+++ b/roles/kubernetes/node/templates/kubelet.standard.env.j2
@@ -5,8 +5,8 @@ KUBE_LOG_LEVEL="--v={{ kube_log_level }}"
 KUBELET_ADDRESS="--address={{ kubelet_bind_address }} --node-ip={{ kubelet_address }}"
 # The port for the info server to serve on
 # KUBELET_PORT="--port=10250"
-# You may leave this blank to use the actual hostname
 {% if kube_override_hostname|default('') %}
+# You may leave this blank to use the actual hostname
 KUBELET_HOSTNAME="--hostname-override={{ kube_override_hostname }}"
 {% endif %}
 {# Base kubelet args #}


### PR DESCRIPTION
Fix 'no such host' problem reported by commands *kubectl logs* and *kubectl exec*
when cloud_provider is OpenStack

Closes: #2147