### PR TITLE
Update Calico and Canal

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -29,9 +29,9 @@ kubeadm_version: "{{ kube_version }}"
 etcd_version: v3.2.4
 # TODO(mattymo): Move calico versions to roles/network_plugins/calico/defaults
 # after migration to container download
-calico_version: "v2.6.2"
+calico_version: "v2.6.7"
 calico_ctl_version: "v1.6.1"
-calico_cni_version: "v1.11.0"
+calico_cni_version: "v1.11.2"
 calico_policy_version: "v1.0.0"
 calico_rr_version: "v0.4.0"
 flannel_version: "v0.10.0"

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -29,11 +29,11 @@ kubeadm_version: "{{ kube_version }}"
 etcd_version: v3.2.4
 # TODO(mattymo): Move calico versions to roles/network_plugins/calico/defaults
 # after migration to container download
-calico_version: "v2.6.7"
-calico_ctl_version: "v1.6.1"
-calico_cni_version: "v1.11.2"
-calico_policy_version: "v1.0.0"
-calico_rr_version: "v0.4.0"
+calico_version: "v2.6.8"
+calico_ctl_version: "v1.6.3"
+calico_cni_version: "v1.11.4"
+calico_policy_version: "v1.0.3"
+calico_rr_version: "v0.4.2"
 flannel_version: "v0.10.0"
 flannel_cni_version: "v0.3.0"
 istio_version: "0.2.6"

--- a/roles/network_plugin/calico/templates/calico-node.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-node.yml.j2
@@ -28,6 +28,9 @@ spec:
       tolerations:
         - effect: NoSchedule
           operator: Exists
+      # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
+      # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
+      terminationGracePeriodSeconds: 0
       containers:
         # Runs calico/node container on each Kubernetes node.  This
         # container programs network policy and routes on each
@@ -53,6 +56,11 @@ spec:
                 configMapKeyRef:
                   name: calico-config
                   key: cluster_type
+            # Set noderef for node controller.
+            - name: CALICO_K8S_NODE_REF
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
             # Disable file logging so `kubectl logs` works.
             - name: CALICO_DISABLE_FILE_LOGGING
               value: "true"

--- a/roles/network_plugin/canal/templates/canal-node.yaml.j2
+++ b/roles/network_plugin/canal/templates/canal-node.yaml.j2
@@ -148,13 +148,20 @@ spec:
                   name: canal-config
                   key: etcd_endpoints
             # Disable Calico BGP.  Calico is simply enforcing policy.
-            - name: CALICO_NETWORKING
-              value: "false"
+            - name: CALICO_NETWORKING_BACKEND
+              value: "none"
             # Cluster type to identify the deployment type
             - name: CLUSTER_TYPE
               value: "kubespray,canal"
             # Disable file logging so `kubectl logs` works.
             - name: CALICO_DISABLE_FILE_LOGGING
+              value: "true"
+            # Set noderef for node controller.
+            - name: CALICO_K8S_NODE_REF
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: FELIX_HEALTHENABLED
               value: "true"
             # Etcd SSL vars
             - name: ETCD_CA_CERT_FILE
@@ -178,6 +185,18 @@ spec:
                   fieldPath: spec.nodeName
           securityContext:
             privileged: true
+          livenessProbe:
+            httpGet:
+              path: /liveness
+              port: 9099
+            periodSeconds: 10
+            initialDelaySeconds: 10
+            failureThreshold: 6
+          readinessProbe:
+            httpGet:
+              path: /readiness
+              port: 9099
+            periodSeconds: 10
           volumeMounts:
             - mountPath: /lib/modules
               name: lib-modules


### PR DESCRIPTION
# Changes
- Update calico-node version used
- Update calico/cni
- Updated manifests with some changes that have been made upstream
- Added liveness and readiness for calico-node in Canal configuration
- ~Remove un-needed ClusterRole from Canal for calico-node (@mattymo I'm fairly confident that this is not needed but you added it originally so please take a look.)~

# Testing
I've tested my changes by using the provided Vagrant with both Calico and Canal as the network_plugin (with network policy enabled) and verified that the "Simple Policy Demo" https://docs.projectcalico.org/v2.6/getting-started/kubernetes/tutorials/simple-policy works as expected.