### PR TITLE
Update comment about max nodes

### DIFF
--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -99,7 +99,7 @@ kube_pods_subnet: 10.233.64.0/18
 
 # internal network node size allocation (optional). This is the size allocated
 # to each node on your network.  With these defaults you should have
-# room for 4096 nodes with 254 pods per node.
+# room for 64 nodes with 254 pods per node.
 kube_network_node_prefix: 24
 
 # The virtual cluster IP, real host IPs and ports the API Server will be


### PR DESCRIPTION
kube_pods_subnet defaults to /18 and kube_network_node_prefix to /24. I count 64 /24 in a /18.
