### PR TITLE
Disable obsoletes on the yum repo.

### DIFF
--- a/roles/docker/templates/rh_docker.repo.j2
+++ b/roles/docker/templates/rh_docker.repo.j2
@@ -3,5 +3,6 @@ name=Docker Repository
 baseurl={{ docker_rh_repo_base_url }}
 enabled=1
 gpgcheck=1
+obsoletes=0
 gpgkey={{ docker_rh_repo_gpgkey }}
 {% if http_proxy is defined %}proxy={{ http_proxy }}{% endif %}


### PR DESCRIPTION
Now by default docker is pushing the latest docker rpm when you try to install docker-ce-selinux

Package docker-ce-selinux is obsoleted by docker-ce, trying to install docker-ce-17.12.1.ce-1.el7.centos.x86_64 instead