### PR TITLE
remove references to deprecated kubespray-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ If you have questions, join us on the [kubernetes slack](https://kubernetes.slac
 
 To deploy the cluster you can use :
 
-[**kubespray-cli**](https://github.com/kubespray/kubespray-cli) <br>
 **Ansible** usual commands and [**inventory builder**](https://github.com/kubernetes-incubator/kubespray/blob/master/contrib/inventory_builder/inventory.py) <br>
 **vagrant** by simply running `vagrant up` (for tests purposes) <br>
 
@@ -112,7 +111,6 @@ See also [Network checker](docs/netcheck.md).
 
 ## Tools and projects on top of Kubespray
  - [Digital Rebar Provision](https://github.com/digitalrebar/provision/blob/master/doc/integrations/ansible.rst)
- - [Kubespray-cli](https://github.com/kubespray/kubespray-cli)
  - [Fuel-ccp-installer](https://github.com/openstack/fuel-ccp-installer)
  - [Terraform Contrib](https://github.com/kubernetes-incubator/kubespray/tree/master/contrib/terraform)
 

--- a/docs/cloud.md
+++ b/docs/cloud.md
@@ -3,20 +3,11 @@ Cloud providers
 
 #### Provisioning
 
-You can use kubespray-cli to start new instances on cloud providers
-here's an example
-```
-kubespray [aws|gce] --nodes 2 --etcd 3 --cluster-name test-smana
-```
+You can deploy instances in your cloud environment in several different ways. Examples include Terraform, Ansible (ec2 and gce modules), and manual creation.
 
 #### Deploy kubernetes
 
-With kubespray-cli
-```
-kubespray deploy [--aws|--gce] -u admin
-```
-
-Or ansible-playbook command
+With ansible-playbook command
 ```
 ansible-playbook -u smana -e ansible_ssh_user=admin -e cloud_provider=[aws|gce] -b --become-user=root -i inventory/single.cfg cluster.yml
 ```

--- a/docs/coreos.md
+++ b/docs/coreos.md
@@ -1,13 +1,7 @@
 CoreOS bootstrap
 ===============
 
-Example with **kubespray-cli**:
-
-```
-kubespray deploy --gce --coreos
-```
-
-Or with Ansible:
+Example with Ansible:
 
 Before running the cluster playbook you must satisfy the following requirements:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,23 +1,6 @@
 Getting started
 ===============
 
-The easiest way to run the deployement is to use the **kubespray-cli** tool.
-A complete documentation can be found in its [github repository](https://github.com/kubespray/kubespray-cli).
-
-Here is a simple example on AWS:
-
-* Create instances and generate the inventory
-
-```
-kubespray aws --instances 3
-```
-
-* Run the deployment
-
-```
-kubespray deploy --aws -u centos -n calico
-```
-
 Building your own inventory
 ---------------------------
 


### PR DESCRIPTION
Went ahead and dropped all the references of kubespray-cli from the docs, as they were causing confusion for new users.

This is a docs change only, shouldn't need CI.