### PR TITLE
Document sneaky etcd memory limit...

### DIFF
--- a/inventory/sample/group_vars/all.yml
+++ b/inventory/sample/group_vars/all.yml
@@ -128,5 +128,9 @@ bin_dir: /usr/local/bin
 ## Set level of detail for etcd exported metrics, specify 'extensive' to include histogram metrics.
 #etcd_metrics: basic
 
+## Etcd is restricted by default to 512M on systems under 4GB RAM, 512MB is not enough for much more than testing.
+## Set this if your etcd nodes have less than 4GB but you want more RAM for etcd. Set to 0 for unrestricted RAM.
+#etcd_memory_limit: "512M"
+
 # The read-only port for the Kubelet to serve on with no authentication/authorization. Uncomment to enable.
 # kube_read_only_port: 10255


### PR DESCRIPTION
Adding this into the default example inventory so it has less of a chance of biting others after weeks of random failures (as etcd does not  express that it has run out of RAM it just stalls).. 512MB was not  enough for us to run one of our products.