### PR TITLE
etcd: ability to enable/disable ETCD_PEER_CLIENT_CERT_AUTH

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -20,6 +20,10 @@ bin_dir: /usr/local/bin
 ## This may be the case if clients support and loadbalance multiple etcd servers  natively.
 #etcd_multiaccess: true
 
+### ETCD: disable peer client cert authentication.
+# This affects ETCD_PEER_CLIENT_CERT_AUTH variable
+#etcd_peer_client_auth: true
+
 ## External LB example config
 ## apiserver_loadbalancer_domain_name: "elb.some.domain"
 #loadbalancer_apiserver:

--- a/roles/etcd/defaults/main.yml
+++ b/roles/etcd/defaults/main.yml
@@ -40,3 +40,6 @@ etcd_vault_mount_path: etcd
 
 # Force clients like etcdctl to use TLS certs (different than peer security)
 etcd_secure_client: true
+
+# Enable peer client cert authentication
+etcd_peer_client_auth: true

--- a/roles/etcd/templates/etcd.env.j2
+++ b/roles/etcd/templates/etcd.env.j2
@@ -23,4 +23,4 @@ ETCD_CLIENT_CERT_AUTH={{ etcd_secure_client | lower}}
 ETCD_PEER_TRUSTED_CA_FILE={{ etcd_cert_dir }}/ca.pem
 ETCD_PEER_CERT_FILE={{ etcd_cert_dir }}/member-{{ inventory_hostname }}.pem
 ETCD_PEER_KEY_FILE={{ etcd_cert_dir }}/member-{{ inventory_hostname }}-key.pem
-ETCD_PEER_CLIENT_CERT_AUTH=true
+ETCD_PEER_CLIENT_CERT_AUTH={{ etcd_peer_client_auth }}


### PR DESCRIPTION
Some installation are failing to authenticate with peers due to
etcd picking up/resoling the wrong node.

By setting 'etcd_peer_client_auth' to "False" you can disable peer client cert
authentication.

Signed-off-by: Sébastien Han <seb@redhat.com>