### PR TITLE
--etcd-quorum-read is depricated in kube >= 1.9

### DIFF
--- a/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
@@ -30,7 +30,9 @@ spec:
     - apiserver
     - --advertise-address={{ ip | default(ansible_default_ipv4.address) }}
     - --etcd-servers={{ etcd_access_addresses }}
+{%   if kube_version | version_compare('v1.9', '<')  %}
     - --etcd-quorum-read=true
+{% endif %}
     - --etcd-cafile={{ etcd_cert_dir }}/ca.pem
     - --etcd-certfile={{ etcd_cert_dir }}/node-{{ inventory_hostname }}.pem
     - --etcd-keyfile={{ etcd_cert_dir }}/node-{{ inventory_hostname }}-key.pem


### PR DESCRIPTION
Only set --etcd-quorum-read if deploying kubernetes version less than 1.9, this now defaults to true and is not tunable. 

https://github.com/kubernetes/kubernetes/pull/53795