### PR TITLE
Move to new Docker package repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# My cluster is special like everyone else
-inventory/mycluster/
-
 .vagrant
 *.retry
 inventory/vagrant_ansible_inventory

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# My cluster is special like everyone else
+inventory/mycluster/
+
 .vagrant
 *.retry
 inventory/vagrant_ansible_inventory

--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -16,5 +16,5 @@ docker_container_storage_setup: false
 
 docker_rh_repo_base_url: 'https://yum.dockerproject.org/repo/main/centos/7'
 docker_rh_repo_gpgkey: 'https://yum.dockerproject.org/gpg'
-docker_apt_repo_base_url: 'https://apt.dockerproject.org/repo'
-docker_apt_repo_gpgkey: 'https://apt.dockerproject.org/gpg'
+docker_apt_repo_base_url: 'https://download.docker.com/linux/ubuntu'
+docker_apt_repo_gpgkey: 'https://download.docker.com/linux/ubuntu/gpg'

--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-docker_version: '17.03'
+docker_version: 'stable'
 
 docker_package_info:
   pkgs:

--- a/roles/docker/vars/ubuntu.yml
+++ b/roles/docker/vars/ubuntu.yml
@@ -1,15 +1,13 @@
 ---
 docker_kernel_min_version: '3.10'
+docker_package_arch: 'amd64'
 
 # https://download.docker.com/linux/ubuntu/dists/trusty/stable/
 docker_versioned_pkg:
   'latest': docker-ce
-  '1.11': docker-ce=1.11.1-0~{{ ansible_distribution_release|lower }}
-  '1.12': docker-ce=1.12.6-0~ubuntu-{{ ansible_distribution_release|lower }}
-  '1.13': docker-ce=1.13.1-0~ubuntu-{{ ansible_distribution_release|lower }}
-  '17.03': docker-ce=17.03.1~ce-0~ubuntu-{{ ansible_distribution_release|lower }}
-  'stable': docker-ce=17.03.1~ce-0~ubuntu-{{ ansible_distribution_release|lower }}
-  'edge': docker-ce=17.05.0~ce-0~ubuntu-{{ ansible_distribution_release|lower }}
+  '17.12': docker-ce=17.03.1~ce-0~ubuntu
+  'stable': docker-ce=17.12.0~ce-0~ubuntu
+  'edge': docker-ce=18.02.0~ce-0~ubuntu
 
 docker_package_info:
   pkg_mgr: apt
@@ -27,6 +25,7 @@ docker_repo_info:
   pkg_repo: apt_repository
   repos:
     - >
-       deb {{ docker_apt_repo_base_url }}
+       deb [arch={{ docker_package_arch }}]
+       {{ docker_apt_repo_base_url }}
        {{ ansible_distribution_release|lower }}
        stable

--- a/roles/docker/vars/ubuntu.yml
+++ b/roles/docker/vars/ubuntu.yml
@@ -1,15 +1,15 @@
 ---
 docker_kernel_min_version: '3.10'
 
-# https://apt.dockerproject.org/repo/dists/ubuntu-xenial/main/filelist
+# https://download.docker.com/linux/ubuntu/dists/trusty/stable/
 docker_versioned_pkg:
-  'latest': docker-engine
-  '1.11': docker-engine=1.11.1-0~{{ ansible_distribution_release|lower }}
-  '1.12': docker-engine=1.12.6-0~ubuntu-{{ ansible_distribution_release|lower }}
-  '1.13': docker-engine=1.13.1-0~ubuntu-{{ ansible_distribution_release|lower }}
-  '17.03': docker-engine=17.03.1~ce-0~ubuntu-{{ ansible_distribution_release|lower }}
-  'stable': docker-engine=17.03.1~ce-0~ubuntu-{{ ansible_distribution_release|lower }}
-  'edge': docker-engine=17.05.0~ce-0~ubuntu-{{ ansible_distribution_release|lower }}
+  'latest': docker-ce
+  '1.11': docker-ce=1.11.1-0~{{ ansible_distribution_release|lower }}
+  '1.12': docker-ce=1.12.6-0~ubuntu-{{ ansible_distribution_release|lower }}
+  '1.13': docker-ce=1.13.1-0~ubuntu-{{ ansible_distribution_release|lower }}
+  '17.03': docker-ce=17.03.1~ce-0~ubuntu-{{ ansible_distribution_release|lower }}
+  'stable': docker-ce=17.03.1~ce-0~ubuntu-{{ ansible_distribution_release|lower }}
+  'edge': docker-ce=17.05.0~ce-0~ubuntu-{{ ansible_distribution_release|lower }}
 
 docker_package_info:
   pkg_mgr: apt
@@ -21,12 +21,12 @@ docker_repo_key_info:
   pkg_key: apt_key
   url: '{{ docker_apt_repo_gpgkey }}'
   repo_keys:
-    - 58118E89F3A912897C070ADBF76221572C52609D
+    - 9DC858229FC7DD38854AE2D88D81803C0EBFCD88
 
 docker_repo_info:
   pkg_repo: apt_repository
   repos:
     - >
        deb {{ docker_apt_repo_base_url }}
-       {{ ansible_distribution|lower }}-{{ ansible_distribution_release|lower }}
-       main
+       {{ ansible_distribution_release|lower }}
+       stable

--- a/roles/docker/vars/ubuntu.yml
+++ b/roles/docker/vars/ubuntu.yml
@@ -5,7 +5,7 @@ docker_package_arch: 'amd64'
 # https://download.docker.com/linux/ubuntu/dists/trusty/stable/
 docker_versioned_pkg:
   'latest': docker-ce
-  '17.12': docker-ce=17.03.1~ce-0~ubuntu
+  '17.12': docker-ce=17.12.0~ce-0~ubuntu
   'stable': docker-ce=17.12.0~ce-0~ubuntu
   'edge': docker-ce=18.02.0~ce-0~ubuntu
 


### PR DESCRIPTION
Docker seems to have changed the format & versioning of their APT repo as part of "Project Moby" - this should catch things up to the most recent layout.