### PR TITLE
Add lib/modules to kube-proxy to enable LVS

### DIFF
--- a/roles/kubernetes/node/templates/manifests/kube-proxy.manifest.j2
+++ b/roles/kubernetes/node/templates/manifests/kube-proxy.manifest.j2
@@ -49,6 +49,9 @@ spec:
     - mountPath: /var/run/dbus
       name: var-run-dbus
       readOnly: false
+    - mountPath: /lib/modules
+      name: lib-modules
+      readOnly: true
   volumes:
   - name: ssl-certs-host
     hostPath:
@@ -66,3 +69,6 @@ spec:
   - name: var-run-dbus
     hostPath:
       path: /var/run/dbus
+  - hostPath:
+      path: /lib/modules
+    name: lib-modules


### PR DESCRIPTION
kube-proxy is complaining of missing modules at startup. There is a plan
to also support an LVS implementation of kube-proxy in additon to
userspace and iptables