### PR TITLE
set nodeName to "{{ inventory_hostname }}" in kubeadm-config

### DIFF
--- a/roles/kubernetes/master/templates/kubeadm-config.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.yaml.j2
@@ -84,6 +84,6 @@ apiServerCertSANs:
 certificatesDir: {{ kube_config_dir }}/ssl
 unifiedControlPlaneImage: "{{ hyperkube_image_repo }}:{{ hyperkube_image_tag }}"
 {% if kube_override_hostname|default('') %}
-nodeName: {{ inventory_hostname }}
+nodeName: {{ kube_override_hostname }}
 {% endif %}
 

--- a/roles/kubernetes/master/templates/kubeadm-config.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.yaml.j2
@@ -83,5 +83,7 @@ apiServerCertSANs:
 {% endfor %}
 certificatesDir: {{ kube_config_dir }}/ssl
 unifiedControlPlaneImage: "{{ hyperkube_image_repo }}:{{ hyperkube_image_tag }}"
+{% if kube_override_hostname|default('') %}
 nodeName: {{ inventory_hostname }}
+{% endif %}
 

--- a/roles/kubernetes/master/templates/kubeadm-config.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.yaml.j2
@@ -83,3 +83,5 @@ apiServerCertSANs:
 {% endfor %}
 certificatesDir: {{ kube_config_dir }}/ssl
 unifiedControlPlaneImage: "{{ hyperkube_image_repo }}:{{ hyperkube_image_tag }}"
+nodeName: {{ inventory_hostname }}
+


### PR DESCRIPTION
set nodeName to {{ inventory_hostname }} to match how it's being set in other various places within kubespray. 

I'm not sure if this is a breaking change for folks that maybe have initialized successfully with an fqdn, the apiServerCertSANs is being set with this same data, so i think this should be the desired option. 

