### PR TITLE
Install Python on all hosts

### DIFF
--- a/cluster.yml
+++ b/cluster.yml
@@ -1,4 +1,11 @@
 ---
+- hosts: all
+  gather_facts: False
+  
+  tasks:
+  - name: install python 2
+    raw: test -e /usr/bin/python || (apt -y update && apt install -y python-minimal)
+
 - hosts: localhost
   gather_facts: False
   roles:


### PR DESCRIPTION
Add this snippet to the top of mail playbook. 
It will install python2 if missing (but checks first so no expensive repeated apt updates)
https://gist.github.com/gwillem/4ba393dceb55e5ae276a87300f6b8e6f