### PR TITLE
Fix safe upgrade

### DIFF
--- a/inventory/sample/group_vars/all.yml
+++ b/inventory/sample/group_vars/all.yml
@@ -96,10 +96,6 @@ bin_dir: /usr/local/bin
 
 ## Uncomment to enable experimental kubeadm deployment mode
 #kubeadm_enabled: false
-#kubeadm_token_first: "{{ lookup('password', inventory_dir + '/credentials/kubeadm_token_first length=6  chars=ascii_lowercase,digits') }}"
-#kubeadm_token_second: "{{ lookup('password', inventory_dir + '/credentials/kubeadm_token_second length=16 chars=ascii_lowercase,digits') }}"
-#kubeadm_token: "{{ kubeadm_token_first }}.{{ kubeadm_token_second }}"
-#
 ## Set these proxy values in order to update package manager and docker daemon to use proxies
 #http_proxy: ""
 #https_proxy: ""

--- a/roles/kubernetes/kubeadm/tasks/main.yml
+++ b/roles/kubernetes/kubeadm/tasks/main.yml
@@ -22,6 +22,16 @@
   delegate_to: "{{ groups['kube-master'][0] }}"
   run_once: true
 
+- name: Create kubeadm token for joining nodes with 24h expiration (default)
+  command: "{{ bin_dir }}/kubeadm token create"
+  run_once: true
+  register: temp_token
+  delegate_to: "{{ groups['kube-master'][0] }}"
+
+- name: Override predefined kubeadm_token that expires after 24h
+  set_fact:
+    kubeadm_token: "{{ temp_token.stdout }}"
+    
 - name: Create kubeadm client config
   template:
     src: kubeadm-client.conf.j2

--- a/roles/kubernetes/kubeadm/tasks/main.yml
+++ b/roles/kubernetes/kubeadm/tasks/main.yml
@@ -28,16 +28,14 @@
   register: temp_token
   delegate_to: "{{ groups['kube-master'][0] }}"
 
-- name: Override predefined kubeadm_token that expires after 24h
-  set_fact:
-    kubeadm_token: "{{ temp_token.stdout }}"
-    
 - name: Create kubeadm client config
   template:
     src: kubeadm-client.conf.j2
     dest: "{{ kube_config_dir }}/kubeadm-client.conf"
     backup: yes
   when: not is_kube_master
+  vars:
+    kubeadm_token: "{{ temp_token.stdout }}"
   register: kubeadm_client_conf
 
 - name: Join to cluster if needed

--- a/roles/kubernetes/master/defaults/main.yml
+++ b/roles/kubernetes/master/defaults/main.yml
@@ -82,9 +82,6 @@ controller_mgr_custom_flags: []
 
 scheduler_custom_flags: []
 
-# kubeadm settings
-## Value of 0 means it never expires
-kubeadm_token_ttl: 0
 ## Extra args for k8s components passing by kubeadm
 kube_kubeadm_controller_extra_args: {}
 kube_kubeadm_scheduler_extra_args: {}

--- a/roles/kubernetes/master/templates/kubeadm-config.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.yaml.j2
@@ -29,8 +29,6 @@ authorizationModes:
 {% for mode in authorization_modes %}
 - {{ mode }}
 {% endfor %}
-token: {{ kubeadm_token }}
-tokenTTL: "{{ kubeadm_token_ttl }}"
 selfHosted: false
 apiServerExtraArgs:
   bind-address: {{ kube_apiserver_bind_address }}

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -147,7 +147,6 @@ helm_deployment_type: host
 
 # Enable kubeadm deployment (experimental)
 kubeadm_enabled: false
-kubeadm_token: "abcdef.0123456789abcdef"
 
 # Make a copy of kubeconfig on the host that runs Ansible in GITDIR/artifacts
 kubeconfig_localhost: false

--- a/roles/upgrade/post-upgrade/tasks/main.yml
+++ b/roles/upgrade/post-upgrade/tasks/main.yml
@@ -2,4 +2,4 @@
 - name: Uncordon node
   command: "{{ bin_dir }}/kubectl uncordon {{ inventory_hostname }}"
   delegate_to: "{{ groups['kube-master'][0] }}"
-  when: (needs_cordoning|default(false)) and ( {%- if inventory_hostname in groups['kube-node'] -%} true {%- else -%} false {%- endif -%} )
+  when: needs_cordoning|default(false)


### PR DESCRIPTION
# Problem

A kubespray cluster is running for some time and you want to safely update it to the newer version using `upgrade_cluster.yml`

It will fail during `[kubernetes/kubeadm : Join to cluster if needed]` with error:

```
"stdout": "[preflight] Running pre-flight checks.\n[discovery] Trying to connect to API Server \"10.94.45.185:6443\"\n[discovery] Created cluster-info discovery client, requesting info from \"https://10.94.45.185:6443\"\n[discovery] Failed to connect to API Server \"10.94.45.185:6443\": there is no JWS signed token in the cluster-info ConfigMap. This token id \"abcdef\" is invalid for this cluster, can't connect\n
```

# Expected result

`kubeadm join` will succeed as `kubeadm_token_ttl` is set to 0 which means that token should never expire, but it is not present in `kubeadm token list` after cluster is provisioned (at least after it is running for some time)

# Related issues
https://github.com/kubernetes/kubeadm/issues/335

 # Solution 
Create a new temporary token before the `kubeadm join` command

# Refactoring issues
Not sure what to do with `kubeadm_token` and `kubeadm_token_ttl` that are defined in `roles\kubespray-defaults\defaults\main.yml`. The code I added doesn't really breake anything as much as I tested, but looks like `kubeadm_token_ttl` is not respected, so perhaps it can be removed. `kubeadm_token` is also used for master config, so can stay untouched but it's a bit weird that that token is not used then during `kubeadm join` because I override it with newly generated one. Please suggest if you have ideas how to optimize it.