### PR TITLE
Enable additional addresses to be added to certificates

### DIFF
--- a/roles/kubernetes/secrets/templates/openssl.conf.j2
+++ b/roles/kubernetes/secrets/templates/openssl.conf.j2
@@ -29,6 +29,10 @@ IP.{{ idx + 1 }} = 127.0.0.1
 {% if supplementary_addresses_in_ssl_keys is defined %}
 {% set is = idx + 1 %}
 {% for addr in supplementary_addresses_in_ssl_keys %}
+{% if addr | ipaddr %}
 IP.{{ is + loop.index }} = {{ addr }}
+{% else %}
+DNS.{{ is + loop.index }} = {{ addr }}
+{% endif %}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
https://github.com/kubernetes-incubator/kubespray/pull/1678 added the ability to insert more ip addresses in certificates.

This PR extends that to enable additional addresses to be added to certificates.

One use-case supported by this is to connect to the Kubernetes API without a load-balancer by using a fixed hostname instead of the IP of a node.

The `ipaddr` filter is used so the existing `supplementary_addresses_in_ssl_keys` variable can be used for IPs and hostnames instead of creating a second variable.