### PR TITLE
Set default registry_enabled to false

### DIFF
--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -162,6 +162,7 @@ dashboard_enabled: true
 efk_enabled: false
 helm_enabled: false
 istio_enabled: false
+registry_enabled: false
 enable_network_policy: false
 local_volumes_enabled: false
 persistent_volumes_enabled: false


### PR DESCRIPTION
In PR #2244 the `registry_enabled` is missing in defaults, causing a deployment to fail, if it is not set in k8s-cluster.yml