### PR TITLE
baremetal tweaks

### DIFF
--- a/roles/bootstrap-os/defaults/main.yml
+++ b/roles/bootstrap-os/defaults/main.yml
@@ -2,3 +2,5 @@
 pip_python_coreos_modules:
   - httplib2
   - six
+
+override_system_hostname: true

--- a/roles/bootstrap-os/tasks/main.yml
+++ b/roles/bootstrap-os/tasks/main.yml
@@ -29,12 +29,12 @@
 - name: Assign inventory name to unconfigured hostnames (non-CoreOS)
   hostname:
     name: "{{inventory_hostname}}"
-  when: ansible_os_family not in ['CoreOS', 'Container Linux by CoreOS']
+  when: ansible_os_family not in ['CoreOS', 'Container Linux by CoreOS'] and override_system_hostname
 
 - name: Assign inventory name to unconfigured hostnames (CoreOS only)
   command: "hostnamectl set-hostname  {{inventory_hostname}}"
   register: hostname_changed
-  when: ansible_hostname == 'localhost' and ansible_os_family in ['CoreOS', 'Container Linux by CoreOS']
+  when: ansible_hostname == 'localhost' and ansible_os_family in ['CoreOS', 'Container Linux by CoreOS'] and override_system_hostname
 
 - name: Update hostname fact (CoreOS only)
   setup:

--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -84,7 +84,7 @@ kube_hyperkube_image_repo: ""
 kube_override_hostname: >-
   {%- if cloud_provider is defined and cloud_provider in [ 'aws' ] -%}
   {%- else -%}
-  {{ ansible_hostname }}
+  {{ inventory_hostname }}
   {%- endif -%}
 
 # cAdvisor port

--- a/roles/network_plugin/calico/templates/calico-config.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-config.yml.j2
@@ -14,6 +14,6 @@ data:
   cluster_type: "kubespray,bgp"
 {% endif %}
   calico_backend: "bird"
-  {%- if inventory_hostname in groups['k8s-cluster'] and peer_with_router|default(false) %}
-  as: "{{ local_as }}"
-  {% endif -%}
+{% if inventory_hostname in groups['k8s-cluster'] and peer_with_router|default(false) %}
+  as: "{{ local_as|default(global_as_num) }}"
+{% endif -%}

--- a/roles/network_plugin/calico/templates/cni-calico.conflist.j2
+++ b/roles/network_plugin/calico/templates/cni-calico.conflist.j2
@@ -6,7 +6,7 @@
     {% if cloud_provider is defined %}
       "nodename": "{{ calico_kubelet_name.stdout }}",
     {% else %}
-      "nodename": "{{ ansible_hostname }}",
+      "nodename": "{{ inventory_hostname }}",
     {% endif %}
       "type": "calico",
       "etcd_endpoints": "{{ etcd_access_addresses }}",

--- a/roles/reset/defaults/main.yml
+++ b/roles/reset/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 flush_iptables: true
+reset_restart_network: true

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -195,7 +195,7 @@
       networking
       {%- endif %}
     state: restarted
-  when: ansible_os_family not in ["CoreOS", "Container Linux by CoreOS"]
+  when: ansible_os_family not in ["CoreOS", "Container Linux by CoreOS"] and reset_restart_network
   tags:
     - services
     - network


### PR DESCRIPTION
* allow installs to not have hostname overriden with fqdn from inventory
* calico-config no longer requires local as and will default to global (and syntax error fixes)
* when cloudprovider is not defined, use the inventory_hostname for cni-calico
* allow reset to not restart network (buggy nodes die with this cmd)
* default kube_override_hostname to inventory_hostname