### PR TITLE
add new docker repos for debian

### DIFF
--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -17,4 +17,5 @@ docker_container_storage_setup: false
 docker_rh_repo_base_url: 'https://yum.dockerproject.org/repo/main/centos/7'
 docker_rh_repo_gpgkey: 'https://yum.dockerproject.org/gpg'
 docker_apt_repo_base_url: 'https://apt.dockerproject.org/repo'
-docker_apt_repo_gpgkey: 'https://apt.dockerproject.org/gpg'
+docker_apt_repo_new_base_url: 'https://download.docker.com/linux/{{ ansible_distribution|lower }}'
+docker_apt_repo_gpgkey: 'https://download.docker.com/linux/{{ ansible_distribution|lower }}/gpg'

--- a/roles/docker/vars/debian.yml
+++ b/roles/docker/vars/debian.yml
@@ -8,6 +8,9 @@ docker_versioned_pkg:
   '1.12': docker-engine=1.12.6-0~debian-{{ ansible_distribution_release|lower }}
   '1.13': docker-engine=1.13.1-0~debian-{{ ansible_distribution_release|lower }}
   '17.03': docker-engine=17.03.1~ce-0~debian-{{ ansible_distribution_release|lower }}
+  '17.06': docker-ce=17.06.2~ce-0~debian
+  '17.09': docker-ce=17.09.1~ce-0~debian
+  '17.12': docker-ce=17.12.1~ce-0~debian
   'stable': docker-engine=17.03.1~ce-0~debian-{{ ansible_distribution_release|lower }}
   'edge': docker-engine=17.05.0~ce-0~debian-{{ ansible_distribution_release|lower }}
 
@@ -22,6 +25,7 @@ docker_repo_key_info:
   url: '{{ docker_apt_repo_gpgkey }}'
   repo_keys:
     - 58118E89F3A912897C070ADBF76221572C52609D
+    - 9DC858229FC7DD38854AE2D88D81803C0EBFCD88
 
 docker_repo_info:
   pkg_repo: apt_repository
@@ -30,3 +34,7 @@ docker_repo_info:
        deb {{ docker_apt_repo_base_url }}
        {{ ansible_distribution|lower }}-{{ ansible_distribution_release|lower }}
        main
+    - >
+       deb [arch=amd64] {{ docker_apt_repo_new_base_url }}
+       {{ ansible_distribution_release|lower }}
+       stable


### PR DESCRIPTION
this adds the new docker repos for debian (#1939) for docker>=17.06  and keeps the old repos for previous versions.

docker < 17.06:
  repo: apt.dockerproject.org
  package: docker-engine
docker >= 17.06:
  repo: download.docker.com
  package: docker-ce

I tested this with debian.
