### PR TITLE
Fixup for cephfs_provisioner_namespace

### DIFF
--- a/roles/kubernetes-apps/cephfs_provisioner/tasks/main.yml
+++ b/roles/kubernetes-apps/cephfs_provisioner/tasks/main.yml
@@ -13,6 +13,7 @@
     src: "{{ item.file }}.j2"
     dest: "{{ kube_config_dir }}/addons/cephfs_provisioner/{{ item.file }}"
   with_items:
+    - { name: cephfs-provisioner-ns, file: cephfs-provisioner-ns.yml, type: ns }
     - { name: cephfs-provisioner-sa, file: cephfs-provisioner-sa.yml, type: sa }
     - { name: cephfs-provisioner-role, file: cephfs-provisioner-role.yml, type: role }
     - { name: cephfs-provisioner-rolebinding, file: cephfs-provisioner-rolebinding.yml, type: rolebinding }
@@ -27,7 +28,7 @@
 - name: CephFS Provisioner | Apply manifests
   kube:
     name: "{{ item.item.name }}"
-    namespace: "{{ system_namespace }}"
+    namespace: "{{ cephfs_provisioner_namespace }}"
     kubectl: "{{ bin_dir }}/kubectl"
     resource: "{{ item.item.type }}"
     filename: "{{ kube_config_dir }}/addons/cephfs_provisioner/{{ item.item.file }}"

--- a/roles/kubernetes-apps/cephfs_provisioner/templates/cephfs-provisioner-clusterrole.yml.j2
+++ b/roles/kubernetes-apps/cephfs_provisioner/templates/cephfs-provisioner-clusterrole.yml.j2
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cephfs-provisioner
-  namespace: {{ system_namespace }}
+  namespace: {{ cephfs_provisioner_namespace }}
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]

--- a/roles/kubernetes-apps/cephfs_provisioner/templates/cephfs-provisioner-ns.yml.j2
+++ b/roles/kubernetes-apps/cephfs_provisioner/templates/cephfs-provisioner-ns.yml.j2
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespacec
+metadata:
+  name: {{ cephfs_provisioner_namespace }}

--- a/roles/kubernetes-apps/cephfs_provisioner/templates/cephfs-provisioner-rolebinding.yml.j2
+++ b/roles/kubernetes-apps/cephfs_provisioner/templates/cephfs-provisioner-rolebinding.yml.j2
@@ -7,6 +7,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: cephfs-provisioner
+    namespace: {{ cephfs_provisioner_namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role


### PR DESCRIPTION
Similar as https://github.com/kubernetes-incubator/kubespray/pull/2320, some position forget to use ``{{ cephfs_provisioner_namespacec }}`` correctly.