### PR TITLE
Add Optional Namespace supprot for Registry Addon

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s-cluster.yml
@@ -167,6 +167,7 @@ istio_enabled: false
 
 # Registry deployment
 registry_enabled: false
+registry_namespace: "{{ system_namespace }}"
 
 # Local volume provisioner deployment
 # deprecated will be removed

--- a/roles/kubernetes-apps/registry/defaults/main.yml
+++ b/roles/kubernetes-apps/registry/defaults/main.yml
@@ -3,3 +3,5 @@ registry_image_repo: registry
 registry_image_tag: 2.6
 registry_proxy_image_repo: gcr.io/google_containers/kube-registry-proxy
 registry_proxy_image_tag: 0.4
+
+registry_namespace: "{{ system_namespace }}"

--- a/roles/kubernetes-apps/registry/tasks/main.yml
+++ b/roles/kubernetes-apps/registry/tasks/main.yml
@@ -13,16 +13,17 @@
     src: "{{ item.file }}.j2"
     dest: "{{ kube_config_dir }}/addons/registry/{{ item.file }}"
   with_items:
-    - { name: registry-svc, file: registry-svc.yml, type: service }
-    - { name: registry-rc, file: registry-rc.yml, type: replicationcontroller }
-    - { name: registry-ds, file: registry-ds.yml, type: daemonset }
+    - { name: registry-ns, file: registry-ns.yml, type: ns }
+    - { name: registry-svc, file: registry-svc.yml, type: svc }
+    - { name: registry-rc, file: registry-rc.yml, type: rc }
+    - { name: registry-ds, file: registry-ds.yml, type: ds }
   register: registry_manifests
   when: inventory_hostname == groups['kube-master'][0]
 
 - name: Registry | Apply manifests
   kube:
     name: "{{ item.item.name }}"
-    namespace: "{{ system_namespace }}"
+    namespace: "{{ registry_namespace }}"
     kubectl: "{{ bin_dir }}/kubectl"
     resource: "{{ item.item.type }}"
     filename: "{{ kube_config_dir }}/addons/registry/{{ item.item.file }}"

--- a/roles/kubernetes-apps/registry/templates/registry-ds.yml.j2
+++ b/roles/kubernetes-apps/registry/templates/registry-ds.yml.j2
@@ -3,7 +3,7 @@ apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   name: kube-registry-proxy
-  namespace: {{ system_namespace }}
+  namespace: {{ registry_namespace }}
   labels:
     k8s-app: kube-registry-proxy
     kubernetes.io/cluster-service: "true"

--- a/roles/kubernetes-apps/registry/templates/registry-ns.yml.j2
+++ b/roles/kubernetes-apps/registry/templates/registry-ns.yml.j2
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespacec
+metadata:
+  name: {{ registry_namespace }}

--- a/roles/kubernetes-apps/registry/templates/registry-rc.yml.j2
+++ b/roles/kubernetes-apps/registry/templates/registry-rc.yml.j2
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ReplicationController
 metadata:
   name: kube-registry-v{{ registry_image_tag }}
-  namespace: {{ system_namespace }}
+  namespace: {{ registry_namespace }}
   labels:
     k8s-app: kube-registry-upstream
     version: v{{ registry_image_tag }}

--- a/roles/kubernetes-apps/registry/templates/registry-svc.yml.j2
+++ b/roles/kubernetes-apps/registry/templates/registry-svc.yml.j2
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: kube-registry
-  namespace: {{ system_namespace }}
+  namespace: {{ registry_namespace }}
   labels:
     k8s-app: kube-registry-upstream
     kubernetes.io/cluster-service: "true"


### PR DESCRIPTION
Similar as https://github.com/kubernetes-incubator/kubespray/pull/2230 and https://github.com/kubernetes-incubator/kubespray/pull/2321, also add optional namespace support for Registry addon, so no longer hard code with ``{{ system_namespace }}``