### PR TITLE
Credentials files should not be considered as inventory files

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -12,3 +12,4 @@ library = ./library
 callback_whitelist = profile_tasks
 roles_path = roles:$VIRTUAL_ENV/usr/local/share/kubespray/roles:$VIRTUAL_ENV/usr/local/share/ansible/roles:/usr/share/kubespray/roles
 deprecation_warnings=False
+inventory_ignore_extensions = ~, .orig, .bak, .ini, .cfg, .retry, .pyc, .pyo, .creds

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -74,7 +74,7 @@ authentication. One could generate a kubeconfig based on one installed
 kube-master hosts (needs improvement) or connect with a username and password.
 By default, a user with admin rights is created, named `kube`.
 The password can be viewed after deployment by looking at the file
-`PATH_TO_KUBESPRAY/credentials/kube_user`. This contains a randomly generated
+`PATH_TO_KUBESPRAY/credentials/kube_user.creds`. This contains a randomly generated
 password. If you wish to set your own password, just precreate/modify this
 file yourself.
 

--- a/docs/vars.md
+++ b/docs/vars.md
@@ -137,6 +137,6 @@ The possible vars are:
 
 By default, a user with admin rights is created, named `kube`.
 The password can be viewed after deployment by looking at the file
-`PATH_TO_KUBESPRAY/credentials/kube_user`. This contains a randomly generated
+`PATH_TO_KUBESPRAY/credentials/kube_user.creds`. This contains a randomly generated
 password. If you wish to set your own password, just precreate/modify this
 file yourself or change `kube_api_pwd` var.

--- a/inventory/sample/group_vars/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s-cluster.yml
@@ -37,7 +37,7 @@ kube_log_level: 2
 
 # Users to create for basic auth in Kubernetes API via HTTP
 # Optionally add groups for user
-kube_api_pwd: "{{ lookup('password', inventory_dir + '/credentials/kube_user length=15 chars=ascii_letters,digits') }}"
+kube_api_pwd: "{{ lookup('password', inventory_dir + '/credentials/kube_user.creds length=15 chars=ascii_letters,digits') }}"
 kube_users:
   kube:
     pass: "{{kube_api_pwd}}"

--- a/roles/kubernetes/master/defaults/main.yml
+++ b/roles/kubernetes/master/defaults/main.yml
@@ -95,5 +95,5 @@ volume_cross_zone_attachment: false
 
 ## Encrypting Secret Data at Rest
 kube_encrypt_secret_data: false
-kube_encrypt_token: "{{ lookup('password', inventory_dir + '/credentials/kube_encrypt_token length=32 chars=ascii_letters,digits') }}"
+kube_encrypt_token: "{{ lookup('password', inventory_dir + '/credentials/kube_encrypt_token.creds length=32 chars=ascii_letters,digits') }}"
 kube_encryption_algorithm: "aescbc" # Must be either: aescbc, secretbox or aesgcm

--- a/roles/vault/defaults/main.yml
+++ b/roles/vault/defaults/main.yml
@@ -115,7 +115,7 @@ vault_pki_mounts:
     roles:
       - name: vault
         group: vault
-        password: "{{ lookup('password', inventory_dir + '/credentials/vault/vault length=15') }}"
+        password: "{{ lookup('password', inventory_dir + '/credentials/vault/vault.creds length=15') }}"
         policy_rules: default
         role_options: default
   etcd:
@@ -127,7 +127,7 @@ vault_pki_mounts:
     roles:
       - name: etcd
         group: etcd
-        password: "{{ lookup('password', inventory_dir + '/credentials/vault/etcd length=15') }}"
+        password: "{{ lookup('password', inventory_dir + '/credentials/vault/etcd.creds length=15') }}"
         policy_rules: default
         role_options:
           allow_any_name: true
@@ -142,7 +142,7 @@ vault_pki_mounts:
     roles:
       - name: kube-master
         group: kube-master
-        password: "{{ lookup('password', inventory_dir + '/credentials/vault/kube-master length=15') }}"
+        password: "{{ lookup('password', inventory_dir + '/credentials/vault/kube-master.creds length=15') }}"
         policy_rules: default
         role_options:
           allow_any_name: true
@@ -150,7 +150,7 @@ vault_pki_mounts:
           organization: "system:masters"
       - name: kube-node
         group: k8s-cluster
-        password: "{{ lookup('password', inventory_dir + '/credentials/vault/kube-node length=15') }}"
+        password: "{{ lookup('password', inventory_dir + '/credentials/vault/kube-node.creds length=15') }}"
         policy_rules: default
         role_options:
           allow_any_name: true
@@ -158,7 +158,7 @@ vault_pki_mounts:
           organization: "system:nodes"
       - name: kube-proxy
         group: k8s-cluster
-        password: "{{ lookup('password', inventory_dir + '/credentials/vault/kube-proxy length=15') }}"
+        password: "{{ lookup('password', inventory_dir + '/credentials/vault/kube-proxy.creds length=15') }}"
         policy_rules: default
         role_options:
           allow_any_name: true
@@ -166,7 +166,7 @@ vault_pki_mounts:
           organization: "system:node-proxier"
       - name: front-proxy-client
         group: k8s-cluster
-        password: "{{ lookup('password', inventory_dir + '/credentials/vault/kube-proxy length=15') }}"
+        password: "{{ lookup('password', inventory_dir + '/credentials/vault/kube-proxy.creds length=15') }}"
         policy_rules: default
         role_options:
           allow_any_name: true

--- a/tests/testcases/010_check-apiserver.yml
+++ b/tests/testcases/010_check-apiserver.yml
@@ -6,7 +6,7 @@
     uri:
       url: "https://{{ access_ip | default(ansible_default_ipv4.address) }}:{{ kube_apiserver_port }}/api/v1"
       user: kube
-      password: "{{ lookup('password', inventory_dir + '/credentials/kube_user length=15 chars=ascii_letters,digits') }}"
+      password: "{{ lookup('password', inventory_dir + '/credentials/kube_user.creds length=15 chars=ascii_letters,digits') }}"
       validate_certs: no
       status_code: 200,401
     when: not kubeadm_enabled|default(false)


### PR DESCRIPTION
Addition of the .creds extension to the credentials files generated by password lookup in order for Ansible not to consider them as inventory files with inventory_ignore_extensions set accordingly

Should fix #2410