### PR TITLE
Fix spelling mistakes in group_vars

### DIFF
--- a/inventory/group_vars/k8s-cluster.yml
+++ b/inventory/group_vars/k8s-cluster.yml
@@ -176,9 +176,9 @@ persistent_volumes_enabled: false
 # kubelet_cgroups_per_qos: true
 
 # A comma separated list of levels of node allocatable enforcement to be enforced by kubelet.
-# Acceptible options are 'pods', 'system-reserved', 'kube-reserved' and ''. Default is "".
+# Acceptable options are 'pods', 'system-reserved', 'kube-reserved' and ''. Default is "".
 # kubelet_enforce_node_allocatable: pods
 
 ## Supplementary addresses that can be added in kubernetes ssl keys.
-## That can be usefull for example to setup a keepalived virtual IP
+## That can be useful for example to setup a keepalived virtual IP
 # supplementary_addresses_in_ssl_keys: [10.0.0.1, 10.0.0.2, 10.0.0.3]


### PR DESCRIPTION
Closes https://github.com/kubernetes-incubator/kubespray/issues/2165

Fixes the spelling mistakes in https://github.com/kubernetes-incubator/kubespray/blob/master/inventory/group_vars/k8s-cluster.yml