### PR TITLE
Fix symlinking vagrant inventory

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -61,7 +61,7 @@ if ! File.exist?(File.join(File.dirname($inventory), "hosts"))
                        "provisioners", "ansible")
   FileUtils.mkdir_p($vagrant_ansible) if ! File.exist?($vagrant_ansible)
   if ! File.exist?(File.join($vagrant_ansible,"inventory"))
-    FileUtils.ln_s($inventory, $vagrant_ansible)
+    FileUtils.ln_s($inventory, File.join($vagrant_ansible,"inventory"))
   end
 end
 


### PR DESCRIPTION
The default path assumes that the vagrant dir is called 'inventory'.
With custom defined inventory dirs that are not called 'inventory' this
fails to create the correct symlink under .vagrant.d.

It then becomes possible to use any path as $inventory and create group_vars there.