### PR TITLE
Local volume provisioner fixes

### DIFF
--- a/roles/kubernetes-apps/local_volume_provisioner/templates/configmap.yml.j2
+++ b/roles/kubernetes-apps/local_volume_provisioner/templates/configmap.yml.j2
@@ -10,5 +10,5 @@ data:
   "local-storage": |
     {
       "hostDir": "{{ local_volume_base_dir }}",
-      "mountDir": "/mnt/local-storage/"
+      "mountDir": "{{ local_volume_mount_dir }}"
     }

--- a/roles/kubernetes-apps/local_volume_provisioner/templates/configmap.yml.j2
+++ b/roles/kubernetes-apps/local_volume_provisioner/templates/configmap.yml.j2
@@ -7,7 +7,7 @@ metadata:
   name: local-volume-config
   namespace: {{ system_namespace }}
 data:
-  "local-storage": |
+  "{{ local_volume_storage_class }}": |
     {
       "hostDir": "{{ local_volume_base_dir }}",
       "mountDir": "{{ local_volume_mount_dir }}"

--- a/roles/kubernetes-apps/local_volume_provisioner/templates/configmap.yml.j2
+++ b/roles/kubernetes-apps/local_volume_provisioner/templates/configmap.yml.j2
@@ -5,9 +5,10 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: local-volume-config
-  namespace: {{ system_namespace }}
+  namespace: {{ system_namespace }}a
 data:
-  storageClassMap: |
-    local-storage:
-      hostDir: "{{ local_volume_base_dir }}"
-      mountDir: "/mnt/local-storage/"
+  "local-storage": |
+    {
+      "hostDir": "{{ local_volume_base_dir }}",
+      "mountDir": "/mnt/local-storage/"
+    }

--- a/roles/kubernetes-apps/local_volume_provisioner/templates/configmap.yml.j2
+++ b/roles/kubernetes-apps/local_volume_provisioner/templates/configmap.yml.j2
@@ -5,7 +5,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: local-volume-config
-  namespace: {{ system_namespace }}a
+  namespace: {{ system_namespace }}
 data:
   "local-storage": |
     {

--- a/roles/kubernetes-apps/local_volume_provisioner/templates/daemonset.yml.j2
+++ b/roles/kubernetes-apps/local_volume_provisioner/templates/daemonset.yml.j2
@@ -18,7 +18,7 @@ spec:
             privileged: true
           volumeMounts:
             - name: discovery-vol
-              mountPath: "/{{ local_volume_mount_dir }}"
+              mountPath: "{{ local_volume_mount_dir }}"
             - name: local-volume-config
               mountPath: /etc/provisioner/config/
           env:

--- a/roles/kubernetes-apps/local_volume_provisioner/templates/daemonset.yml.j2
+++ b/roles/kubernetes-apps/local_volume_provisioner/templates/daemonset.yml.j2
@@ -32,6 +32,8 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.namespace
+            - name: VOLUME_CONFIG_NAME
+              value: "local-volume-config"
       volumes:
         - name: discovery-vol
           hostPath:

--- a/roles/kubernetes-apps/local_volume_provisioner/templates/daemonset.yml.j2
+++ b/roles/kubernetes-apps/local_volume_provisioner/templates/daemonset.yml.j2
@@ -18,7 +18,7 @@ spec:
             privileged: true
           volumeMounts:
             - name: discovery-vol
-              mountPath: "/local-disks"
+              mountPath: "/{{ local_volume_mount_dir }}"
             - name: local-volume-config
               mountPath: /etc/provisioner/config/
           env:

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -170,6 +170,7 @@ persistent_volumes_enabled: false
 # Base path for local volume provisioner addon
 local_volume_base_dir: /mnt/disks
 local_volume_mount_dir: /local-disks
+local_volume_storage_class: local-storage
 
 ## When OpenStack is used, Cinder version can be explicitly specified if autodetection fails (Fixed in 1.9: https://github.com/kubernetes/kubernetes/issues/50461)
 # openstack_blockstorage_version: "v1/v2/auto (default)"

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -169,6 +169,7 @@ persistent_volumes_enabled: false
 
 # Base path for local volume provisioner addon
 local_volume_base_dir: /mnt/disks
+local_volume_mount_dir: /local-disks
 
 ## When OpenStack is used, Cinder version can be explicitly specified if autodetection fails (Fixed in 1.9: https://github.com/kubernetes/kubernetes/issues/50461)
 # openstack_blockstorage_version: "v1/v2/auto (default)"


### PR DESCRIPTION
- Fixes configmap format to comply with local-provisioner:v1.0.1 expecting JSON
- Added VOLUME_CONFIG_NAME envvar to comply with local-provisioner:v1.0.1 expectation
- Fixes daemonset.yml and configmap.yml to have compatible mountdirs (added local_volume_mount_dir variable for that purpose)