### PR TITLE
fix apiserver manifest when disabling insecure_port

### DIFF
--- a/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
@@ -123,7 +123,7 @@ spec:
       httpGet:
         host: 127.0.0.1
         path: /healthz
-{% if kube_apiserver_insecure_port == 0 %}
+{% if kube_apiserver_insecure_port|int == 0 %}
         port: {{ kube_apiserver_port }}
         scheme: HTTPS
 {% else %}


### PR DESCRIPTION
Jinja2 seems to be casting `kube_apiserver_insecure_port` as a string; when set to `0` it does not pass the conditionals in the kube-apiserver.manifest template to enable secure livenessProbes.
 