### PR TITLE
Set filemode to 0640

### DIFF
--- a/roles/kubernetes/master/tasks/users-file.yml
+++ b/roles/kubernetes/master/tasks/users-file.yml
@@ -10,5 +10,6 @@
   template:
     src: known_users.csv.j2
     dest: "{{ kube_users_dir }}/known_users.csv"
+    mode: 0640
     backup: yes
   notify: Master | set secret_changed

--- a/roles/network_plugin/weave/tasks/main.yml
+++ b/roles/network_plugin/weave/tasks/main.yml
@@ -17,4 +17,5 @@
   template:
     src: weave-net.yml.j2
     dest: "{{ kube_config_dir }}/weave-net.yml"
+    mode: 0640
   register: weave_manifest


### PR DESCRIPTION
weave-net.yml file is readable by all users on the host. It however contains the weave_password to encrypt all pod communication. It should only be readable by root.