### PR TITLE
Fixing cert name in calico when we delegate to etcd[0]

### DIFF
--- a/roles/network_plugin/calico/tasks/main.yml
+++ b/roles/network_plugin/calico/tasks/main.yml
@@ -83,8 +83,8 @@
   uri:
     url: https://localhost:2379/health
     validate_certs: no
-    client_cert: "{{ etcd_cert_dir }}/node-{{ inventory_hostname }}.pem"
-    client_key: "{{ etcd_cert_dir }}/node-{{ inventory_hostname }}-key.pem"
+    client_cert: "{{ etcd_cert_dir }}/node-{{ groups['etcd'][0] }}.pem"
+    client_key: "{{ etcd_cert_dir }}/node-{{ groups['etcd'][0] }}-key.pem"
   register: result
   until: result.status == 200 or result.status == 401
   retries: 10

--- a/roles/network_plugin/canal/tasks/main.yml
+++ b/roles/network_plugin/canal/tasks/main.yml
@@ -35,8 +35,8 @@
   changed_when: false
   run_once: true
   environment:
-    ETCDCTL_CERT_FILE: "{{ etcd_cert_dir }}/node-{{ inventory_hostname }}.pem"
-    ETCDCTL_KEY_FILE: "{{ etcd_cert_dir }}/node-{{ inventory_hostname }}-key.pem"
+    ETCDCTL_CERT_FILE: "{{ etcd_cert_dir }}/node-{{ groups['etcd'][0] }}.pem"
+    ETCDCTL_KEY_FILE: "{{ etcd_cert_dir }}/node-{{ groups['etcd'][0] }}-key.pem"
 
 - name: Canal | Create canal node manifests
   template:


### PR DESCRIPTION
This fixes a bug with upgrades. 

```
TASK [network_plugin/calico : Calico | wait for etcd] ********************************************************************************************************
task path: /kubespray/roles/network_plugin/calico/tasks/main.yml:82
The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_vRbB7m/ansible_modlib.zip/ansible/module_utils/urls.py", line 1044, in fetch_url
    client_key=client_key, cookies=cookies)
  File "/tmp/ansible_vRbB7m/ansible_modlib.zip/ansible/module_utils/urls.py", line 951, in open_url
    r = urllib_request.urlopen(*urlopen_args)
  File "/usr/lib/python2.7/urllib2.py", line 154, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/lib/python2.7/urllib2.py", line 429, in open
    response = self._open(req, data)
  File "/usr/lib/python2.7/urllib2.py", line 447, in _open
    '_open', req)
  File "/usr/lib/python2.7/urllib2.py", line 407, in _call_chain
    result = func(*args)
  File "/tmp/ansible_vRbB7m/ansible_modlib.zip/ansible/module_utils/urls.py", line 417, in https_open
    return self.do_open(self._build_https_connection, req)
  File "/usr/lib/python2.7/urllib2.py", line 1167, in do_open
    h = http_class(host, timeout=req.timeout, **http_conn_args)
  File "/tmp/ansible_vRbB7m/ansible_modlib.zip/ansible/module_utils/urls.py", line 428, in _build_https_connection
    return httplib.HTTPSConnection(host, **kwargs)
  File "/usr/lib/python2.7/httplib.py", line 1264, in __init__
    context.load_cert_chain(cert_file, key_file)
IOError: [Errno 2] No such file or directory

fatal: [kube02.stargazer.local -> 10.100.48.38]: FAILED! => {
    "attempts": 10, 
    "changed": false, 
    "content": "", 
    "failed": true, 
    "invocation": {
        "module_args": {
            "attributes": null, 
            "backup": null, 
            "body": null, 
            "body_format": "raw", 
            "client_cert": "/etc/ssl/etcd/ssl/node-kube02.local.pem", 
            "client_key": "/etc/ssl/etcd/ssl/node-kube02.local-key.pem", 
            "content": null, 
            "creates": null, 
            "delimiter": null, 
            "dest": null, 
            "directory_mode": null, 
            "follow": false, 
            "follow_redirects": "safe", 
            "force": false, 
            "force_basic_auth": false, 
            "group": null, 
            "headers": {}, 
            "http_agent": "ansible-httpget", 
            "method": "GET", 
            "mode": null, 
            "owner": null, 
            "regexp": null, 
            "remote_src": null, 
            "removes": null, 
            "return_content": false, 
            "selevel": null, 
            "serole": null, 
            "setype": null, 
            "seuser": null, 
            "src": null, 
            "status_code": [
                200
            ], 
            "timeout": 30, 
            "unsafe_writes": null, 
            "url": "https://localhost:2379/health", 
            "url_password": null, 
            "url_username": null, 
            "use_proxy": true, 
            "validate_certs": false
        }
    }, 
    "msg": "Status code was not [200]: An unknown error occurred: [Errno 2] No such file or directory", 
    "redirected": false, 
    "status": -1, 
    "url": "https://localhost:2379/health"
}
```