### PR TITLE
Loadbalancer Apiserver Address is missing

### DIFF
--- a/roles/kubernetes/secrets/templates/openssl.conf.j2
+++ b/roles/kubernetes/secrets/templates/openssl.conf.j2
@@ -25,6 +25,9 @@ IP.{{ 2 * loop.index }} = {{ hostvars[host]['ip'] | default(hostvars[host]['ansi
 {% endfor %}
 {% set idx =  groups['kube-master'] | length | int * 2 + 1 %}
 IP.{{ idx }} = {{ kube_apiserver_ip }}
+{% if loadbalancer_apiserver is defined  %}
+IP.{{ idx + 1 }} = {{ loadbalancer_apiserver.address }}
+{% endif %}
 IP.{{ idx + 1 }} = 127.0.0.1
 {% if supplementary_addresses_in_ssl_keys is defined %}
 {% set is = idx + 1 %}

--- a/roles/kubernetes/secrets/templates/openssl.conf.j2
+++ b/roles/kubernetes/secrets/templates/openssl.conf.j2
@@ -27,6 +27,7 @@ IP.{{ 2 * loop.index }} = {{ hostvars[host]['ip'] | default(hostvars[host]['ansi
 IP.{{ idx }} = {{ kube_apiserver_ip }}
 {% if loadbalancer_apiserver is defined  %}
 IP.{{ idx + 1 }} = {{ loadbalancer_apiserver.address }}
+{% set idx = idx + 1 %}
 {% endif %}
 IP.{{ idx + 1 }} = 127.0.0.1
 {% if supplementary_addresses_in_ssl_keys is defined %}


### PR DESCRIPTION
If you configure your external loadbalancer to do a simple tcp pass-through to the api servers, and you do not use a DNS FQDN but just the ip, then you need to add the ip adress to the certificates too.

Example config:

```
## External LB example config
apiserver_loadbalancer_domain_name: "10.50.63.10"
loadbalancer_apiserver:
  address: 10.50.63.10
  port: 8383
```