### PR TITLE
Fix indexing of supplementary DNS in openssl.conf

### DIFF
--- a/roles/kubernetes/secrets/templates/openssl.conf.j2
+++ b/roles/kubernetes/secrets/templates/openssl.conf.j2
@@ -15,9 +15,10 @@ DNS.5 = localhost
 {% for host in groups['kube-master'] %}
 DNS.{{ 5 + loop.index }} = {{ host }}
 {% endfor %}
+{% set idns = groups['kube-master'] | length | int + 5 %}
 {% if loadbalancer_apiserver is defined  %}
-{% set idx =  groups['kube-master'] | length | int + 5 + 1 %}
-DNS.{{ idx | string }} = {{ apiserver_loadbalancer_domain_name }}
+{% set idns = idns + 1 %}
+DNS.{{ idns | string }} = {{ apiserver_loadbalancer_domain_name }}
 {% endif %}
 {% for host in groups['kube-master'] %}
 IP.{{ 2 * loop.index - 1 }} = {{ hostvars[host]['access_ip'] | default(hostvars[host]['ansible_default_ipv4']['address']) }}
@@ -36,7 +37,7 @@ IP.{{ idx + 1 }} = 127.0.0.1
 {% if addr | ipaddr %}
 IP.{{ is + loop.index }} = {{ addr }}
 {% else %}
-DNS.{{ is + loop.index }} = {{ addr }}
+DNS.{{ idns + loop.index }} = {{ addr }}
 {% endif %}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
I made a mistake in https://github.com/kubernetes-incubator/kubespray/pull/2226 as I didn't realise the `idx` variable in `openssl.conf.j2` was redefined, which may lead to duplicate `DNS.N` entries. This wasn't apparent at first as all my testing was done using a multi-node master, so the IP index was always greater than the DNS index.