### PR TITLE
gather facts for all nodes, even if running for single one (--limit)

### DIFF
--- a/cluster.yml
+++ b/cluster.yml
@@ -21,6 +21,12 @@
   vars:
     ansible_ssh_pipelining: true
   gather_facts: true
+  pre_tasks:
+    - name: gather facts from all instances
+      setup:
+      delegate_to: "{{item}}"
+      delegate_facts: True
+      with_items: "{{ groups['k8s-cluster'] + groups['etcd'] + groups['calico-rr'] }}"
 
 - hosts: k8s-cluster:etcd:calico-rr
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"

--- a/upgrade-cluster.yml
+++ b/upgrade-cluster.yml
@@ -21,6 +21,12 @@
   vars:
     ansible_ssh_pipelining: true
   gather_facts: true
+  pre_tasks:
+    - name: gather facts from all instances
+      setup:
+      delegate_to: "{{item}}"
+      delegate_facts: True
+      with_items: "{{ groups['k8s-cluster'] + groups['etcd'] + groups['calico-rr'] }}"
 
 - hosts: k8s-cluster:etcd:calico-rr
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"


### PR DESCRIPTION
* without this, ansible never collects facts for other nodes, so for example, when adding a new worker node and targeting only it with `--limit`, preinstallation checks will fail
* might be related to #1114