### PR TITLE
FIXUP #2424: local_provisioner directory should be created only if enabled

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s-cluster.yml
@@ -171,8 +171,8 @@ registry_enabled: false
 # Local volume provisioner deployment
 local_volume_provisioner_enabled: false
 # local_volume_provisioner_namespace: "{{ system_namespace }}"
-local_volume_provisioner_base_dir: /mnt/disks
-local_volume_provisioner_mount_dir: /mnt/disks
+# local_volume_provisioner_base_dir: /mnt/disks
+# local_volume_provisioner_mount_dir: /mnt/disks
 # local_volume_provisioner_storage_class: local-storage
 
 # CephFS provisioner deployment

--- a/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-ns.yml.j2
+++ b/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-ns.yml.j2
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ local_volume_provisioner_namespace }}
+  labels:
+    name: {{ local_volume_provisioner_namespace }}

--- a/roles/kubernetes/node/templates/kubelet-container.j2
+++ b/roles/kubernetes/node/templates/kubelet-container.j2
@@ -26,9 +26,6 @@
   -v /var/run:/var/run:rw \
   -v {{kube_config_dir}}:{{kube_config_dir}}:ro \
   -v /etc/os-release:/etc/os-release:ro \
-{% if local_volume_provisioner_enabled == true %}
-  -v {{ local_volume_provisioner_base_dir }}:{{ local_volume_provisioner_base_dir }}:shared \
-{% endif %}
   {{ hyperkube_image_repo }}:{{ hyperkube_image_tag}} \
   ./hyperkube kubelet \
   "$@"

--- a/roles/kubernetes/node/templates/kubelet.rkt.service.j2
+++ b/roles/kubernetes/node/templates/kubelet.rkt.service.j2
@@ -36,9 +36,6 @@ ExecStart=/usr/bin/rkt run \
         --volume var-lib-docker,kind=host,source={{ docker_daemon_graph }},readOnly=false \
         --volume var-lib-kubelet,kind=host,source=/var/lib/kubelet,readOnly=false,recursive=true \
         --volume var-log,kind=host,source=/var/log \
-{% if local_volume_provisioner_enabled == true %}
-        --volume local-volume-provisioner-base-dir,kind=host,source={{ local_volume_provisioner_base_dir }},readOnly=false,recursive=true \
-{% endif %}
 {% if kube_network_plugin in ["calico", "weave", "canal", "flannel", "contiv", "cilium"] %}
         --volume etc-cni,kind=host,source=/etc/cni,readOnly=true \
         --volume opt-cni,kind=host,source=/opt/cni,readOnly=true \
@@ -67,9 +64,6 @@ ExecStart=/usr/bin/rkt run \
         --mount volume=var-lib-kubelet,target=/var/lib/kubelet \
         --mount volume=var-log,target=/var/log \
         --mount volume=hosts,target=/etc/hosts \
-{% if local_volume_provisioner_enabled == true %}
-        --mount volume=local-volume-provisioner-base-dir,target={{ local_volume_provisioner_base_dir }} \
-{% endif %}
 {% if kubelet_flexvolumes_plugins_dir is defined %}
         --mount volume=flexvolumes,target={{ kubelet_flexvolumes_plugins_dir }} \
 {% endif %}

--- a/roles/kubernetes/preinstall/tasks/main.yml
+++ b/roles/kubernetes/preinstall/tasks/main.yml
@@ -60,7 +60,6 @@
     - "{{ kube_config_dir }}/ssl"
     - "{{ kube_manifest_dir }}"
     - "{{ kube_script_dir }}"
-    - "{{ local_volume_provisioner_base_dir }}"
 
 - name: check cloud_provider value
   fail:


### PR DESCRIPTION
Target:
* Fix #2424, so scope the use of {{ local_volume_provisioner_base_dir }} in `roles/kubernetes-apps/external_provisioner/local_volume_provisioner` only
* Add labels for namespace, prepare for using with NetworkPolicy

# Testing Procedures
## Create Ram Disks to Simulate Real Local Volumes 
See https://github.com/kubernetes-incubator/external-storage/tree/master/local-volume#option-4-local-test-cluster

```
mkdir -p /mnt/disks
for vol in vol1 vol2 vol3; do
    mkdir -p /mnt/disks/$vol
    mount -t tmpfs $vol /mnt/disks/$vol
done
```

## Deploy with ``local_volume_provisioner_enabled``
Edit ``inventory/mycluster/group_vars/k8s-cluster.yml`` with something similar as below and deploy Kubespray:
```
# Local volume provisioner deployment
local_volume_provisioner_enabled: true
# local_volume_provisioner_namespace: "{{ system_namespace }}"
# local_volume_provisioner_base_dir: /mnt/disks
# local_volume_provisioner_mount_dir: /mnt/disks
# local_volume_provisioner_storage_class: local-storage
```

## Check Result
e.g. ``kubectl -n kube-system logs -f local-volume-provisioner-l26hw``
```
I0307 01:08:56.139270       1 common.go:294] Creating client using in-cluster config
I0307 01:08:56.159618       1 main.go:56] Starting controller
I0307 01:08:56.159638       1 controller.go:42] Initializing volume cache
I0307 01:08:56.171611       1 populator.go:85] Starting Informer controller
I0307 01:08:56.171636       1 populator.go:89] Waiting for Informer initial sync
I0307 01:08:57.171913       1 controller.go:73] Controller started
I0307 01:08:57.172311       1 discovery.go:207] Found new volume of volumeType "file" at host path "/mnt/disks/vol2" with capacity 2068348928, creating Local PV "local-pv-5caec43d"
I0307 01:08:57.193946       1 cache.go:55] Added pv "local-pv-5caec43d" to cache
I0307 01:08:57.194413       1 cache.go:64] Updated pv "local-pv-5caec43d" to cache
I0307 01:08:57.194526       1 discovery.go:225] Created PV "local-pv-5caec43d" for volume at "/mnt/disks/vol2"
I0307 01:08:57.194589       1 discovery.go:207] Found new volume of volumeType "file" at host path "/mnt/disks/vol3" with capacity 2068348928, creating Local PV "local-pv-e403cb66"
I0307 01:08:57.199867       1 discovery.go:225] Created PV "local-pv-e403cb66" for volume at "/mnt/disks/vol3"
I0307 01:08:57.199919       1 discovery.go:207] Found new volume of volumeType "file" at host path "/mnt/disks/vol1" with capacity 2068348928, creating Local PV "local-pv-e68f5cf0"
I0307 01:08:57.200148       1 cache.go:55] Added pv "local-pv-e403cb66" to cache
I0307 01:08:57.204181       1 discovery.go:225] Created PV "local-pv-e68f5cf0" for volume at "/mnt/disks/vol1"
I0307 01:08:57.204255       1 cache.go:55] Added pv "local-pv-e68f5cf0" to cache
I0307 01:08:57.204267       1 cache.go:64] Updated pv "local-pv-e403cb66" to cache
I0307 01:08:57.211884       1 cache.go:64] Updated pv "local-pv-e68f5cf0" to cache
```

e.g. ``kubectl get pv``
```
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS      CLAIM                                                   STORAGECLASS    REASON    AGE
local-pv-5caec43d                          1972Mi     RWO            Delete           Available                                                           local-storage             10m
local-pv-e403cb66                          1972Mi     RWO            Delete           Available                                                           local-storage             10m
local-pv-e68f5cf0                          1972Mi     RWO            Delete           Available                                                           local-storage             10m
```

e.g. ``kubectl describe pv local-pv-e68f5cf0``
```
Name:            local-pv-e68f5cf0
Labels:          <none>
Annotations:     pv.kubernetes.io/provisioned-by=local-volume-provisioner-anewsnode11-3253f1af-2066-11e8-a4ec-00163e00b641
                 volume.alpha.kubernetes.io/node-affinity={"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/hostname","operator":"In","values":["anewsno...
StorageClass:    local-storage
Status:          Available
Claim:           
Reclaim Policy:  Delete
Access Modes:    RWO
Capacity:        1972Mi
Message:         
Source:
    Type:  LocalVolume (a persistent volume backed by local storage on a node)
    Path:  /mnt/disks/vol1
Events:    <none>
```