### PR TITLE
Added support for etcd running on host

### DIFF
--- a/roles/etcd/tasks/configure.yml
+++ b/roles/etcd/tasks/configure.yml
@@ -12,6 +12,16 @@
     ETCDCTL_CERT_FILE: "{{ etcd_cert_dir }}/node-{{ inventory_hostname }}.pem"
     ETCDCTL_KEY_FILE: "{{ etcd_cert_dir }}/node-{{ inventory_hostname }}-key.pem"
 
+- name: Install etcd launch script
+  template:
+    src: etcd.j2
+    dest: "{{ bin_dir }}/etcd"
+    owner: 'root'
+    mode: 0755
+    backup: yes
+  notify: restart etcd
+  when: etcd_deployment_type == "docker" or etcd_deployment_type == "rkt"
+
 - name: Configure | Copy etcd.service systemd file
   template:
     src: "etcd-{{ etcd_deployment_type }}.service.j2"

--- a/roles/etcd/tasks/install_host.yml
+++ b/roles/etcd/tasks/install_host.yml
@@ -1,10 +1,11 @@
 ---
-- name: Install | Copy etcdctl and etcd binary from docker container
-  command: sh -c "{{ docker_bin_dir }}/docker rm -f etcdctl-binarycopy;
-           {{ docker_bin_dir }}/docker create --name etcdctl-binarycopy {{ etcd_image_repo }}:{{ etcd_image_tag }} &&
-           {{ docker_bin_dir }}/docker cp etcdctl-binarycopy:/usr/local/bin/etcdctl {{ bin_dir }}/etcdctl &&
-           {{ docker_bin_dir }}/docker cp etcdctl-binarycopy:/usr/local/bin/etcd {{ bin_dir }}/etcd &&
-           {{ docker_bin_dir }}/docker rm -f etcdctl-binarycopy"
+- name: Install | Copy etcd and etcdctl binaries from docker container
+  command: sh -c "{{ docker_bin_dir }}/docker rm -f etcd-binarycopy;
+           {{ docker_bin_dir }}/docker create --name etcd-binarycopy {{ etcd_image_repo }}:{{ etcd_image_tag }} &&
+           {{ docker_bin_dir }}/docker cp etcd-binarycopy:/usr/local/bin/etcd {{ bin_dir }}/etcd &&
+           {{ docker_bin_dir }}/docker cp etcd-binarycopy:/usr/local/bin/etcdctl {{ bin_dir }}/etcdctl &&
+           {{ docker_bin_dir }}/docker rm -f etcd-binarycopy"
+  when: etcd_deployment_type == "host"
   register: etcd_task_result
   until: etcd_task_result.rc == 0
   retries: 4


### PR DESCRIPTION
Related to issue: https://github.com/kubernetes-incubator/kubespray/issues/2336

This code change adds support for etcd_deployment_type=host. It seems that this feature was somehow foreseen before since the systemd config file was already in the repo.