### PR TITLE
Dashboard template should not suffix with .yml.j2

### DIFF
--- a/roles/kubernetes-apps/ansible/tasks/dashboard.yml
+++ b/roles/kubernetes-apps/ansible/tasks/dashboard.yml
@@ -2,7 +2,7 @@
 - name: Kubernetes Apps | Delete old kubernetes-dashboard resources
   kube:
     name: "kubernetes-dashboard"
-    kubectl: "{{bin_dir}}/kubectl"
+    kubectl: "{{ bin_dir }}/kubectl"
     resource: "{{ item }}"
     state: absent
   with_items:
@@ -12,20 +12,20 @@
 
 - name: Kubernetes Apps | Lay down dashboard template
   template:
-    src: "{{item.file}}"
-    dest: "{{kube_config_dir}}/{{item.file}}"
+    src: "{{ item.file }}.j2"
+    dest: "{{ kube_config_dir }}/{{ item.file }}"
   with_items:
-    - {file: dashboard.yml.j2, type: deploy, name: kubernetes-dashboard}
+    - { file: dashboard.yml, type: deploy, name: kubernetes-dashboard }
   register: manifests
   when: inventory_hostname == groups['kube-master'][0]
 
 - name: Kubernetes Apps | Start dashboard
   kube:
-    name: "{{item.item.name}}"
-    namespace: "{{system_namespace}}"
-    kubectl: "{{bin_dir}}/kubectl"
-    resource: "{{item.item.type}}"
-    filename: "{{kube_config_dir}}/{{item.item.file}}"
+    name: "{{ item.item.name }}"
+    namespace: "{{ system_namespace }}"
+    kubectl: "{{ bin_dir }}/kubectl"
+    resource: "{{ item.item.type }}"
+    filename: "{{ kube_config_dir }}/{{ item.item.file }}"
     state: "latest"
   with_items: "{{ manifests.results }}"
   when: inventory_hostname == groups['kube-master'][0]


### PR DESCRIPTION
Currently, the generated template file for dashboard become ``/etc/kubernetes/dashboard.yml.j2``, which should be ``/etc/kubernetes/dashboard.yml``