### PR TITLE
Add support for adding custom routes to subnet

### DIFF
--- a/contrib/terraform/openstack/kubespray.tf
+++ b/contrib/terraform/openstack/kubespray.tf
@@ -6,6 +6,7 @@ module "network" {
   network_name = "${var.network_name}"
   cluster_name = "${var.cluster_name}"
   dns_nameservers = "${var.dns_nameservers}"
+  host_routes = "${var.host_routes}"
 }
 
 

--- a/contrib/terraform/openstack/modules/network/main.tf
+++ b/contrib/terraform/openstack/modules/network/main.tf
@@ -16,6 +16,7 @@ resource "openstack_networking_subnet_v2" "k8s" {
   cidr            = "10.0.0.0/24"
   ip_version      = 4
   dns_nameservers = "${var.dns_nameservers}"
+  host_routes     = "${var.host_routes}"
 }
 
 resource "openstack_networking_router_interface_v2" "k8s" {

--- a/contrib/terraform/openstack/modules/network/variables.tf
+++ b/contrib/terraform/openstack/modules/network/variables.tf
@@ -11,3 +11,7 @@ variable "cluster_name" {
 variable "dns_nameservers"{
   type = "list"
 }
+
+variable "host_routes" {
+  type = "list"
+}

--- a/contrib/terraform/openstack/variables.tf
+++ b/contrib/terraform/openstack/variables.tf
@@ -103,6 +103,12 @@ variable "dns_nameservers"{
   default = []
 }
 
+variable "host_routes" {
+  description = "An array of routes that should be used by devices with IPs from this subnet."
+  type = "list"
+  default = []
+}
+
 variable "floatingip_pool" {
   description = "name of the floating ip pool to use"
   default = "external"


### PR DESCRIPTION
This uses Openstack's builtin support for specifying custom routes for
networking subnet.

Fixes https://github.com/kubernetes-incubator/kubespray/issues/2252.