### PR TITLE
Fixed generate front proxy client certs with vault

### DIFF
--- a/roles/etcd/defaults/main.yml
+++ b/roles/etcd/defaults/main.yml
@@ -32,7 +32,7 @@ etcd_memory_limit: "{% if ansible_memtotal_mb < 4096 %}512M{% else %}0{% endif %
 
 etcd_blkio_weight: 1000
 
-etcd_node_cert_hosts: "{{ groups['k8s-cluster'] | union(groups.get('calico-rr', [])) }}"
+etcd_node_cert_hosts: "{{ groups['k8s-cluster'] | union(groups.get('calico-rr', [])) | union(groups.get('vault', [])) }}"
 
 etcd_compaction_retention: "8"
 

--- a/roles/kubernetes/secrets/tasks/gen_certs_vault.yml
+++ b/roles/kubernetes/secrets/tasks/gen_certs_vault.yml
@@ -116,6 +116,6 @@
     issue_cert_role: front-proxy-client
     issue_cert_url: "{{ hostvars[groups.vault|first]['vault_leader_url'] }}"
     issue_cert_mount_path: "{{ kube_vault_mount_path }}"
-  with_items: "{{ kube_master_components_certs_needed|d([]) }}"
+  with_items: "{{ kube_front_proxy_clients_certs_needed|d([]) }}"
   when: inventory_hostname in groups['kube-master']
   notify: set secret_changed

--- a/roles/kubernetes/secrets/tasks/sync_kube_master_certs.yml
+++ b/roles/kubernetes/secrets/tasks/sync_kube_master_certs.yml
@@ -32,7 +32,7 @@
     sync_file_hosts: "{{ groups['kube-master'] }}"
     sync_file_is_cert: true
     sync_file_owner: kube
-  with_items: ["apiserver.pem", "kube-scheduler.pem", "kube-controller-manager.pem", "front-proxy-client.pem"]
+  with_items: ["apiserver.pem", "kube-scheduler.pem", "kube-controller-manager.pem"]
 
 - name: sync_kube_master_certs | Set facts for kube master components sync_file results
   set_fact:
@@ -41,6 +41,26 @@
   when: item.no_srcs|bool
 
 - name: sync_kube_master_certs | Unset sync_file_results after kube master components cert
+  set_fact:
+    sync_file_results: []
+
+- include_tasks: ../../../vault/tasks/shared/sync_file.yml
+  vars:
+    sync_file: "{{ item }}"
+    sync_file_dir: "{{ kube_cert_dir }}"
+    sync_file_group: "{{ kube_cert_group }}"
+    sync_file_hosts: "{{ groups['kube-master'] }}"
+    sync_file_is_cert: true
+    sync_file_owner: kube
+  with_items: ["front-proxy-client.pem"]
+
+- name: sync_kube_master_certs | Set facts for front-proxy-client certs sync_file results
+  set_fact:
+    kube_front_proxy_clients_certs_needed: "{{ kube_front_proxy_clients_certs_needed|d([]) + [item.path] }}"
+  with_items: "{{ sync_file_results|d([]) }}"
+  when: item.no_srcs|bool
+
+- name: sync_kube_master_certs | Unset sync_file_results after front-proxy-client sync
   set_fact:
     sync_file_results: []
 

--- a/tests/files/gce_ubuntu-vault-sep.yml
+++ b/tests/files/gce_ubuntu-vault-sep.yml
@@ -6,7 +6,7 @@ mode: separate
 
 # Instance settings
 bootstrap_os: ubuntu
-cert_mgmt: vault
+cert_management: vault
 kube_network_plugin: canal
 deploy_netchecker: true
 kubedns_min_replicas: 1


### PR DESCRIPTION
After changes https://github.com/kubernetes-incubator/kubespray/pull/2251/files#diff-5ed62ced0ee77f0150eb0e961ce32497R119 vault deployment was broken, it regenerate core components certificates with wrong `CN`:

```
root@control-01:/etc/kubernetes/ssl# openssl x509 -in apiserver.pem -text -noout 
   Subject: O=system:kube-aggregator, CN=front-proxy-client
```
