### PR TITLE
Disalbe install epel-release rpm on Centos/Redhat

### DIFF
--- a/roles/kubernetes-apps/meta/main.yml
+++ b/roles/kubernetes-apps/meta/main.yml
@@ -33,7 +33,7 @@ dependencies:
       - apps
       - local_volume_provisioner
       - storage
-  
+
   # istio role should be last because it takes a long time to initialize and
   # will cause timeouts trying to start other addons.
   - role: kubernetes-apps/istio
@@ -41,7 +41,7 @@ dependencies:
     tags:
       - apps
       - istio
-  
+
   - role: kubernetes-apps/persistent_volumes
     when: persistent_volumes_enabled
     tags:

--- a/roles/kubernetes/preinstall/defaults/main.yml
+++ b/roles/kubernetes/preinstall/defaults/main.yml
@@ -4,8 +4,7 @@ run_gitinfos: false
 # Set to true to allow pre-checks to fail and continue deployment
 ignore_assert_errors: false
 
-epel_rpm_download_url: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
-epel_enabled: true
+epel_enabled: false
 
 common_required_pkgs:
   - python-httplib2

--- a/roles/kubernetes/preinstall/tasks/main.yml
+++ b/roles/kubernetes/preinstall/tasks/main.yml
@@ -172,18 +172,13 @@
     - bootstrap-os
 
 - name: Install epel-release on RedHat/CentOS
-  shell: rpm -qa | grep epel-release || rpm -ivh {{ epel_rpm_download_url }}
-  register: epel_task_result
-  until: epel_task_result|succeeded
-  retries: 4
-  delay: "{{ retry_stagger | random + 3 }}"
-  changed_when: False
+  yum:
+    name: epel-release
+    state: present
   when:
     - ansible_distribution in ["CentOS","RedHat"]
     - not is_atomic
-    - epel_rpm_download_url != ''
     - epel_enabled|bool
-  check_mode: no
   tags:
     - bootstrap-os
 


### PR DESCRIPTION
1.Disalbe install epel-release rpm on Centos/Redhat
2.Use yum install epel-release

epel-release.noarch : Extra Packages for Enterprise Linux repository configuration
epel-release  in Extra Packages   and   not use epel-release to install some rpm