### PR TITLE
Added taint for master and node labels when using kubeadm

### DIFF
--- a/roles/kubernetes/node/templates/kubelet.kubeadm.env.j2
+++ b/roles/kubernetes/node/templates/kubelet.kubeadm.env.j2
@@ -62,6 +62,27 @@ KUBELET_HOSTNAME="--hostname-override={{ kube_override_hostname }}"
 {% endif %}
 {% set kubelet_args_dns %}{{ kubelet_args_cluster_dns }} --cluster-domain={{ dns_domain }} --resolv-conf={{ kube_resolv_conf }}{% endset %}
 
+{% if standalone_kubelet|bool %}
+{# We are on a master-only host. Make the master unschedulable in this case. #}
+{% if kube_version | version_compare('v1.6', '>=') %}
+{# Set taints on the master so that it's unschedulable by default. Use node-role.kubernetes.io/master taint like kubeadm. #}
+{% set kubelet_args_kubeconfig %}{{ kubelet_args_kubeconfig }} --register-with-taints=node-role.kubernetes.io/master=:NoSchedule{% endset %}
+{% else %}
+{# --register-with-taints was added in 1.6 so just register unschedulable if Kubernetes < 1.6 #}
+{% set kubelet_args_kubeconfig %}{{ kubelet_args_kubeconfig }} --register-schedulable=false{% endset %}
+{% endif %}
+{% endif %}
+
+
+{# Kubelet node labels #}
+{% if inventory_hostname in groups['kube-master'] %}
+{%   set node_labels %}--node-labels=node-role.kubernetes.io/master=true{% endset %}
+{%   if not standalone_kubelet|bool %}
+{%     set node_labels %}{{ node_labels }},node-role.kubernetes.io/node=true{% endset %}
+{%   endif %}
+{% else %}
+{%   set node_labels %}--node-labels=node-role.kubernetes.io/node=true{% endset %}
+{% endif %}
 
 KUBELET_ARGS="{{ kubelet_args_base }} {{ kubelet_args_dns }} {{ kube_reserved }} {% if kubelet_custom_flags is string %} {{kubelet_custom_flags}} {% else %}{% for flag in kubelet_custom_flags %} {{flag}} {% endfor %}{% endif %}"
 {% if kube_network_plugin is defined and kube_network_plugin in ["calico", "canal", "flannel", "weave", "contiv", "cilium"] %}


### PR DESCRIPTION
The kubelet env file for kubeadm is not "equal" to the kubelet when not using kubeadm. Taints, roles and labels are not added.