### PR TITLE
update local-volume-storage to v2.0.0

### DIFF
--- a/roles/kubernetes-apps/local_volume_provisioner/defaults/main.yml
+++ b/roles/kubernetes-apps/local_volume_provisioner/defaults/main.yml
@@ -1,6 +1,3 @@
 ---
-local_volume_provisioner_bootstrap_image_repo: quay.io/external_storage/local-volume-provisioner-bootstrap
-local_volume_provisioner_bootstrap_image_tag: v1.0.1
-
 local_volume_provisioner_image_repo: quay.io/external_storage/local-volume-provisioner
-local_volume_provisioner_image_tag: v1.0.1
+local_volume_provisioner_image_tag: v2.0.0

--- a/roles/kubernetes-apps/local_volume_provisioner/tasks/main.yml
+++ b/roles/kubernetes-apps/local_volume_provisioner/tasks/main.yml
@@ -27,6 +27,7 @@
     - { name: local-volume-clusterrolebinding, file: clusterrolebinding.yml, type, clusterrolebinding }
     - { name: local-volume-configmap, file: configmap.yml, type, configmap }
     - { name: local-volume-daemonset, file: daemonset.yml, type, daemonset }
+    - { name: local-volume-storageclass, file: storageclass.yml, type, storageclass }
   register: local_volume_manifests
   when: inventory_hostname == groups['kube-master'][0]
 

--- a/roles/kubernetes-apps/local_volume_provisioner/templates/configmap.yml.j2
+++ b/roles/kubernetes-apps/local_volume_provisioner/templates/configmap.yml.j2
@@ -7,8 +7,7 @@ metadata:
   name: local-volume-config
   namespace: {{ system_namespace }}
 data:
-  "{{ local_volume_storage_class }}": |
-    {
-      "hostDir": "{{ local_volume_base_dir }}",
-      "mountDir": "{{ local_volume_mount_dir }}"
-    }
+  storageClassMap: |
+    {{ local_volume_storage_class }}:
+      hostDir: {{ local_volume_base_dir }}
+      mountDir:  {{ local_volume_mount_dir }}

--- a/roles/kubernetes-apps/local_volume_provisioner/templates/storageclass.yml.j2
+++ b/roles/kubernetes-apps/local_volume_provisioner/templates/storageclass.yml.j2
@@ -1,0 +1,7 @@
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: {{ local_volume_storage_class }}
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -199,7 +199,7 @@ rbac_enabled: "{{ 'RBAC' in authorization_modes or kubeadm_enabled }}"
 
 ## List of key=value pairs that describe feature gates for
 ## the k8s cluster.
-kube_feature_gates: ['Initializers={{ istio_enabled|string }}', 'PersistentLocalVolumes={{ local_volume_provisioner_enabled|string }}']
+kube_feature_gates: ['Initializers={{ istio_enabled|string }}', 'PersistentLocalVolumes={{ local_volume_provisioner_enabled|string }}', 'VolumeScheduling={{ local_volume_provisioner_enabled|string }}', 'MountPropagation={{ local_volume_provisioner_enabled|string }}']
 
 # Vault data dirs.
 vault_base_dir: /etc/vault


### PR DESCRIPTION
ref https://github.com/kubernetes-incubator/external-storage/tree/local-volume-provisioner-v2.0.0/local-volume to update local-volueme-storage to v2.0.0
update below:
1. delete unused image(local_volume_provisioner_bootstrap_image)
2. update image to v2.0.0(local_volume_provisioner_image)
3. add local-volume-storageclass to more easy to use.