### PR TITLE
Fix sometimes net.bridge.bridge-nf-call-iptables is disable

### DIFF
--- a/roles/kubernetes/node/tasks/main.yml
+++ b/roles/kubernetes/node/tasks/main.yml
@@ -98,7 +98,7 @@
     state: present
     value: 1
     reload: yes
-  when: modinfo_br_netfilter.rc == 1 and sysctl_bridge_nf_call_iptables.rc == 0
+  when: sysctl_bridge_nf_call_iptables.rc == 0
   with_items:
     - net.bridge.bridge-nf-call-iptables
     - net.bridge.bridge-nf-call-arptables


### PR DESCRIPTION
Fix sometimes net.bridge.bridge-nf-call-iptables is disable

if modinfo_br_netfilter.rc == 0   
it will skip Enable bridge-nf-call tables