### PR TITLE
Use legacy policy config to apply the scheduler policy

### DIFF
--- a/roles/kubernetes/master/templates/manifests/kube-scheduler.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-scheduler.manifest.j2
@@ -29,6 +29,7 @@ spec:
     - --leader-elect=true
     - --kubeconfig={{ kube_config_dir }}/kube-scheduler-kubeconfig.yaml
 {% if volume_cross_zone_attachment %}
+    - --use-legacy-policy-config
     - --policy-config-file={{ kube_config_dir }}/kube-scheduler-policy.yaml
 {% endif %}
     - --profiling=false


### PR DESCRIPTION
When setting the `volume_cross_zone_attachment: true`, kube-scheduler the custom policy file is ignored.

Relates to #2155 and #2141