### PR TITLE
Localhost in hosts files should be updated (if necessary), not overriden

### DIFF
--- a/roles/kubernetes/preinstall/defaults/main.yml
+++ b/roles/kubernetes/preinstall/defaults/main.yml
@@ -34,7 +34,15 @@ preinstall_selinux_state: permissive
 
 sysctl_file_path: "/etc/sysctl.d/99-sysctl.conf"
 
-etc_hosts_filter:
+etc_hosts_localhost_entries:
+  127.0.0.1:
+    expected:
+      - localhost
+      - localhost.localdomain
   ::1:
-    - localhost
-    - localhost.localdomain
+    expected:
+      - localhost6
+      - localhost6.localdomain
+    unexpected:
+      - localhost
+      - localhost.localdomain

--- a/roles/kubernetes/preinstall/defaults/main.yml
+++ b/roles/kubernetes/preinstall/defaults/main.yml
@@ -33,3 +33,8 @@ populate_inventory_to_hosts_file: true
 preinstall_selinux_state: permissive
 
 sysctl_file_path: "/etc/sysctl.d/99-sysctl.conf"
+
+etc_hosts_filter:
+  ::1:
+    - localhost
+    - localhost.localdomain

--- a/roles/kubernetes/preinstall/tasks/etchosts.yml
+++ b/roles/kubernetes/preinstall/tasks/etchosts.yml
@@ -29,38 +29,20 @@
 
 - name: Hosts | Extract existing entries for localhost from hosts file
   set_fact:
-    entry: "{{ item | regex_replace('[ ]+', ' ')|regex_replace('#.+$')|trim }}"
+    etc_hosts_localhosts_dict: >-
+       {%- set splitted = (item | regex_replace('[ ]+', ' ')|regex_replace('#.+$')|trim).split( ' ') -%}
+       {{ etc_hosts_localhosts_dict|default({}) | combine({splitted[0]: splitted[1::] }) }}
   with_items: "{{ (etc_hosts_content['content'] | b64decode).split('\n') }}"
-  register: etc_hosts_localhosts
   when:
     - etc_hosts_content.content is defined
-    - (item|match('^::1 .*') or item|match('^127.0.0.1 .*'))
-
-- name: Hosts | Convert extract entries for localhost as dict
-  set_fact:
-    etc_hosts_localhosts_dict: >-
-      {% set splitted = item.split(' ') %}{{ etc_hosts_localhosts_dict|default({}) | combine({splitted[0]: splitted[1::] }) }}
-  with_items: "{{ etc_hosts_localhosts.results | selectattr('ansible_facts', 'defined') | map(attribute='ansible_facts.entry') | list }}"
-
-- name: Hosts | Initiate target hosts file entries dict and filter unwanted values
-  set_fact:
-    etc_hosts_localhosts_dict_target: >-
-      {%- set target_entries = [] -%}
-      {%- for entry in item.value -%}
-      {%- if entry not in etc_hosts_filter.get(item.key,[]) -%}
-      {%- set DO = target_entries.append(entry) -%}
-      {%- endif -%}
-      {%- endfor -%}
-      {{ etc_hosts_localhosts_dict_target|default({}) | combine({item.key: target_entries}) }}
-  with_dict: "{{etc_hosts_localhosts_dict}}"
+    - etc_hosts_localhost_entries.keys()|map('regex_replace', '(.*)', '^\\1 .*') | map('match', item) | list | length > 0
 
 - name: Hosts | Update target hosts file entries dict with required entries
   set_fact:
     etc_hosts_localhosts_dict_target: >-
-      {{ etc_hosts_localhosts_dict_target|default({}) | combine({item.ip: (etc_hosts_localhosts_dict_target[item.ip]|default([]) + item.entries)|unique}) }}
-  with_items:
-    - {ip: '127.0.0.1', entries: ['localhost', 'localhost.localdomain']}
-    - {ip: '::1', entries: ['localhost6', 'localhost6.localdomain']}
+      {%- set target_entries = etc_hosts_localhosts_dict.get(item.key, []) | difference(item.value.get('unexpected' ,[])) -%}
+      {{ etc_hosts_localhosts_dict_target|default({}) | combine({item.key: (target_entries + item.value.expected)|unique}) }}
+  with_dict: "{{ etc_hosts_localhost_entries }}"
 
 - name: Hosts | Update (if necessary) hosts file
   lineinfile:

--- a/roles/kubernetes/preinstall/tasks/etchosts.yml
+++ b/roles/kubernetes/preinstall/tasks/etchosts.yml
@@ -22,18 +22,51 @@
     - loadbalancer_apiserver is defined
     - loadbalancer_apiserver.address is defined
 
-- name: Hosts | localhost ipv4 in hosts file
-  lineinfile:
-    dest: /etc/hosts
-    line: "127.0.0.1 localhost localhost.localdomain"
-    regexp: '^127.0.0.1.*$'
-    state: present
-    backup: yes
+- name: Hosts | Retrieve hosts file content
+  slurp:
+    src: /etc/hosts
+  register: etc_hosts_content
 
-- name: Hosts | localhost ipv6 in hosts file
+- name: Hosts | Extract existing entries for localhost from hosts file
+  set_fact:
+    entry: "{{ item | regex_replace('[ ]+', ' ')|regex_replace('#.+$')|trim }}"
+  with_items: "{{ (etc_hosts_content['content'] | b64decode).split('\n') }}"
+  register: etc_hosts_localhosts
+  when:
+    - etc_hosts_content.content is defined
+    - (item|match('^::1 .*') or item|match('^127.0.0.1 .*'))
+
+- name: Hosts | Convert extract entries for localhost as dict
+  set_fact:
+    etc_hosts_localhosts_dict: >-
+      {% set splitted = item.split(' ') %}{{ etc_hosts_localhosts_dict|default({}) | combine({splitted[0]: splitted[1::] }) }}
+  with_items: "{{ etc_hosts_localhosts.results | selectattr('ansible_facts', 'defined') | map(attribute='ansible_facts.entry') | list }}"
+
+- name: Hosts | Initiate target hosts file entries dict and filter unwanted values
+  set_fact:
+    etc_hosts_localhosts_dict_target: >-
+      {%- set target_entries = [] -%}
+      {%- for entry in item.value -%}
+      {%- if entry not in etc_hosts_filter.get(item.key,[]) -%}
+      {%- set DO = target_entries.append(entry) -%}
+      {%- endif -%}
+      {%- endfor -%}
+      {{ etc_hosts_localhosts_dict_target|default({}) | combine({item.key: target_entries}) }}
+  with_dict: "{{etc_hosts_localhosts_dict}}"
+
+- name: Hosts | Update target hosts file entries dict with required entries
+  set_fact:
+    etc_hosts_localhosts_dict_target: >-
+      {{ etc_hosts_localhosts_dict_target|default({}) | combine({item.ip: (etc_hosts_localhosts_dict_target[item.ip]|default([]) + item.entries)|unique}) }}
+  with_items:
+    - {ip: '127.0.0.1', entries: ['localhost', 'localhost.localdomain']}
+    - {ip: '::1', entries: ['localhost6', 'localhost6.localdomain']}
+
+- name: Hosts | Update (if necessary) hosts file
   lineinfile:
     dest: /etc/hosts
-    line: "::1 localhost6 localhost6.localdomain"
-    regexp: '^::1.*$'
+    line: "{{ item.key }} {{ item.value|join(' ') }}"
+    regexp: "^{{ item.key }}.*$"
     state: present
     backup: yes
+  with_dict: "{{ etc_hosts_localhosts_dict_target }}"


### PR DESCRIPTION
Currently, the entries in /etc/hosts for ipv4 and ipv6 are hardcoded (i.e. "localhost localhost.localdomain" for 127.0.01 and "localhost6 localhost6.localdomain" for ::1) which is a problem on some systems.

My proposal is to collect the content of /etc/hosts and add the values if not present.
Should fix #2368