### PR TITLE
Remove redundant python-apt install

### DIFF
--- a/roles/kubernetes/preinstall/tasks/main.yml
+++ b/roles/kubernetes/preinstall/tasks/main.yml
@@ -147,10 +147,8 @@
   tags: bootstrap-os
 
 
-- name: Install latest version of python-apt for Debian distribs
+- name: Update package management cache (APT)
   apt:
-    name: python-apt
-    state: latest
     update_cache: yes
     cache_valid_time: 3600
   when: ansible_os_family == "Debian"


### PR DESCRIPTION
This implements the first half of issue #2284 

Ansible automatically installs the python-apt package when using
the 'apt' Ansible module, if python-apt is not present. This patch
removes the (unneeded) explicit installation in the Kubespray
'preinstall' role.

Current Ansible code can be seen here: https://github.com/ansible/ansible/blob/7d721c1ec5d4066547c4b7bf51d452d956ae366a/lib/ansible/modules/packaging/os/apt.py#L888
And it's been there since 2013: https://github.com/ansible/ansible/issues/4079

Fairly confident that this behavior won't change upstream, and even it does, the python-apt install in Kubespray won't work as is since it is using the 'apt' module that depends on the 'python-apt' package.

Tested by uninstalling python-apt/python-apt-common/python3-apt from an Ubuntu 16.04.3 Server, running Kubespray against it, and then validating a functioning deployment + presence of the python-apt package.