### PR TITLE
Adding missing defaults for weave

### DIFF
--- a/roles/network_plugin/weave/defaults/main.yml
+++ b/roles/network_plugin/weave/defaults/main.yml
@@ -12,6 +12,16 @@ weave_cpu_requests: 10m
 weave_seed: uninitialized
 weave_peers: uninitialized
 
+# weave's network password for encryption
+# if null then no network encryption
+# you can use --extra-vars to pass the password in command line
+weave_password: EnterPasswordHere
+
+# Weave uses consensus mode by default
+# Enabling seed mode allow to dynamically add or remove hosts
+# https://www.weave.works/docs/net/latest/ipam/
+weave_mode_seed: false
+
 # Set the MTU of Weave (default 1376, Jumbo Frames: 8916)
 weave_mtu: 1376
 


### PR DESCRIPTION
The PR #2203 add's missing defaults for weave, but no signed CLA. So this PR fixes it.