### PR TITLE
Update weave ClusterRole

### DIFF
--- a/roles/network_plugin/weave/templates/weave-net.yml.j2
+++ b/roles/network_plugin/weave/templates/weave-net.yml.j2
@@ -27,7 +27,7 @@ items:
           - list
           - watch
       - apiGroups:
-          - extensions
+          - networking.k8s.io
         resources:
           - networkpolicies
         verbs:


### PR DESCRIPTION
The 2.1.3 which is currently fetched has a fix for Kubernetes 1.7, 1.8 and 1.9 that adds an access to networkpolicies from the networking.k8s.io API group used by the 'v1' policies when using RBAC

See more at https://github.com/weaveworks/weave/releases/tag/v2.1.3