### PR TITLE
Rename default_resolver to cloud_resolver

### DIFF
--- a/roles/kubernetes/preinstall/handlers/main.yml
+++ b/roles/kubernetes/preinstall/handlers/main.yml
@@ -5,7 +5,9 @@
     - Preinstall | reload network
     - Preinstall | reload kubelet
     - Preinstall | kube-controller configured
+    - Preinstall | kube-apiserver configured
     - Preinstall | restart kube-controller-manager
+    - Preinstall | restart kube-apiserver
   when: not ansible_os_family in ["CoreOS", "Container Linux by CoreOS"]
 
   # FIXME(bogdando) https://github.com/projectcalico/felix/issues/1185
@@ -37,14 +39,27 @@
     state: restarted
   notify:
     - Preinstall | kube-controller configured
+    - Preinstall | kube-apiserver configured
     - Preinstall | restart kube-controller-manager
+    - Preinstall | restart kube-apiserver
   when: not dns_early|bool
 
+# FIXME(mattymo): Also restart for kubeadm mode
+- name: Preinstall | kube-apiserver configured
+  stat: path="{{ kube_manifest_dir }}/kube-apiserver.manifest"
+  register: kube_apiserver_set
+  when: inventory_hostname in groups['kube-master'] and dns_mode != 'none' and resolvconf_mode == 'host_resolvconf'
+
+# FIXME(mattymo): Also restart for kubeadm mode
 - name: Preinstall | kube-controller configured
   stat: path="{{ kube_manifest_dir }}/kube-controller-manager.manifest"
   register: kube_controller_set
   when: inventory_hostname in groups['kube-master'] and dns_mode != 'none' and resolvconf_mode == 'host_resolvconf'
 
 - name: Preinstall | restart kube-controller-manager
-  shell: "docker ps -f name=k8s_kube-controller-manager* -q | xargs --no-run-if-empty docker rm -f"
+  shell: "docker ps -f name=k8s_POD_kube-controller-manager* -q | xargs --no-run-if-empty docker rm -f"
   when: inventory_hostname in groups['kube-master'] and dns_mode != 'none' and resolvconf_mode == 'host_resolvconf' and kube_controller_set.stat.exists
+
+- name: Preinstall | restart kube-apiserver
+  shell: "docker ps -f name=k8s_POD_kube-apiserver* -q | xargs --no-run-if-empty docker rm -f"
+  when: inventory_hostname in groups['kube-master'] and dns_mode != 'none' and resolvconf_mode == 'host_resolvconf'

--- a/roles/kubernetes/preinstall/tasks/set_resolv_facts.yml
+++ b/roles/kubernetes/preinstall/tasks/set_resolv_facts.yml
@@ -15,13 +15,13 @@
       {% for d in [ 'default.svc.' + dns_domain, 'svc.' + dns_domain ] + searchdomains|default([]) -%}
       {{dns_domain}}.{{d}}./{{d}}.{{d}}./com.{{d}}./
       {%- endfor %}
-    default_resolver: >-
+    cloud_resolver: >-
       {%- if cloud_provider is defined and cloud_provider == 'gce' -%}
-        169.254.169.254
+        ['169.254.169.254']
       {%- elif cloud_provider is defined and cloud_provider == 'aws' -%}
-        169.254.169.253
+        ['169.254.169.253']
       {%- else -%}
-        8.8.8.8
+        []
       {%- endif -%}
 
 - name: check if kubelet is configured
@@ -106,6 +106,6 @@
 - name: generate nameservers to resolvconf
   set_fact:
     nameserverentries:
-      nameserver {{( dnsmasq_server + nameservers|default([default_resolver])) | join(',nameserver ')}}
+      nameserver {{( dnsmasq_server + nameservers|d([]) + cloud_resolver|d([])) | join(',nameserver ')}}
     supersede_nameserver:
-      supersede domain-name-servers {{( dnsmasq_server + nameservers|default([default_resolver])) | join(', ') }};
+      supersede domain-name-servers {{( dnsmasq_server + nameservers|d([]) + cloud_resolver|d([])) | join(', ') }};


### PR DESCRIPTION
Cloud resolvers are mandatory for hosts on GCE and OpenStack
clouds. The 8.8.8.8 alternative resolver was dropped because
there is already a default nameserver. The new var name
reflects the purpose better.