### PR TITLE
Added missing cephfs_provisioner_enabled to kubespray-defaults vars

### DIFF
--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -169,6 +169,7 @@ registry_enabled: false
 enable_network_policy: false
 local_volume_provisioner_enabled: false
 persistent_volumes_enabled: false
+cephfs_provisioner_enabled: false
 
 # Base path for local volume provisioner addon
 local_volume_base_dir: /mnt/disks


### PR DESCRIPTION
got error on upgrade cluster

```
TASK [kubernetes-apps/cephfs_provisioner : CephFS Provisioner | Create addon dir] **************************************************************************************************************************
Friday 09 February 2018  16:55:15 +0300 (0:00:05.136)       0:36:12.822 *******
fatal: [kube01]: FAILED! => {"msg": "The conditional check 'cephfs_provisioner_enabled' failed. The error was: error while evaluating conditional (cephfs_provisioner_enabled): 'cephfs_provisioner_enabled' is undefined\n\nThe error appears to have been in '/Users/mak/Projects/ansible/ansible-meta/kubespray/roles/kubernetes-apps/cephfs_provisioner/tasks/main.yml': line 3, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: CephFS Provisioner | Create addon dir\n  ^ here\n"}
```

relates to https://github.com/kubernetes-incubator/kubespray/pull/2230

