### PR TITLE
customization: allow to pass extra options to docker

### DIFF
--- a/docs/vars.md
+++ b/docs/vars.md
@@ -100,8 +100,11 @@ Stack](https://github.com/kubernetes-incubator/kubespray/blob/master/docs/dns-st
 
 #### Other service variables
 
-* *docker_options* - Commonly used to set
-  ``--insecure-registry=myregistry.mydomain:5000``
+* *docker_options* - Explicit list of dockerd's options. In most cases you should not change that.
+  
+* *docker_extra_opts* - Append extra options to ``docker_extra_opts``. Commonly
+  used to set ``--insecure-registry=myregistry.mydomain:5000``
+
 * *http_proxy/https_proxy/no_proxy* - Proxy variables for deploying behind a
   proxy. Note that no_proxy defaults to all internal cluster IPs and hostnames
   that correspond to each node.

--- a/inventory/group_vars/k8s-cluster.yml
+++ b/inventory/group_vars/k8s-cluster.yml
@@ -135,8 +135,7 @@ docker_daemon_graph: "/var/lib/docker"
 ## This string should be exactly as you wish it to appear.
 ## An obvious use case is allowing insecure-registry access
 ## to self hosted registries like so:
-
-docker_options: "--insecure-registry={{ kube_service_addresses }} --graph={{ docker_daemon_graph }}  {{ docker_log_opts }}"
+docker_options: "--insecure-registry={{ kube_service_addresses }} --graph={{ docker_daemon_graph }}  {{ docker_log_opts }} {{ docker_extra_opts }}"
 docker_bin_dir: "/usr/bin"
 
 # Settings for containerized control plane (etcd/kubelet/secrets)

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -129,11 +129,14 @@ docker_daemon_graph: "/var/lib/docker"
 # Rotate container stderr/stdout logs at 50m and keep last 5
 docker_log_opts: "--log-opt max-size=50m --log-opt max-file=5"
 
+# Extra docker options appended to docker_options
+docker_extra_opts: ""
+
 ## A string of extra options to pass to the docker daemon.
 ## This string should be exactly as you wish it to appear.
 ## An obvious use case is allowing insecure-registry access
 ## to self hosted registries like so:
-docker_options: "--insecure-registry={{ kube_service_addresses }} --graph={{ docker_daemon_graph }} {{ docker_log_opts }}"
+docker_options: "--insecure-registry={{ kube_service_addresses }} --graph={{ docker_daemon_graph }} {{ docker_log_opts }} {{ docker_extra_opts }}"
 
 # Settings for containerized control plane (etcd/kubelet/secrets)
 etcd_deployment_type: docker


### PR DESCRIPTION
In most cases generated 'docker_options' has sane value, but if one want to
add something he should copy whole generation logic. Which is suboptimal.
and error prone.