### PR TITLE
Making node status and scheduling detection mo betta for upgrades

### DIFF
--- a/roles/upgrade/post-upgrade/tasks/main.yml
+++ b/roles/upgrade/post-upgrade/tasks/main.yml
@@ -2,4 +2,5 @@
 - name: Uncordon node
   command: "{{ bin_dir }}/kubectl uncordon {{ inventory_hostname }}"
   delegate_to: "{{ groups['kube-master'][0] }}"
-  when: needs_cordoning|default(false)
+  when:
+    - needs_cordoning|default(false)

--- a/roles/upgrade/pre-upgrade/tasks/main.yml
+++ b/roles/upgrade/pre-upgrade/tasks/main.yml
@@ -1,13 +1,27 @@
 ---
+# Node Ready: type = ready, status = True
+# Node NotReady: type = ready, status = Unknown
 - name: See if node is in ready state
-  shell: "{{ bin_dir }}/kubectl get nodes | grep {{ inventory_hostname }}"
-  register: kubectl_nodes
+  shell: >-
+     {{ bin_dir }}/kubectl get node {{ inventory_hostname }}
+     -o jsonpath='{ range .status.conditions[?(@.type == "Ready")].status }{ @ }{ end }'
+  register: kubectl_node_ready
+  delegate_to: "{{ groups['kube-master'][0] }}"
+  failed_when: false
+
+# SchedulingDisabled: unschedulable = true
+# else unschedulable key doesn't exist
+- name: See if node is schedulable
+  shell: >-
+     {{ bin_dir }}/kubectl get node {{ inventory_hostname }}
+     -o jsonpath='{ .spec.unschedulable }'
+  register: kubectl_node_schedulable
   delegate_to: "{{ groups['kube-master'][0] }}"
   failed_when: false
 
 - set_fact:
     needs_cordoning: >-
-      {% if " Ready" in kubectl_nodes.stdout -%}
+      {% if kubectl_node_ready.stdout == "True" and kubectl_node_schedulable.stdout == "" -%}
       true
       {%- else -%}
       false


### PR DESCRIPTION
This should enhance the way we detect node status and eventually decide to cordon. 
Enhanced the conditional check for cordoning to include if node has scheduling disabled set. This should allow us to properly flex on masters being either `Ready` or `Ready,SchedulingDisabled`.