### PR TITLE
Wait for external apiserver consistency.

### DIFF
--- a/roles/kubernetes-apps/ansible/tasks/main.yml
+++ b/roles/kubernetes-apps/ansible/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Kubernetes Apps | Wait for kube-apiserver
   uri:
-    url: "{{ kube_apiserver_endpoint }}/healthz"
+    url: "{{ external_apiserver_endpoint }}/healthz"
     validate_certs: no
     client_cert: "{{ kube_apiserver_client_cert }}"
     client_key: "{{ kube_apiserver_client_key }}"

--- a/roles/kubernetes-apps/cluster_roles/tasks/main.yml
+++ b/roles/kubernetes-apps/cluster_roles/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Kubernetes Apps | Wait for kube-apiserver
   uri:
-    url: "{{ kube_apiserver_endpoint }}/healthz"
+    url: "{{ external_apiserver_endpoint }}/healthz"
     validate_certs: no
     client_cert: "{{ kube_apiserver_client_cert }}"
     client_key: "{{ kube_apiserver_client_key }}"


### PR DESCRIPTION
When the playbook is doing kubectl calls (for example applying the dashboard)  it is using an external api server variable. So if you look at admin.conf.j2 it contains "external_apiserver_endpoint". 

Howhever the "Wait for kube-apiserver" contains "kube_apiserver_endpoint".

This means that if the local endpoint is up and the external endpoint is not yet up it will go pass the wait for kube-api server but will fail later when actually applying.

Hence this pr to make this consistent, we are using an external endpoint, then lets wait for the external endpoint.

I`ve tried running this and it fixes the issue we had.