### PR TITLE
fix space indent with multiline ingress_nginx_configmap* vairables

### DIFF
--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ingress-nginx-cm.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ingress-nginx-cm.yml.j2
@@ -7,4 +7,4 @@ metadata:
   labels:
     k8s-app: ingress-nginx
 data:
-  {{ ingress_nginx_configmap | to_nice_yaml }}
+{{ ingress_nginx_configmap | to_nice_yaml | indent(2, true)}}

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ingress-nginx-tcp-servicecs-cm.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ingress-nginx-tcp-servicecs-cm.yml.j2
@@ -7,4 +7,4 @@ metadata:
   labels:
     k8s-app: ingress-nginx
 data:
-  {{ ingress_nginx_configmap_tcp_services | to_nice_yaml }}
+{{ ingress_nginx_configmap_tcp_services | to_nice_yaml | indent(2, true) }}

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ingress-nginx-udp-servicecs-cm.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ingress-nginx-udp-servicecs-cm.yml.j2
@@ -7,4 +7,4 @@ metadata:
   labels:
     k8s-app: ingress-nginx
 data:
-  {{ ingress_nginx_configmap_udp_services | to_nice_yaml }}
+{{ ingress_nginx_configmap_udp_services | to_nice_yaml | indent(2, true) }}


### PR DESCRIPTION
when set variable
```
ingress_nginx_configmap:
  server-tokens: "False"
  proxy-body-size: "2G"
  proxy-buffer-size: "16k"
```

task produce ingress-nginx-cm.yml with this data

```
data:
  proxy-body-size: 2G
proxy-buffer-size: 16k
server-tokens: 'False'
```