### PR TITLE
Option to launch Dashboard as insecure (to use it with reverse proxy)

### DIFF
--- a/roles/kubernetes-apps/ansible/defaults/main.yml
+++ b/roles/kubernetes-apps/ansible/defaults/main.yml
@@ -40,6 +40,7 @@ netchecker_server_memory_requests: 64M
 
 # Dashboard
 dashboard_enabled: true
+dashboard_enable_insecure_port: false
 dashboard_image_repo: gcr.io/google_containers/kubernetes-dashboard-amd64
 dashboard_image_tag: v1.8.1
 dashboard_init_image_repo: gcr.io/google_containers/kubernetes-dashboard-init-amd64

--- a/roles/kubernetes-apps/ansible/templates/dashboard.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/dashboard.yml.j2
@@ -152,14 +152,23 @@ spec:
             cpu: {{ dashboard_cpu_requests }}
             memory: {{ dashboard_memory_requests }}
         ports:
+{% if dashboard_enable_insecure_port %}
+        - containerPort: 9090
+          protocol: TCP
+{% else %}
         - containerPort: 8443
           protocol: TCP
+{% endif %}
         args:
+{% if dashboard_enable_insecure_port %}
+          - --enable-insecure-login
+{% else  %}
 {% if dashboard_use_custom_certs %}
           - --tls-key-file={{ dashboard_tls_key_file }}
           - --tls-cert-file={{ dashboard_tls_cert_file }}
 {% else %}
           - --auto-generate-certificates
+{% endif %}
 {% endif %}
           - --authentication-mode=token{% if kube_basic_auth|default(false) %},basic{% endif %}
           # Uncomment the following line to manually specify Kubernetes API server Host
@@ -174,9 +183,15 @@ spec:
           name: tmp-volume
         livenessProbe:
           httpGet:
+{% if dashboard_enable_insecure_port %}
+            scheme: HTTP
+            path: /
+            port: 9090
+{% else %}
             scheme: HTTPS
             path: /
             port: 8443
+{% endif %}
           initialDelaySeconds: 30
           timeoutSeconds: 30
       volumes:
@@ -203,7 +218,11 @@ metadata:
   namespace: {{ system_namespace }}
 spec:
   ports:
+{% if dashboard_enable_insecure_port %}
+    - port: 9090
+{% else %}
     - port: 443
       targetPort: 8443
+{% endif %}
   selector:
     k8s-app: kubernetes-dashboard


### PR DESCRIPTION
As stated in issues on kubernetes/dashboard like https://github.com/kubernetes/dashboard/issues/2469, the suggested dashboard setup does not allow for reverse-proxy configurations.

This PR allows you to use `dashboard_enable_insecure_port` to disable certificate generation, and use standard `9090` insecure port.

Enabling this:
 - You cannot access dashboard this way `https://first_master:6443/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/#!/login`
 - It is possible to configure an Ingress forwarding service `kubernetes-dashboard` on port `9090`

`ingress-nginx` example:
```yaml
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: kubernetes-dashboard
  namespace: kube-system
  annotations:
    kubernetes.io/tls-acme: "true"
    kubernetes.io/ingress.class: "nginx"
spec:
  tls:
  - hosts:
    # CHANGE ME
    - my.favourite.server
    secretName: dashboard-tls
  rules:
  - host: my.favourite.server
    http:
      paths:
      - path: /
        backend:
          serviceName: kubernetes-dashboard
          servicePort: 9090
``` 