### PR TITLE
Adding support to vagrant-libvirt centos image as per issue #2180

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -122,6 +122,7 @@ Vagrant.configure("2") do |config|
 
      config.vm.provider :libvirt do |lv|
        lv.memory = $vm_memory
+       lv.cpus = $vm_cpus
      end
 
       ip = "#{$subnet}.#{i+100}"


### PR DESCRIPTION
Hi there I'm requesting this pull request for adding support to vagrant-libvirt and running centos image.

I've created a dedicated centos-libvirt format for avoiding breaking old setup.

In my setup I had also to change subnet in the vagrant file because it's overlapping with the docker one that my machine is using. May I propose to update the documentation somewhere for reporting it?

Thanks