### PR TITLE
Increased timeout values for k8s API server restart

### DIFF
--- a/roles/kubernetes/master/handlers/main.yml
+++ b/roles/kubernetes/master/handlers/main.yml
@@ -84,8 +84,8 @@
     client_key: "{{ kube_apiserver_client_key }}"
   register: result
   until: result.status == 200
-  retries: 20
-  delay: 6
+  retries: 30
+  delay: 10
 
 - name: Master | set secret_changed
   command: /bin/true


### PR DESCRIPTION
Related to https://github.com/kubernetes-incubator/kubespray/issues/2310 and https://github.com/kubernetes-incubator/kubespray/issues/2277