### PR TITLE
seperating apiserver_loadbalancer_domain_name from loadbalancer_apise…

### DIFF
--- a/roles/kubernetes/secrets/templates/openssl.conf.j2
+++ b/roles/kubernetes/secrets/templates/openssl.conf.j2
@@ -25,7 +25,7 @@ IP.{{ 2 * loop.index }} = {{ hostvars[host]['ip'] | default(hostvars[host]['ansi
 {% endfor %}
 {% set idx =  groups['kube-master'] | length | int * 2 + 1 %}
 IP.{{ idx }} = {{ kube_apiserver_ip }}
-{% if loadbalancer_apiserver is defined  %}
+{% if loadbalancer_apiserver.address is defined  %}
 IP.{{ idx + 1 }} = {{ loadbalancer_apiserver.address }}
 {% set idx = idx + 1 %}
 {% endif %}

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -240,8 +240,10 @@ weave_peers: uninitialized
 
 ## Set no_proxy to all assigned cluster IPs and hostnames
 no_proxy: >-
-  {%- if loadbalancer_apiserver is defined -%}
+  {%- if apiserver_loadbalancer_domain_name is defined -%}
   {{ apiserver_loadbalancer_domain_name| default('') }},
+  {%- endif -%}
+  {%- if loadbalancer_apiserver.address is defined -%}
   {{ loadbalancer_apiserver.address | default('') }},
   {%- endif -%}
   {%- for item in (groups['k8s-cluster'] + groups['etcd'] + groups['calico-rr']|default([]))|unique -%}


### PR DESCRIPTION
seperating apiserver_loadbalancer_domain_name from loadbalancer_apiserver.address to allow the External LB to be define without static IP. 