### PR TITLE
Fix empty nodename in 10-calico.conflist

### DIFF
--- a/roles/network_plugin/calico/templates/cni-calico.conflist.j2
+++ b/roles/network_plugin/calico/templates/cni-calico.conflist.j2
@@ -3,7 +3,7 @@
   "cniVersion":"0.3.1",
   "plugins":[
     {
-    {% if cloud_provider is defined %}
+    {% if cloud_provider is defined and cloud_provider != "openstack" %}
       "nodename": "{{ calico_kubelet_name.stdout }}",
     {% else %}
       "nodename": "{{ ansible_hostname }}",


### PR DESCRIPTION
When cloud provider is OpenStack

Closes: #2239