### PR TITLE
Remove "-" from etcd openssl.conf

### DIFF
--- a/roles/etcd/templates/openssl.conf.j2
+++ b/roles/etcd/templates/openssl.conf.j2
@@ -32,9 +32,9 @@ DNS.{{ 1 + loop.index }} = {{ host }}
 DNS.{{ idx | string }} = {{ apiserver_loadbalancer_domain_name }}
 {% endif %}
 {% set idx =  groups['etcd'] | length | int + 3 %}
-{%- for etcd_alt_name in etcd_cert_alt_names -%}
+{% for etcd_alt_name in etcd_cert_alt_names %}
 DNS.{{ idx + 1 + loop.index }} = {{ etcd_alt_name }}
-{%- endfor -%}
+{% endfor %}
 {% for host in groups['etcd'] %}
 IP.{{ 2 * loop.index - 1 }} = {{ hostvars[host]['access_ip'] | default(hostvars[host]['ansible_default_ipv4']['address']) }}
 IP.{{ 2 * loop.index }} = {{ hostvars[host]['ip'] | default(hostvars[host]['ansible_default_ipv4']['address']) }}


### PR DESCRIPTION
Templated .conf file was missing newlines causing certs to be generated with
incorrectly formatted subject alternative names.