### PR TITLE
make docker installation optional

### DIFF
--- a/cluster.yml
+++ b/cluster.yml
@@ -27,7 +27,7 @@
   roles:
     - { role: kubespray-defaults}
     - { role: kubernetes/preinstall, tags: preinstall }
-    - { role: docker, tags: docker }
+    - { role: docker, tags: docker, when: "docker_enabled | default(true)" }
     - role: rkt
       tags: rkt
       when: "'rkt' in [etcd_deployment_type, kubelet_deployment_type, vault_deployment_type]"

--- a/inventory/group_vars/k8s-cluster.yml
+++ b/inventory/group_vars/k8s-cluster.yml
@@ -143,6 +143,9 @@ helm_deployment_type: host
 # K8s image pull policy (imagePullPolicy)
 k8s_image_pull_policy: IfNotPresent
 
+# Install/upgrade docker
+docker_enabled: true
+
 # Kubernetes dashboard
 # RBAC required. see docs/getting-started.md for access details.
 dashboard_enabled: true


### PR DESCRIPTION
Allow it to be installed and configured prior to running kubespray

Our motivation is installing nvidia-docker2, but there are probably others.