### PR TITLE
Remove redundant spaces

### DIFF
--- a/inventory/sample/group_vars/all.yml
+++ b/inventory/sample/group_vars/all.yml
@@ -17,7 +17,7 @@ bin_dir: /usr/local/bin
 ### LOADBALANCING AND ACCESS MODES
 ## Enable multiaccess to configure etcd clients to access all of the etcd members directly
 ## as the "http://hostX:port, http://hostY:port, ..." and ignore the proxy loadbalancers.
-## This may be the case if clients support and loadbalance multiple etcd servers  natively.
+## This may be the case if clients support and loadbalance multiple etcd servers natively.
 #etcd_multiaccess: true
 
 ### ETCD: disable peer client cert authentication.
@@ -42,7 +42,7 @@ bin_dir: /usr/local/bin
 ## for mounting persistent volumes into containers.  These may not be loaded by preinstall kubernetes
 ## processes.  For example, ceph and rbd backed volumes.  Set to true to allow kubelet to load kernel
 ## modules.
-# kubelet_load_modules: false
+#kubelet_load_modules: false
 
 ## Internal network total size. This is the prefix of the
 ## entire network. Must be unused in your environment.
@@ -111,7 +111,7 @@ bin_dir: /usr/local/bin
 
 ## Default packages to install within the cluster, f.e:
 #kpm_packages:
-#  - name: kube-system/grafana
+# - name: kube-system/grafana
 
 ## Certificate Management
 ## This setting determines whether certs are generated via scripts or whether a
@@ -129,4 +129,4 @@ bin_dir: /usr/local/bin
 #etcd_metrics: basic
 
 # The read-only port for the Kubelet to serve on with no authentication/authorization. Uncomment to enable.
-# kube_read_only_port: 10255
+#kube_read_only_port: 10255


### PR DESCRIPTION
What this PR does / why we need it:
1. There are two spaces in the comment
2. Some of the commented variables are not consistently aligned with others. 