### PR TITLE
Fix for Issue #2141

### DIFF
--- a/inventory/group_vars/k8s-cluster.yml
+++ b/inventory/group_vars/k8s-cluster.yml
@@ -183,4 +183,4 @@ local_volumes_enabled: false
 ## Running on top of openstack vms with cinder enabled may lead to unschedulable pods due to NoVolumeZoneConflict restriction in kube-scheduler.
 ## See https://github.com/kubernetes-incubator/kubespray/issues/2141
 ## Set this variable to true to get rid of this issue
-disable_volume_zone_conflict: false
+volume_cross_zone_attachment: false

--- a/inventory/group_vars/k8s-cluster.yml
+++ b/inventory/group_vars/k8s-cluster.yml
@@ -179,3 +179,8 @@ local_volumes_enabled: false
 ## Supplementary addresses that can be added in kubernetes ssl keys.
 ## That can be usefull for example to setup a keepalived virtual IP
 # supplementary_addresses_in_ssl_keys: [10.0.0.1, 10.0.0.2, 10.0.0.3]
+
+## Running on top of openstack vms with cinder enabled may lead to unschedulable pods due to NoVolumeZoneConflict restriction in kube-scheduler.
+## See https://github.com/kubernetes-incubator/kubespray/issues/2141
+## Set this variable to true to get rid of this issue
+disable_volume_zone_conflict: false

--- a/roles/kubernetes/master/defaults/main.yml
+++ b/roles/kubernetes/master/defaults/main.yml
@@ -82,4 +82,4 @@ scheduler_custom_flags: []
 kubeadm_token_ttl: 0
 
 ## Variable for influencing kube-scheduler behaviour
-disable_volume_zone_conflict: false
+volume_cross_zone_attachment: false

--- a/roles/kubernetes/master/defaults/main.yml
+++ b/roles/kubernetes/master/defaults/main.yml
@@ -80,3 +80,6 @@ scheduler_custom_flags: []
 # kubeadm settings
 # Value of 0 means it never expires
 kubeadm_token_ttl: 0
+
+## Variable for influencing kube-scheduler behaviour
+disable_volume_zone_conflict: false

--- a/roles/kubernetes/master/tasks/static-pod-setup.yml
+++ b/roles/kubernetes/master/tasks/static-pod-setup.yml
@@ -9,6 +9,13 @@
 
 - meta: flush_handlers
 
+- name: Write kube-scheduler policy file
+  template:
+     src: kube-scheduler-policy.yaml.j2
+     dest: "{{ kube_config_dir }}/kube-scheduler-policy.yaml"
+  tags:
+    - kube-scheduler
+
 - name: Write kube-scheduler kubeconfig
   template:
     src: kube-scheduler-kubeconfig.yaml.j2

--- a/roles/kubernetes/master/tasks/static-pod-setup.yml
+++ b/roles/kubernetes/master/tasks/static-pod-setup.yml
@@ -11,8 +11,8 @@
 
 - name: Write kube-scheduler policy file
   template:
-     src: kube-scheduler-policy.yaml.j2
-     dest: "{{ kube_config_dir }}/kube-scheduler-policy.yaml"
+    src: kube-scheduler-policy.yaml.j2
+    dest: "{{ kube_config_dir }}/kube-scheduler-policy.yaml"
   tags:
     - kube-scheduler
 

--- a/roles/kubernetes/master/templates/kube-scheduler-policy.yaml.j2
+++ b/roles/kubernetes/master/templates/kube-scheduler-policy.yaml.j2
@@ -1,0 +1,18 @@
+{
+"kind" : "Policy",
+"apiVersion" : "v1",
+"predicates" : [
+    {"name" : "PodFitsHostPorts"},
+    {"name" : "PodFitsResources"},
+    {"name" : "NoDiskConflict"},
+    {"name" : "MatchNodeSelector"},
+    {"name" : "HostName"}
+    ],
+"priorities" : [
+    {"name" : "LeastRequestedPriority", "weight" : 1},
+    {"name" : "BalancedResourceAllocation", "weight" : 1},
+    {"name" : "ServiceSpreadingPriority", "weight" : 1},
+    {"name" : "EqualPriority", "weight" : 1}
+    ],
+"hardPodAffinitySymmetricWeight" : 10
+}

--- a/roles/kubernetes/master/templates/manifests/kube-scheduler.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-scheduler.manifest.j2
@@ -28,7 +28,7 @@ spec:
     - scheduler
     - --leader-elect=true
     - --kubeconfig={{ kube_config_dir }}/kube-scheduler-kubeconfig.yaml
-{% if cloud_provider == 'openstack' and disable_volume_zone_conflict %}
+{% if volume_cross_zone_attachment %}
     - --policy-config-file={{ kube_config_dir }}/kube-scheduler-policy.yaml
 {% endif %}
     - --profiling=false
@@ -65,7 +65,7 @@ spec:
     - mountPath: "{{ kube_config_dir }}/kube-scheduler-kubeconfig.yaml"
       name: kubeconfig
       readOnly: true
-{% if cloud_provider == 'openstack' and disable_volume_zone_conflict %}
+{% if volume_cross_zone_attachment %}
     - mountPath: "{{ kube_config_dir }}/kube-scheduler-policy.yaml"
       name: kube-scheduler-policy
       readOnly: true
@@ -85,7 +85,7 @@ spec:
   - name: kubeconfig
     hostPath:
       path: "{{ kube_config_dir }}/kube-scheduler-kubeconfig.yaml"
-{% if cloud_provider == 'openstack' and disable_volume_zone_conflict %}
+{% if volume_cross_zone_attachment %}
   - name: kube-scheduler-policy
     hostPath:
       path: "{{ kube_config_dir }}/kube-scheduler-policy.yaml"

--- a/roles/kubernetes/master/templates/manifests/kube-scheduler.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-scheduler.manifest.j2
@@ -28,6 +28,9 @@ spec:
     - scheduler
     - --leader-elect=true
     - --kubeconfig={{ kube_config_dir }}/kube-scheduler-kubeconfig.yaml
+{% if cloud_provider == 'openstack' %}
+    - --policy-config-file={{ kube_config_dir }}/kube-scheduler-policy.yaml
+{% endif %}
     - --profiling=false
     - --v={{ kube_log_level }}
 {% if kube_feature_gates %}
@@ -62,6 +65,11 @@ spec:
     - mountPath: "{{ kube_config_dir }}/kube-scheduler-kubeconfig.yaml"
       name: kubeconfig
       readOnly: true
+{% if cloud_provider == 'openstack' %}
+    - mountPath: "{{ kube_config_dir }}/kube-scheduler-policy.yaml"
+      name: kube-scheduler-policy
+      readOnly: true
+{% endif %}
   volumes:
   - name: ssl-certs-host
     hostPath:
@@ -77,3 +85,8 @@ spec:
   - name: kubeconfig
     hostPath:
       path: "{{ kube_config_dir }}/kube-scheduler-kubeconfig.yaml"
+{% if cloud_provider == 'openstack' %}
+  - name: kube-scheduler-policy
+    hostPath:
+      path: "{{ kube_config_dir }}/kube-scheduler-policy.yaml"
+{% endif %}

--- a/roles/kubernetes/master/templates/manifests/kube-scheduler.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-scheduler.manifest.j2
@@ -28,7 +28,7 @@ spec:
     - scheduler
     - --leader-elect=true
     - --kubeconfig={{ kube_config_dir }}/kube-scheduler-kubeconfig.yaml
-{% if cloud_provider == 'openstack' %}
+{% if cloud_provider == 'openstack' and disable_volume_zone_conflict %}
     - --policy-config-file={{ kube_config_dir }}/kube-scheduler-policy.yaml
 {% endif %}
     - --profiling=false
@@ -65,7 +65,7 @@ spec:
     - mountPath: "{{ kube_config_dir }}/kube-scheduler-kubeconfig.yaml"
       name: kubeconfig
       readOnly: true
-{% if cloud_provider == 'openstack' %}
+{% if cloud_provider == 'openstack' and disable_volume_zone_conflict %}
     - mountPath: "{{ kube_config_dir }}/kube-scheduler-policy.yaml"
       name: kube-scheduler-policy
       readOnly: true
@@ -85,7 +85,7 @@ spec:
   - name: kubeconfig
     hostPath:
       path: "{{ kube_config_dir }}/kube-scheduler-kubeconfig.yaml"
-{% if cloud_provider == 'openstack' %}
+{% if cloud_provider == 'openstack' and disable_volume_zone_conflict %}
   - name: kube-scheduler-policy
     hostPath:
       path: "{{ kube_config_dir }}/kube-scheduler-policy.yaml"


### PR DESCRIPTION
This is a fix for issue: https://github.com/kubernetes-incubator/kubespray/issues/2141

The solution was to configure a bit more permissive default scheduler policy, by removing the NoVolumeZoneConflict predicate from default policy hosted on kubernetes repo.

One possible improvement is to gather somehow the default policy file and remove only this predicate.