### PR TITLE
new parameter: supplementary_names_in_ssl_keys

### DIFF
--- a/inventory/group_vars/k8s-cluster.yml
+++ b/inventory/group_vars/k8s-cluster.yml
@@ -182,3 +182,7 @@ persistent_volumes_enabled: false
 ## Supplementary addresses that can be added in kubernetes ssl keys.
 ## That can be useful for example to setup a keepalived virtual IP
 # supplementary_addresses_in_ssl_keys: [10.0.0.1, 10.0.0.2, 10.0.0.3]
+
+## Supplementary names that can be added in kubernetes ssl keys.
+## That can be usefull for example to setup external named load balancers and/or failovers
+# supplementary_names_in_ssl_keys: ['kubernertes.example.com']

--- a/roles/kubernetes/master/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-setup.yml
@@ -59,6 +59,11 @@
       {{ addr }}
       {%- endfor %}
       {%- endif %}
+      {%- if supplementary_names_in_ssl_keys is defined %}
+      {%- for addr in supplementary_names_in_ssl_keys %}
+      {{ addr }}
+      {%- endfor %}
+      {%- endif %}
   tags: facts
 
 - name: kubeadm | Copy etcd cert dir under k8s cert dir

--- a/roles/kubernetes/secrets/templates/openssl.conf.j2
+++ b/roles/kubernetes/secrets/templates/openssl.conf.j2
@@ -15,8 +15,11 @@ DNS.5 = localhost
 {% for host in groups['kube-master'] %}
 DNS.{{ 5 + loop.index }} = {{ host }}
 {% endfor %}
+{% for host in supplementary_names_in_ssl_keys|default([]) %}
+DNS.{{ (groups['kube-master'] | length | int + 5 + loop.index) | string }} = {{ host }}
+{% endfor %}
 {% if loadbalancer_apiserver is defined  %}
-{% set idx =  groups['kube-master'] | length | int + 5 + 1 %}
+{% set idx =  groups['kube-master'] | length | int + supplementary_names_in_ssl_keys | default([]) | length | int + 5 + 1 %}
 DNS.{{ idx | string }} = {{ apiserver_loadbalancer_domain_name }}
 {% endif %}
 {% for host in groups['kube-master'] %}


### PR DESCRIPTION
Allows us to use external load balancers in front of the api server