### PR TITLE
Add Custom ConfigMap Support for ingress-nginx

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s-cluster.yml
@@ -192,6 +192,13 @@ ingress_nginx_enabled: false
 # ingress_nginx_namespace: "ingress-nginx"
 # ingress_nginx_insecure_port: 80
 # ingress_nginx_secure_port: 443
+# ingress_nginx_configmap:
+#   map-hash-bucket-size: "128"
+#   ssl-protocols: "SSLv2"
+# ingress_nginx_configmap_tcp_services:
+#   9000: "default/example-go:8080"
+# ingress_nginx_configmap_udp_services:
+#   53: "kube-system/kube-dns:53"
 
 # Add Persistent Volumes Storage Class for corresponding cloud provider ( OpenStack is only supported now )
 persistent_volumes_enabled: false

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/defaults/main.yml
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/defaults/main.yml
@@ -8,3 +8,6 @@ ingress_nginx_controller_image_tag: 0.11.0
 ingress_nginx_namespace: "ingress-nginx"
 ingress_nginx_insecure_port: 80
 ingress_nginx_secure_port: 443
+ingress_nginx_configmap: {}
+ingress_nginx_configmap_tcp_services: {}
+ingress_nginx_configmap_udp_services: {}

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ingress-nginx-cm.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ingress-nginx-cm.yml.j2
@@ -6,3 +6,5 @@ metadata:
   namespace: {{ ingress_nginx_namespace }}
   labels:
     k8s-app: ingress-nginx
+data:
+  {{ ingress_nginx_configmap | to_nice_yaml }}

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ingress-nginx-tcp-servicecs-cm.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ingress-nginx-tcp-servicecs-cm.yml.j2
@@ -6,3 +6,5 @@ metadata:
   namespace: {{ ingress_nginx_namespace }}
   labels:
     k8s-app: ingress-nginx
+data:
+  {{ ingress_nginx_configmap_tcp_services | to_nice_yaml }}

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ingress-nginx-udp-servicecs-cm.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ingress-nginx-udp-servicecs-cm.yml.j2
@@ -6,3 +6,5 @@ metadata:
   namespace: {{ ingress_nginx_namespace }}
   labels:
     k8s-app: ingress-nginx
+data:
+  {{ ingress_nginx_configmap_udp_services | to_nice_yaml }}


### PR DESCRIPTION
By default ingress-nginx require for 3 ConfigMap but I leave it as empty in original implementation, in order to simplify for debug :-P

With this patch we could apply custom ConfigMap to ingress-nginx in yaml dict format, which is very useful, e.g. I hope to use ingress-nginx to handle a backend BitBucket port 7999 in TCP for git connection ;-)

See:
* https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/configmap.md
* https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/exposing-tcp-udp-services.md