### PR TITLE
Prefix system:node CRB

### DIFF
--- a/roles/kubernetes-apps/cluster_roles/tasks/main.yml
+++ b/roles/kubernetes-apps/cluster_roles/tasks/main.yml
@@ -20,7 +20,7 @@
 
 - name: Apply workaround to allow all nodes with cert O=system:nodes to register
   kube:
-    name: "system:node"
+    name: "kubespray:system:node"
     kubectl: "{{bin_dir}}/kubectl"
     resource: "clusterrolebinding"
     filename: "{{ kube_config_dir }}/node-crb.yml"

--- a/roles/kubernetes-apps/cluster_roles/templates/node-crb.yml.j2
+++ b/roles/kubernetes-apps/cluster_roles/templates/node-crb.yml.j2
@@ -6,7 +6,7 @@ metadata:
     rbac.authorization.kubernetes.io/autoupdate: "true"
   labels:
     kubernetes.io/bootstrapping: rbac-defaults
-  name: system:node
+  name: kubespray:system:node
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
Change the name of `system:node` CRB to `kubespray:system:node` to avoid
conflicts with the auto-reconciled CRB also named `system:node`

Fixes #2121