### PR TITLE
add tip to large-deployments.doc

### DIFF
--- a/docs/large-deployments.md
+++ b/docs/large-deployments.md
@@ -46,5 +46,8 @@ For a large scaled deployments, consider the following configuration changes:
   section of the Getting started guide for tips on creating a large scale
   Ansible inventory.
 
+* Override the ``etcd_events_cluster_setup: true`` store events in a separate
+  dedicated etcd instance.
+
 For example, when deploying 200 nodes, you may want to run ansible with
 ``--forks=50``, ``--timeout=600`` and define the ``retry_stagger: 60``.


### PR DESCRIPTION
ref [Building Large Clusters](https://kubernetes.io/docs/admin/cluster-large/)
> Etcd storage
To improve performance of large clusters, we store events in a separate dedicated etcd instance.

so need add tip about set the ``etcd_events_cluster_setup: true`` store events
in a separate dedicated etcd instance.
