### PR TITLE
WIP: nvidia gpu support

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -101,6 +101,11 @@ bin_dir: /usr/local/bin
 ## Please note that overlay2 is only supported on newer kernels
 #docker_storage_options: -s overlay2
 
+## Uncomment this if you want to enable nvidia GPU support. Note that you also need to
+## set kube_feature_gates to DevicePlugins=true and install the nvidia device plugin
+## daemoneset for k8s: https://github.com/NVIDIA/k8s-device-plugin
+#docker_nvidia_enabled: true
+
 # Uncomment this if you have more than 3 nameservers, then we'll only use the first 3.
 #docker_dns_servers_strict: false
 

--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -18,3 +18,8 @@ docker_rh_repo_base_url: 'https://yum.dockerproject.org/repo/main/centos/7'
 docker_rh_repo_gpgkey: 'https://yum.dockerproject.org/gpg'
 docker_apt_repo_base_url: 'https://apt.dockerproject.org/repo'
 docker_apt_repo_gpgkey: 'https://apt.dockerproject.org/gpg'
+
+docker_nvidia_version: 2.0.1
+docker_nvidia_container_runtime_version: 1.1.0
+docker_nvidia_apt_repo_gpgkey: 'https://nvidia.github.io/nvidia-docker/gpgkey'
+docker_nvidia_apt_repo_url: 'https://nvidia.github.io/nvidia-docker/ubuntu16.04/amd64/nvidia-docker.list'

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -20,6 +20,11 @@
   tags:
     - facts
 
+- include: set_facts_runtime.yml
+  when: docker_nvidia_enabled
+  tags:
+    - facts
+
 - name: check for minimum kernel version
   fail:
     msg: >
@@ -70,6 +75,10 @@
   with_items: "{{ docker_package_info.pkgs }}"
   notify: restart docker
   when: not (ansible_os_family in ["CoreOS", "Container Linux by CoreOS"] or is_atomic) and (docker_package_info.pkgs|length > 0)
+
+- name: Enabling nvidia docker support
+  include: nvidia.yml
+  when: docker_nvidia_enabled
 
 - name: flush handlers so we can wait for docker to come up
   meta: flush_handlers

--- a/roles/docker/tasks/nvidia.yml
+++ b/roles/docker/tasks/nvidia.yml
@@ -1,0 +1,36 @@
+---
+- name: ensure docker nvidia repository public key is installed
+  action: "{{ docker_nvidia_repo_key_info.pkg_key }}"
+  args:
+    id: "{{item}}"
+    url: "{{docker_nvidia_repo_key_info.url}}"
+    state: present
+  register: keyserver_task_result
+  until: keyserver_task_result|succeeded
+  retries: 4
+  delay: "{{ retry_stagger | random + 3 }}"
+  with_items: "{{ docker_nvidia_repo_key_info.repo_keys }}"
+  when: not (ansible_os_family in ["CoreOS", "Container Linux by CoreOS"] or is_atomic)
+
+- name: download docker nvidia apt list
+  get_url:
+    url: "{{ docker_nvidia_apt_repo_url }}"
+    dest: "/etc/apt/sources.list.d/nvidia-docker.list"
+  register: result
+
+- name: apt-get update
+  apt: update_cache=yes
+  when: result.changed
+
+- name: ensure docker nvidia packages are installed
+  action: "{{ docker_nvidia_package_info.pkg_mgr }}"
+  args:
+    pkg: "{{item.name}}"
+    force: "{{item.force|default(omit)}}"
+    state: present
+  register: docker_task_result
+  until: docker_task_result|succeeded
+  retries: 4
+  delay: "{{ retry_stagger | random + 3 }}"
+  with_items: "{{ docker_nvidia_package_info.pkgs }}"
+  when: not (ansible_os_family in ["CoreOS", "Container Linux by CoreOS"] or is_atomic) and (docker_nvidia_package_info.pkgs|length > 0)

--- a/roles/docker/tasks/set_facts_runtime.yml
+++ b/roles/docker/tasks/set_facts_runtime.yml
@@ -1,0 +1,8 @@
+---
+- set_fact:
+    docker_options: "{{ docker_options }} --default-runtime=nvidia"
+
+- debug:
+    msg: "docker-nvidia amending {{ docker_package_info }}"
+
+

--- a/roles/docker/vars/ubuntu.yml
+++ b/roles/docker/vars/ubuntu.yml
@@ -8,8 +8,9 @@ docker_versioned_pkg:
   '1.12': docker-engine=1.12.6-0~ubuntu-{{ ansible_distribution_release|lower }}
   '1.13': docker-engine=1.13.1-0~ubuntu-{{ ansible_distribution_release|lower }}
   '17.03': docker-ce=17.03.2~ce-0~ubuntu-{{ ansible_distribution_release|lower }}
-  'stable': docker-ce=17.03.2~ce-0~ubuntu-{{ ansible_distribution_release|lower }}
-  'edge': docker-engine=17.05.0~ce-0~ubuntu-{{ ansible_distribution_release|lower }}
+  '17.06': docker-ce=17.06.2~ce-0~ubuntu
+  'stable': docker-ce=17.06.2~ce-0~ubuntu
+  'edge': docker-engine=17.09.0~ce-0~ubuntu
 
 docker_package_info:
   pkg_mgr: apt
@@ -30,3 +31,19 @@ docker_repo_info:
        deb {{ docker_apt_repo_base_url }}
        {{ ansible_distribution|lower }}-{{ ansible_distribution_release|lower }}
        main
+
+docker_nvidia_docker_version: 17.06.2
+
+docker_nvidia_repo_key_info:
+  pkg_key: apt_key
+  url: '{{ docker_nvidia_apt_repo_gpgkey }}'
+  repo_keys:
+    - C95B321B61E88C1809C4F759DDCAE044F796ECB0
+
+docker_nvidia_package_info:
+  pkg_mgr: apt
+  pkgs:
+    - name: "nvidia-container-runtime={{ docker_nvidia_container_runtime_version }}+docker{{ docker_nvidia_docker_version }}-1"
+      force: yes
+    - name: "nvidia-docker2={{ docker_nvidia_version }}+docker{{ docker_nvidia_docker_version }}-1"
+      force: yes

--- a/roles/docker/vars/ubuntu.yml
+++ b/roles/docker/vars/ubuntu.yml
@@ -7,8 +7,8 @@ docker_versioned_pkg:
   '1.11': docker-engine=1.11.1-0~{{ ansible_distribution_release|lower }}
   '1.12': docker-engine=1.12.6-0~ubuntu-{{ ansible_distribution_release|lower }}
   '1.13': docker-engine=1.13.1-0~ubuntu-{{ ansible_distribution_release|lower }}
-  '17.03': docker-engine=17.03.1~ce-0~ubuntu-{{ ansible_distribution_release|lower }}
-  'stable': docker-engine=17.03.1~ce-0~ubuntu-{{ ansible_distribution_release|lower }}
+  '17.03': docker-ce=17.03.2~ce-0~ubuntu-{{ ansible_distribution_release|lower }}
+  'stable': docker-ce=17.03.2~ce-0~ubuntu-{{ ansible_distribution_release|lower }}
   'edge': docker-engine=17.05.0~ce-0~ubuntu-{{ ansible_distribution_release|lower }}
 
 docker_package_info:


### PR DESCRIPTION
This is still work in progress and is only tested on ubuntu.

Note that we need to switch to the new docker-ce apt repo.

Config options:
- docker_nvidia_enabled

Todo:
- [ ] Update docker-ce apt source
- [ ] Install nvidia driver (>=384)
- [x] Install nvidia-docker2 nvidia-container-runtime
- [ ] Enable DevicePlugins for kube_feature_gates
- [ ] Install nvidia-device-plugin to k8s
- [ ] Verify node capability

Closes #2079