### PR TITLE
Issue 2353: Retain iptables config across reboots on Container Linux

### DIFF
--- a/contrib/terraform/openstack/modules/network/main.tf
+++ b/contrib/terraform/openstack/modules/network/main.tf
@@ -2,7 +2,7 @@
 resource "openstack_networking_router_v2" "k8s" {
   name             = "${var.cluster_name}-router"
   admin_state_up   = "true"
-  external_gateway = "${var.external_net}"
+  external_network_id = "${var.external_net}"
 }
 
 resource "openstack_networking_network_v2" "k8s" {

--- a/roles/kubernetes/preinstall/tasks/main.yml
+++ b/roles/kubernetes/preinstall/tasks/main.yml
@@ -293,6 +293,22 @@
     - bootstrap-os
     - resolvconf
 
+- name: Retain firewall configuration
+  command: systemctl enable iptables-store.service
+  when:
+    - ansible_os_family in ["CoreOS", "Container Linux by CoreOS"]
+    - kube_proxy_mode == 'iptables'
+  tags:
+    - network
+
+- name: Restore firewall configuration
+  command: systemctl enable iptables-restore.service
+  when:
+    - ansible_os_family in ["CoreOS", "Container Linux by CoreOS"]
+    - kube_proxy_mode == 'iptables'
+  tags:
+    - network
+
 - name: Check if we are running inside a Azure VM
   stat:
     path: /var/lib/waagent/


### PR DESCRIPTION
This PR includes two changes:

* A minor fix to the Terraform module for OpenStack to avoid a deprecation warning on the use of `external_gateway`
* Ansible pre-install tasks to enable iptables save/restore handlers in CoreOS when using iptables for kube-proxy (see issue #2353)
