### PR TITLE
Support ipvs mode for kube-proxy

### DIFF
--- a/inventory/group_vars/k8s-cluster.yml
+++ b/inventory/group_vars/k8s-cluster.yml
@@ -109,6 +109,10 @@ kube_apiserver_insecure_port: 8080 # (http)
 # Set to 0 to disable insecure port - Requires RBAC in authorization_modes and kube_api_anonymous_auth: true
 #kube_apiserver_insecure_port: 0 # (disabled)
 
+# Kube-proxy proxyMode configuration.
+# Can be ipvs, iptables
+kube_proxy_mode: iptables 
+
 # DNS configuration.
 # Kubernetes cluster name, also will be used as DNS domain
 cluster_name: cluster.local

--- a/roles/kubernetes/master/templates/kubeadm-config.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.yaml.j2
@@ -19,6 +19,12 @@ kubernetesVersion: {{ kube_version }}
 {% if cloud_provider is defined and cloud_provider != "gce" %}
 cloudProvider: {{ cloud_provider }}
 {% endif %}
+{% if kube_proxy_mode == 'ipvs' %}
+kubeProxy:
+  config:
+    featureGates: SupportIPVSProxyMode=true
+    mode: ipvs
+{% endif %}
 authorizationModes:
 {% for mode in authorization_modes %}
 - {{ mode }}

--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -14,6 +14,7 @@ kubelet_bind_address: "{{ ip | default('0.0.0.0') }}"
 # resolv.conf to base dns config
 kube_resolv_conf: "/etc/resolv.conf"
 
+# Can be ipvs, iptables
 kube_proxy_mode: iptables
 
 # If using the pure iptables proxy, SNAT everything. Note that it breaks any

--- a/roles/kubernetes/node/tasks/main.yml
+++ b/roles/kubernetes/node/tasks/main.yml
@@ -104,6 +104,20 @@
     - net.bridge.bridge-nf-call-arptables
     - net.bridge.bridge-nf-call-ip6tables
 
+- name: Modprode Kernel Module for IPVS
+  modprobe:
+    name: "{{ item }}"
+    state: present
+  when: kube_proxy_mode == 'ipvs'
+  with_items:
+    - ip_vs
+    - ip_vs_rr
+    - ip_vs_wrr
+    - ip_vs_sh
+    - nf_conntrack_ipv4
+  tags:
+    - kube-proxy
+
 - name: Write proxy manifest
   template:
     src: manifests/kube-proxy.manifest.j2

--- a/roles/kubernetes/node/templates/manifests/kube-proxy.manifest.j2
+++ b/roles/kubernetes/node/templates/manifests/kube-proxy.manifest.j2
@@ -33,6 +33,13 @@ spec:
     - --proxy-mode={{ kube_proxy_mode }}
 {% if kube_proxy_masquerade_all and kube_proxy_mode == "iptables" %}
     - --masquerade-all
+{% elif kube_proxy_mode == 'ipvs' %}
+    - --masquerade-all
+    - --feature-gates=SupportIPVSProxyMode=true
+    - --proxy-mode=ipvs
+    - --ipvs-min-sync-period=5s
+    - --ipvs-sync-period=5s
+    - --ipvs-scheduler=rr
 {% endif %}
     securityContext:
       privileged: true


### PR DESCRIPTION
Support ipvs mode for kube-proxy

PVS vs. IPTables Latency to Add Rules
Measured by iptables and ipvsadm, observation:
In iptables mode, latency to add rules increase significantly when number of service increases
In IPVS mode, latency to add VIP and backend IPs does not increase when number of service increases