### PR TITLE
Use CNI to assign kube_pods_subnet for calico

### DIFF
--- a/roles/etcd/defaults/main.yml
+++ b/roles/etcd/defaults/main.yml
@@ -32,7 +32,7 @@ etcd_memory_limit: "{% if ansible_memtotal_mb < 4096 %}512M{% else %}0{% endif %
 
 etcd_blkio_weight: 1000
 
-etcd_node_cert_hosts: "{{ groups['k8s-cluster'] | union(groups.get('calico-rr', [])) }}"
+etcd_node_cert_hosts: "{{ groups['k8s-cluster'] | union(groups.get('calico-rr', [])) | union(groups.get('vault', [])) }}"
 
 etcd_compaction_retention: "8"
 

--- a/roles/network_plugin/calico/defaults/main.yml
+++ b/roles/network_plugin/calico/defaults/main.yml
@@ -16,9 +16,6 @@ etcd_cert_dir: /etc/ssl/etcd/ssl
 # Global as_num (/calico/bgp/v1/global/as_num)
 global_as_num: "64512"
 
-# Set to true if you need to configure multiple pools (this is not common)
-calico_ignore_extra_pools: false
-
 # You can set MTU value here. If left undefined or empty, it will
 # not be specified in calico CNI config, so Calico will use built-in
 # defaults. The value should be a number, not a string.

--- a/roles/network_plugin/calico/tasks/main.yml
+++ b/roles/network_plugin/calico/tasks/main.yml
@@ -138,14 +138,6 @@
     calico_pools: "{{ calico_pools_raw.stdout | from_json }}"
   run_once: true
 
-- name: Calico | Check if calico pool is properly configured
-  fail:
-    msg: 'Only one network pool must be configured and it must be the subnet {{ kube_pods_subnet }}.
-    Please erase calico configuration and run the playbook again ("etcdctl rm --recursive /calico/v1/ipam/v4/pool")'
-  when: ( calico_pools['node']['nodes'] | length > 1 and not calico_ignore_extra_pools ) or
-        ( not calico_pools['node']['nodes'][0]['key'] | search(".*{{ kube_pods_subnet | ipaddr('network') }}.*") )
-  run_once: true
-
 - name: Calico | Set global as_num
   command: "{{ bin_dir}}/calicoctl config set asNumber {{ global_as_num }}"
   run_once: true

--- a/roles/network_plugin/calico/templates/cni-calico.conflist.j2
+++ b/roles/network_plugin/calico/templates/cni-calico.conflist.j2
@@ -15,16 +15,18 @@
       "etcd_ca_cert_file": "{{ etcd_cert_dir }}/ca.pem",
       "log_level": "info",
       "ipam": {
-        "type": "calico-ipam"
+        "type": "calico-ipam",
+        "assign_ipv4": "true",
+        "ipv4_pools": ["{{ kube_pods_subnet }}"]
       },
     {% if enable_network_policy %}
       "policy": {
         "type": "k8s"
       },
-    {% endif %}
+    {%- endif %}
     {% if calico_mtu is defined and calico_mtu is number %}
       "mtu": {{ calico_mtu }},
-    {% endif %}
+    {%- endif %}
       "kubernetes": {
         "kubeconfig": "{{ kube_config_dir }}/node-kubeconfig.yaml"
       }


### PR DESCRIPTION
Now calico can be deployed if there are other existing pools
and not confuse IPAM and end up with pods in the wrong pools.