### PR TITLE
Correct use of deprecated argument to TF/OpenStack module

### DIFF
--- a/contrib/terraform/openstack/modules/network/main.tf
+++ b/contrib/terraform/openstack/modules/network/main.tf
@@ -1,7 +1,7 @@
 resource "openstack_networking_router_v2" "k8s" {
-  name             = "${var.cluster_name}-router"
-  admin_state_up   = "true"
-  external_gateway = "${var.external_net}"
+  name                = "${var.cluster_name}-router"
+  admin_state_up      = "true"
+  external_network_id = "${var.external_net}"
 }
 
 resource "openstack_networking_network_v2" "k8s" {


### PR DESCRIPTION
Use of deprecated argument `external_gateway` to openstack_networking_router_v2 entity in OpenStack module for Terraform led to following warning on OpenStack deployments:

```
Warning: module.network.openstack_networking_router_v2.k8s: "external_gateway": [DEPRECATED] use external_network_id instead
```

https://www.terraform.io/docs/providers/openstack/r/networking_router_v2.html#external_gateway