### PR TITLE
Fix network_plugin always undefined

### DIFF
--- a/roles/kubernetes/preinstall/tasks/verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/verify-settings.yml
@@ -17,13 +17,12 @@
 
 - name: Stop if unknown network plugin
   assert:
-    that: network_plugin in ['calico', 'canal', 'flannel', 'weave', 'cloud']
-  when: network_plugin is defined
+    that: kube_network_plugin in ['calico', 'canal', 'flannel', 'weave', 'cloud']
   ignore_errors: "{{ ignore_assert_errors }}"
 
 - name: Stop if incompatible network plugin and cloudprovider
   assert:
-    that: network_plugin != 'calico'
+    that: kube_network_plugin != 'calico'
     msg: "Azure and Calico are not compatible. See https://github.com/projectcalico/calicoctl/issues/949 for details."
   when: cloud_provider is defined and cloud_provider == 'azure'
   ignore_errors: "{{ ignore_assert_errors }}"


### PR DESCRIPTION
When setting `cloud_provider` to azure, the `network_plugin` value is always undefined. it appears that this should be the `kube_network_plugin` name instead.

This breaks  a check to ensure it is not 'calico'. Also, this removes a when clause because the `kube_network_plugin` should be defined.

There are other issues with the Azure deployment, but this felt important to address separately.