### PR TITLE
Update coreos-calico-aio scenario to test no group vars

### DIFF
--- a/tests/cloud_playbooks/create-gce.yml
+++ b/tests/cloud_playbooks/create-gce.yml
@@ -7,6 +7,7 @@
     mode: default
     preemptible: no
     ci_job_name: "{{ lookup('env', 'CI_JOB_NAME') }}"
+    delete_group_vars: no
   tasks:
     - name: include vars for test {{ ci_job_name }}
       include_vars: "../files/{{ ci_job_name }}.yml"
@@ -63,6 +64,13 @@
         src: ../templates/fake_hosts.yml.j2
         dest: "{{ inventory_path|dirname }}/group_vars/fake_hosts.yml"
       when: mode in ['scale', 'separate-scale', 'ha-scale']
+
+    - name: Delete group_vars directory
+      file:
+        path: "{{ inventory_path|dirname }}/group_vars"
+        state: absent
+        recurse: yes
+      when: delete_group_vars
 
 - name: Wait for instances
   hosts: "waitfor_hosts"

--- a/tests/files/coreos-calico-aio.yml
+++ b/tests/files/coreos-calico-aio.yml
@@ -7,6 +7,7 @@ mode: aio
 startup_script: 'systemctl disable locksmithd && systemctl stop locksmithd'
 
 # Deployment settings
+no_group_vars: true
 bootstrap_os: coreos
 kube_network_plugin: calico
 resolvconf_mode: host_resolvconf # this is required as long as the coreos stable channel uses docker < 1.12


### PR DESCRIPTION
This updated scenario ensures deployment still passes without
having any group_vars available.