### PR TITLE
Set TasksMax to infinity on any OS with systemd

### DIFF
--- a/roles/docker/tasks/systemd.yml
+++ b/roles/docker/tasks/systemd.yml
@@ -12,9 +12,9 @@
   when: http_proxy is defined or https_proxy is defined
 
 - name: get systemd version
-  command: rpm -q --qf '%{V}\n' systemd
+  command: systemctl --version | head -n 1 | cut -d " " -f 2
   register: systemd_version
-  when: ansible_os_family == "RedHat" and not is_atomic
+  when: not is_atomic
   changed_when: false
 
 - name: Write docker.service systemd file

--- a/roles/docker/templates/docker.service.j2
+++ b/roles/docker/templates/docker.service.j2
@@ -24,7 +24,7 @@ ExecStart={{ docker_bin_dir }}/docker{% if installed_docker_version.stdout|versi
           $DOCKER_NETWORK_OPTIONS \
           $DOCKER_DNS_OPTIONS \
           $INSECURE_REGISTRY
-{% if systemd_version.stdout|int >= 226 %}
+{% if not is_atomic and systemd_version.stdout|int >= 226 %}
 TasksMax=infinity
 {% endif %}
 LimitNOFILE=1048576

--- a/roles/docker/templates/docker.service.j2
+++ b/roles/docker/templates/docker.service.j2
@@ -24,7 +24,7 @@ ExecStart={{ docker_bin_dir }}/docker{% if installed_docker_version.stdout|versi
           $DOCKER_NETWORK_OPTIONS \
           $DOCKER_DNS_OPTIONS \
           $INSECURE_REGISTRY
-{% if ansible_os_family == "RedHat" and systemd_version.stdout|int >= 226 %}
+{% if systemd_version.stdout|int >= 226 %}
 TasksMax=infinity
 {% endif %}
 LimitNOFILE=1048576


### PR DESCRIPTION
Get systemd version from any OS other than atomic. Get the version from the systemd command. Set TasksMax=infinity for any OS that has a systemd version greater than 226.