### PR TITLE
Install latest version of Helm

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -122,7 +122,7 @@ kibana_version: "v4.6.1"
 kibana_image_repo: "gcr.io/google_containers/kibana"
 kibana_image_tag: "{{ kibana_version }}"
 
-helm_version: "v2.7.2"
+helm_version: "v2.8.1"
 helm_image_repo: "lachlanevenson/k8s-helm"
 helm_image_tag: "{{ helm_version }}"
 tiller_image_repo: "gcr.io/kubernetes-helm/tiller"


### PR DESCRIPTION
This patch makes Kubespray install the latest version of Helm by default: https://github.com/kubernetes/helm/releases