### PR TITLE
Fix version comparison

### DIFF
--- a/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
@@ -102,7 +102,7 @@ spec:
 {% if kube_feature_gates %}
     - --feature-gates={{ kube_feature_gates|join(',') }}
 {% endif %}
-{% if kube_version | version_compare('1.9', '>=') %}
+{% if kube_version | version_compare('v1.9', '>=') %}
     - --requestheader-client-ca-file={{ kube_cert_dir }}/ca.pem
     - --requestheader-allowed-names=front-proxy-client
     - --requestheader-extra-headers-prefix=X-Remote-Extra-


### PR DESCRIPTION
the current master fails with:

`FAILED! => {"changed": false, "msg": "AnsibleFilterError: Version comparison: unorderable types: str() < int()"}`