### PR TITLE
iptables: flush nat table as well as filter table upon reset

### DIFF
--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -72,7 +72,11 @@
 
 - name: flush iptables
   iptables:
+    table: "{{ item }}"
     flush: yes
+ with_items:
+    - filter
+    - nat
   when: flush_iptables|bool
   tags:
     - iptables

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -74,7 +74,7 @@
   iptables:
     table: "{{ item }}"
     flush: yes
- with_items:
+  with_items:
     - filter
     - nat
   when: flush_iptables|bool


### PR DESCRIPTION
Default table in ansible's iptables module's flush parameter is filter.
Nat table should be purged as well.