### PR TITLE
Fix kubernetes cert permission sync

### DIFF
--- a/roles/kubernetes/secrets/tasks/gen_certs_script.yml
+++ b/roles/kubernetes/secrets/tasks/gen_certs_script.yml
@@ -179,6 +179,7 @@
   file:
     path: "{{ kube_cert_dir }}"
     group: "{{ kube_cert_group }}"
+    state: directory
     owner: kube
     mode: "u=rwX,g-rwx,o-rwx"
     recurse: yes


### PR DESCRIPTION
Add `state: directory` to `file` task so that `recurse: yes` will actually take effect and ensure
certs/keys have the right file mode and owner:group