### PR TITLE
Fix indent  in custom ConfigMap ingress-nginx

### DIFF
--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ingress-nginx-cm.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ingress-nginx-cm.yml.j2
@@ -7,4 +7,4 @@ metadata:
   labels:
     k8s-app: ingress-nginx
 data:
-  {{ ingress_nginx_configmap | to_nice_yaml }}
+  {{ ingress_nginx_configmap | to_nice_yaml | indent(2) }}

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ingress-nginx-tcp-servicecs-cm.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ingress-nginx-tcp-servicecs-cm.yml.j2
@@ -7,4 +7,4 @@ metadata:
   labels:
     k8s-app: ingress-nginx
 data:
-  {{ ingress_nginx_configmap_tcp_services | to_nice_yaml }}
+  {{ ingress_nginx_configmap_tcp_services | to_nice_yaml | indent(2) }}

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ingress-nginx-udp-servicecs-cm.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ingress-nginx-udp-servicecs-cm.yml.j2
@@ -7,4 +7,4 @@ metadata:
   labels:
     k8s-app: ingress-nginx
 data:
-  {{ ingress_nginx_configmap_udp_services | to_nice_yaml }}
+  {{ ingress_nginx_configmap_udp_services | to_nice_yaml | indent(2) }}


### PR DESCRIPTION
### To reproduce the problem
```yaml
---
- hosts: localhost
  vars:
    ingress_nginx_namespace: "ingress-nginx"
    ingress_nginx_configmap:
      ssl-protocols: SSLv2
      second_string: second_value

  tasks:
    - template:
        src: roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ingress-nginx-cm.yml.j2
        dest: /tmp/test
    - debug:
        msg: "problem {{ ingress_nginx_configmap | to_nice_yaml }}"
    - debug:
        msg: "fixed  {{ ingress_nginx_configmap | to_nice_yaml | indent(2) }}"

```
ansible 2.4.3.0

Template output (cat /tmp/test )
```yaml
data:
  second_string: second_value
ssl-protocols: SSLv2 #(sic!)
```


###  Fix
I added an indent

```
| to_nice_yaml | indent(2) }}
```