### PR TITLE
Add cephfs_provisioner Support for Kubespray

### DIFF
--- a/extra_playbooks/build-cephfs-provisioner.yml
+++ b/extra_playbooks/build-cephfs-provisioner.yml
@@ -1,0 +1,54 @@
+---
+
+- hosts: localhost
+  tasks:
+    - name: CephFS Provisioner | Install pip packages
+      pip:
+        name: "{{ item.name }}"
+        version: "{{ item.version }}"
+        state: "{{ item.state }}"
+      with_items:
+        - { state: "present", name: "docker", version: "2.7.0" }
+        - { state: "present", name: "docker-compose", version: "1.18.0" }
+
+    - name: CephFS Provisioner | Check Go version
+      shell: |
+        go version
+      ignore_errors: yes
+      register: go_version_result
+
+    - name: CephFS Provisioner | Install Go 1.9
+      shell: |
+        add-apt-repository -y ppa:gophers/archive
+        apt-get update
+        apt-get install -y golang-1.9
+        ln -fs /usr/lib/go-1.9/bin/* /usr/local/bin/
+      when: 'go_version_result.rc != 0 or "go version go1.9" not in go_version_result.stdout'
+
+    - name: CephFS Provisioner | Check if image exists
+      shell: |
+        docker image list | grep 'cephfs-provisioner'
+      ignore_errors: yes
+      register: check_image_result
+
+    - block:
+        - name: CephFS Provisioner | Clone repo
+          git:
+            repo: https://github.com/kubernetes-incubator/external-storage.git
+            dest: "~/go/src/github.com/kubernetes-incubator"
+            version: 92295a30
+            clone: no
+            update: yes
+            
+        - name: CephFS Provisioner | Build image
+          shell: |
+            cd ~/go/src/github.com/kubernetes-incubator/external-storage
+            REGISTRY=quay.io/kubespray/ VERSION=92295a30 make ceph/cephfs
+
+        - name: CephFS Provisioner | Push image
+          docker_image:
+            name: quay.io/kubespray/cephfs-provisioner:92295a30
+            push: yes
+          retries: 10
+
+      when: check_image_result.rc != 0

--- a/inventory/sample/group_vars/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s-cluster.yml
@@ -173,6 +173,17 @@ registry_enabled: false
 local_volumes_enabled: false
 local_volume_provisioner_enabled: "{{ local_volumes_enabled }}"
 
+# CephFS provisioner deployment
+cephfs_provisioner_enabled: false
+# cephfs_provisioner_namespace: "{{ system_namespace }}"
+# cephfs_provisioner_cluster: ceph
+# cephfs_provisioner_monitors:
+#   - 172.24.0.1:6789
+#   - 172.24.0.2:6789
+#   - 172.24.0.3:6789
+# cephfs_provisioner_admin_id: admin
+# cephfs_provisioner_secret: secret
+
 # Add Persistent Volumes Storage Class for corresponding cloud provider ( OpenStack is only supported now )
 persistent_volumes_enabled: false
 

--- a/roles/kubernetes-apps/cephfs_provisioner/defaults/main.yml
+++ b/roles/kubernetes-apps/cephfs_provisioner/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+cephfs_provisioner_image_repo: quay.io/kubespray/cephfs-provisioner
+cephfs_provisioner_image_tag: 92295a30
+
+cephfs_provisioner_namespace: "{{ system_namespace }}"
+cephfs_provisioner_cluster: ceph
+cephfs_provisioner_monitors: []
+cephfs_provisioner_admin_id: admin
+cephfs_provisioner_secret: secret

--- a/roles/kubernetes-apps/cephfs_provisioner/tasks/main.yml
+++ b/roles/kubernetes-apps/cephfs_provisioner/tasks/main.yml
@@ -1,0 +1,36 @@
+---
+
+- name: CephFS Provisioner | Create addon dir
+  file:
+    path: "{{ kube_config_dir }}/addons/cephfs_provisioner"
+    owner: root
+    group: root
+    mode: 0755
+    recurse: true
+
+- name: CephFS Provisioner | Create manifests
+  template:
+    src: "{{ item.file }}.j2"
+    dest: "{{ kube_config_dir }}/addons/cephfs_provisioner/{{ item.file }}"
+  with_items:
+    - { name: cephfs-provisioner-sa, file: cephfs-provisioner-sa.yml, type: sa }
+    - { name: cephfs-provisioner-role, file: cephfs-provisioner-role.yml, type: role }
+    - { name: cephfs-provisioner-rolebinding, file: cephfs-provisioner-rolebinding.yml, type: rolebinding }
+    - { name: cephfs-provisioner-clusterrole, file: cephfs-provisioner-clusterrole.yml, type: clusterrole }
+    - { name: cephfs-provisioner-clusterrolebinding, file: cephfs-provisioner-clusterrolebinding.yml, type: clusterrolebinding }
+    - { name: cephfs-provisioner-deploy, file: cephfs-provisioner-deploy.yml, type: deploy }
+    - { name: cephfs-provisioner-secret, file: cephfs-provisioner-secret.yml, type: secret }
+    - { name: cephfs-provisioner-sc, file: cephfs-provisioner-sc.yml, type: sc }
+  register: cephfs_manifests
+  when: inventory_hostname == groups['kube-master'][0]
+
+- name: CephFS Provisioner | Apply manifests
+  kube:
+    name: "{{ item.item.name }}"
+    namespace: "{{ system_namespace }}"
+    kubectl: "{{ bin_dir }}/kubectl"
+    resource: "{{ item.item.type }}"
+    filename: "{{ kube_config_dir }}/addons/cephfs_provisioner/{{ item.item.file }}"
+    state: "latest"
+  with_items: "{{ cephfs_manifests.results }}"
+  when: inventory_hostname == groups['kube-master'][0]

--- a/roles/kubernetes-apps/cephfs_provisioner/templates/cephfs-provisioner-clusterrole.yml.j2
+++ b/roles/kubernetes-apps/cephfs_provisioner/templates/cephfs-provisioner-clusterrole.yml.j2
@@ -1,0 +1,22 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cephfs-provisioner
+  namespace: {{ system_namespace }}
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "create", "delete"]

--- a/roles/kubernetes-apps/cephfs_provisioner/templates/cephfs-provisioner-clusterrolebinding.yml.j2
+++ b/roles/kubernetes-apps/cephfs_provisioner/templates/cephfs-provisioner-clusterrolebinding.yml.j2
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cephfs-provisioner
+  namespace: {{ cephfs_provisioner_namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: cephfs-provisioner
+    namespace: {{ cephfs_provisioner_namespace }}
+roleRef:
+  kind: ClusterRole
+  name: cephfs-provisioner
+  apiGroup: rbac.authorization.k8s.io

--- a/roles/kubernetes-apps/cephfs_provisioner/templates/cephfs-provisioner-deploy.yml.j2
+++ b/roles/kubernetes-apps/cephfs_provisioner/templates/cephfs-provisioner-deploy.yml.j2
@@ -1,0 +1,26 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: cephfs-provisioner
+  namespace: {{ cephfs_provisioner_namespace }}
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: cephfs-provisioner
+    spec:
+      containers:
+        - name: cephfs-provisioner
+          image: {{ cephfs_provisioner_image_repo }}:{{ cephfs_provisioner_image_tag }}
+          env:
+            - name: PROVISIONER_NAME
+              value: ceph.com/cephfs
+          command:
+            - "/usr/local/bin/cephfs-provisioner"
+          args:
+            - "-id=cephfs-provisioner-1"
+      serviceAccount: cephfs-provisioner

--- a/roles/kubernetes-apps/cephfs_provisioner/templates/cephfs-provisioner-role.yml.j2
+++ b/roles/kubernetes-apps/cephfs_provisioner/templates/cephfs-provisioner-role.yml.j2
@@ -1,0 +1,10 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cephfs-provisioner
+  namespace: {{ cephfs_provisioner_namespace }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create", "get", "delete"]

--- a/roles/kubernetes-apps/cephfs_provisioner/templates/cephfs-provisioner-rolebinding.yml.j2
+++ b/roles/kubernetes-apps/cephfs_provisioner/templates/cephfs-provisioner-rolebinding.yml.j2
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cephfs-provisioner
+  namespace: {{ cephfs_provisioner_namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: cephfs-provisioner
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cephfs-provisioner

--- a/roles/kubernetes-apps/cephfs_provisioner/templates/cephfs-provisioner-sa.yml.j2
+++ b/roles/kubernetes-apps/cephfs_provisioner/templates/cephfs-provisioner-sa.yml.j2
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cephfs-provisioner
+  namespace: {{ cephfs_provisioner_namespace }}

--- a/roles/kubernetes-apps/cephfs_provisioner/templates/cephfs-provisioner-sc.yml.j2
+++ b/roles/kubernetes-apps/cephfs_provisioner/templates/cephfs-provisioner-sc.yml.j2
@@ -1,0 +1,12 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: cephfs
+provisioner: ceph.com/cephfs
+parameters:
+  cluster: {{ cephfs_provisioner_cluster }}
+  monitors: {{ cephfs_provisioner_monitors | join(',') }}
+  adminId: {{ cephfs_provisioner_admin_id }}
+  adminSecretName: cephfs-provisioner-{{ cephfs_provisioner_admin_id }}-secret
+  adminSecretNamespace: {{ cephfs_provisioner_namespace }}

--- a/roles/kubernetes-apps/cephfs_provisioner/templates/cephfs-provisioner-secret.yml.j2
+++ b/roles/kubernetes-apps/cephfs_provisioner/templates/cephfs-provisioner-secret.yml.j2
@@ -1,0 +1,9 @@
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: cephfs-provisioner-{{ cephfs_provisioner_admin_id }}-secret
+  namespace: {{ cephfs_provisioner_namespace }}
+type: Opaque
+data:
+  secret: {{ cephfs_provisioner_secret | b64encode }}

--- a/roles/kubernetes-apps/meta/main.yml
+++ b/roles/kubernetes-apps/meta/main.yml
@@ -34,6 +34,13 @@ dependencies:
       - local_volume_provisioner
       - storage
 
+  - role: kubernetes-apps/cephfs_provisioner
+    when: cephfs_provisioner_enabled
+    tags:
+      - apps
+      - cephfs_provisioner
+      - storage
+
   # istio role should be last because it takes a long time to initialize and
   # will cause timeouts trying to start other addons.
   - role: kubernetes-apps/istio


### PR DESCRIPTION
This patch clone the architecture from ``roles/kubernetes-apps/local_volume_provisioner``, reference guideline provided from https://github.com/kubernetes-incubator/external-storage/tree/master/ceph/cephfs, and utilize the pre-build image from https://quay.io/repository/external_storage/cephfs-provisioner.

Once deployed user just need to define PVC and use it as per example provided:
* https://github.com/kubernetes-incubator/external-storage/blob/master/ceph/cephfs/example/claim.yaml
* https://github.com/kubernetes-incubator/external-storage/blob/master/ceph/cephfs/example/test-pod.yaml

# Testing Procedures
## Deploy with ``cephfs_provisioner_enabled``
Edit ``inventory/group_vars/k8s-cluster.yml`` with something similar as below and deploy Kubespray:
```
registry_enabled: true
cephfs_provisioner_enabled: true
cephfs_provisioner_namespace: "{{ system_namespace }}"
cephfs_provisioner_cluster: ceph
cephfs_provisioner_monitors:
  - 172.31.53.251:6789
  - 172.31.53.254:6789
  - 172.31.53.255:6789
cephfs_provisioner_admin_id: admin
cephfs_provisioner_secret: "__secret__"
```

## Create StatefulSet + volumeClaimTemplates
Something similar as below (e.g. MariaDB):
```
---
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: mariadb
  namespace: default
spec:
  serviceName: mariadb
  replicas: 1
  updateStrategy:
    type: RollingUpdate
  selector:
    matchLabels:
      service: mariadb
  template:
    metadata:
      labels:
        service: mariadb
    spec:
      containers:
        - name: mariadb
          image: mariadb:10.2
          ports:
            - containerPort: 3306
            - containerPort: 4444
            - containerPort: 4567
            - containerPort: 4568
          env:
            - name: MYSQL_ROOT_PASSWORD
              valueFrom:
                secretKeyRef:
                  name: mariadb-secret
                  key: MYSQL_ROOT_PASSWORD
          command: ["docker-entrypoint.sh"]
          args: []
          volumeMounts:
            - name: mariadb-cm
              mountPath: "/etc/mysql/my.cnf"
              subPath: "my.cnf"
            - name: mariadb-pvc-var-lib-mysql
              mountPath: "/var/lib/mysql"
      volumes:
        - name: mariadb-cm
          configMap:
            name: mariadb-cm
  volumeClaimTemplates:
    - metadata:
        name: mariadb-pvc-var-lib-mysql
      spec:
        accessModes:
          - ReadWriteMany
        storageClassName: cephfs
        resources:
          requests:
            storage: 10Gi
```

## Check Result
e.g. ``kubectl get pvc``
```
NAME                                  STATUS    VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
mariadb-pvc-var-lib-mysql-mariadb-0   Bound     pvc-618a6e59-0cad-11e8-9d25-00163e01fcc0   10Gi       RWX            cephfs         6h
```

e.g. `` kubectl get pv``
```
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS    CLAIM                                         STORAGECLASS   REASON    AGE
pvc-618a6e59-0cad-11e8-9d25-00163e01fcc0   10Gi       RWX            Delete           Bound     default/mariadb-pvc-var-lib-mysql-mariadb-0   cephfs                   6h
```

# Limitation
Currently the custom pre-build image is uploaded to https://quay.io/repository/kubespray/cephfs-provisioner, tagged as ``quay.io/kubespray/cephfs-provisioner:92295a30``

This is because:
* https://quay.io/repository/external_storage/cephfs-provisioner image already get outdated (only jewel, no luminous support yet)
* In order to build image locally, we need [patch on external-storage for kubernetes v1.9.2](https://github.com/kubernetes-incubator/external-storage/pull/578)
* Thanks for @ant31, after build image locally now we could temporary push to https://quay.io/repository/kubespray/cephfs-provisioner, and wait until upstream getting a new stable release

Once above issues get resolved, we could simply remove the ``extra_playbooks/build-cephfs-provisioner.yml`` and use the official image.