### PR TITLE
Add PVC support for Registry addon

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s-cluster.yml
@@ -167,6 +167,8 @@ istio_enabled: false
 
 # Registry deployment
 registry_enabled: false
+# registry_storage_class: ""
+# registry_disk_size: "10Gi"
 
 # Local volume provisioner deployment
 # deprecated will be removed

--- a/roles/kubernetes-apps/registry/defaults/main.yml
+++ b/roles/kubernetes-apps/registry/defaults/main.yml
@@ -3,3 +3,6 @@ registry_image_repo: registry
 registry_image_tag: 2.6
 registry_proxy_image_repo: gcr.io/google_containers/kube-registry-proxy
 registry_proxy_image_tag: 0.4
+
+registry_storage_class: ""
+registry_disk_size: "10Gi"

--- a/roles/kubernetes-apps/registry/tasks/main.yml
+++ b/roles/kubernetes-apps/registry/tasks/main.yml
@@ -13,11 +13,12 @@
     src: "{{ item.file }}.j2"
     dest: "{{ kube_config_dir }}/addons/registry/{{ item.file }}"
   with_items:
-    - { name: registry-svc, file: registry-svc.yml, type: service }
-    - { name: registry-rc, file: registry-rc.yml, type: replicationcontroller }
-    - { name: registry-ds, file: registry-ds.yml, type: daemonset }
+    - { name: registry-pvc, file: registry-pvc.yml, type: pvc }
   register: registry_manifests
-  when: inventory_hostname == groups['kube-master'][0]
+  when: 
+    - registry_storage_class != none
+    - registry_disk_size != none
+    - inventory_hostname == groups['kube-master'][0]
 
 - name: Registry | Apply manifests
   kube:
@@ -28,4 +29,31 @@
     filename: "{{ kube_config_dir }}/addons/registry/{{ item.item.file }}"
     state: "latest"
   with_items: "{{ registry_manifests.results }}"
-  when: inventory_hostname == groups['kube-master'][0]
+  when: 
+    - registry_storage_class != none
+    - registry_disk_size != none
+    - inventory_hostname == groups['kube-master'][0]
+
+- name: Registry | Create manifests
+  template:
+    src: "{{ item.file }}.j2"
+    dest: "{{ kube_config_dir }}/addons/registry/{{ item.file }}"
+  with_items:
+    - { name: registry-svc, file: registry-svc.yml, type: svc }
+    - { name: registry-rs, file: registry-rs.yml, type: rs }
+    - { name: registry-ds, file: registry-ds.yml, type: ds }
+  register: registry_manifests
+  when: 
+    - inventory_hostname == groups['kube-master'][0]
+
+- name: Registry | Apply manifests
+  kube:
+    name: "{{ item.item.name }}"
+    namespace: "{{ system_namespace }}"
+    kubectl: "{{ bin_dir }}/kubectl"
+    resource: "{{ item.item.type }}"
+    filename: "{{ kube_config_dir }}/addons/registry/{{ item.item.file }}"
+    state: "latest"
+  with_items: "{{ registry_manifests.results }}"
+  when: 
+    - inventory_hostname == groups['kube-master'][0]

--- a/roles/kubernetes-apps/registry/templates/registry-pvc.yml.j2
+++ b/roles/kubernetes-apps/registry/templates/registry-pvc.yml.j2
@@ -1,5 +1,6 @@
-kind: PersistentVolumeClaim
+---
 apiVersion: v1
+kind: PersistentVolumeClaim
 metadata:
   name: kube-registry-pvc
   namespace: kube-system
@@ -9,6 +10,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
+  storageClassName: {{ registry_storage_class }}
   resources:
     requests:
-      storage: {{ pillar['cluster_registry_disk_size'] }}
+      storage: {{ registry_disk_size }}

--- a/roles/kubernetes-apps/registry/templates/registry-rs.yml.j2
+++ b/roles/kubernetes-apps/registry/templates/registry-rs.yml.j2
@@ -1,6 +1,6 @@
 ---
-apiVersion: v1
-kind: ReplicationController
+apiVersion: apps/v1
+kind: ReplicaSet
 metadata:
   name: kube-registry-v{{ registry_image_tag }}
   namespace: {{ system_namespace }}
@@ -12,8 +12,9 @@ metadata:
 spec:
   replicas: 1
   selector:
-    k8s-app: kube-registry-upstream
-    version: v{{ registry_image_tag }}
+    matchLabels:
+      k8s-app: kube-registry-upstream
+      version: v{{ registry_image_tag }}
   template:
     metadata:
       labels:
@@ -30,12 +31,17 @@ spec:
             - name: REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY
               value: /var/lib/registry
           volumeMounts:
-            - name: image-store
+            - name: kube-registry-pvc
               mountPath: /var/lib/registry
           ports:
             - containerPort: 5000
               name: registry
               protocol: TCP
       volumes:
-        - name: image-store
+        - name: kube-registry-pvc
+{% if registry_storage_class != none %}
+          persistentVolumeClaim:
+            claimName: kube-registry-pvc
+{% else %}
           emptyDir: {}
+{% endif %}


### PR DESCRIPTION
Previous implementation (https://github.com/kubernetes-incubator/kubespray/pull/2244) just simply hardcode map the ``/var/lib/registry`` to ``emptyDir``.

This patch add the PVC support and asking for a ``StorageClassName``, e.g. we could now provide:
* local-volume, or
* cephfs

Also provide a default PV with storageClassName ``kube-registry-pv`` + ``emptyDir`` implementation, so could always works in deployment even if we don't specify our custom ``registry_storage_class``.