### PR TITLE
Dnsmasq autoscaler image should be a variable

### DIFF
--- a/roles/dnsmasq/templates/dnsmasq-autoscaler.yml.j2
+++ b/roles/dnsmasq/templates/dnsmasq-autoscaler.yml.j2
@@ -39,7 +39,7 @@ spec:
           operator: Exists
       containers:
         - name: autoscaler
-          image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.1.1
+          image: "{{ dnsmasqautoscaler_image_repo }}:{{ dnsmasqautoscaler_image_tag }}"
           resources:
             requests:
               cpu: "20m"

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -101,6 +101,9 @@ dnsmasq_nanny_image_repo: "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64"
 dnsmasq_nanny_image_tag: "{{ kubedns_version }}"
 dnsmasq_sidecar_image_repo: "gcr.io/google_containers/k8s-dns-sidecar-amd64"
 dnsmasq_sidecar_image_tag: "{{ kubedns_version }}"
+dnsmasqautoscaler_version: 1.1.1
+dnsmasqautoscaler_image_repo: "gcr.io/google_containers/cluster-proportional-autoscaler-amd64"
+dnsmasqautoscaler_image_tag: "{{ dnsmasqautoscaler_version }}"
 kubednsautoscaler_version: 1.1.1
 kubednsautoscaler_image_repo: "gcr.io/google_containers/cluster-proportional-autoscaler-amd64"
 kubednsautoscaler_image_tag: "{{ kubednsautoscaler_version }}"


### PR DESCRIPTION
I need to override docker registries URLs (no internet access). All other used images references have variables for repo and tag except dnsmasq-autoscaler.yml.j2.