### PR TITLE
[WIP] Correct variable reference in definition of private_subnet_id (issue #2367)

### DIFF
--- a/contrib/terraform/openstack/kubespray.tf
+++ b/contrib/terraform/openstack/kubespray.tf
@@ -53,7 +53,7 @@ module "compute" {
 }
 
 output "private_subnet_id" {
-  value = "${module.network.subnet_id}"
+  value = "${module.network.network_id}"
 }
 
 output "floating_network_id" {


### PR DESCRIPTION
Ref issue #2367.

Corrects reference in definition of `private_subnet_id`.

`terraform init <...>` was failing for OpenStack deployments:

```ShellSession
$ terraform init contrib/terraform/openstack
Initializing modules...
- module.network
- module.ips
- module.compute


Error: output 'private_subnet_id': "subnet_id" is not a valid output for module "network"
```