### PR TITLE
sysctl file should be in defaults so that it can be overriden

### DIFF
--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -94,7 +94,7 @@ kube_cadvisor_port: 0
 kube_read_only_port: 0
 
 # sysctl_file_path to add sysctl conf to
-sysctl_file_path: "/etc/sysctl.conf"
+sysctl_file_path: "/etc/sysctl.d/99-sysctl.conf"
 
 # For the openstack integration kubelet will need credentials to access
 # openstack apis like nova and cinder. Per default this values will be

--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -93,6 +93,8 @@ kube_cadvisor_port: 0
 # The read-only port for the Kubelet to serve on with no authentication/authorization.
 kube_read_only_port: 0
 
+# sysctl_file_path to add sysctl conf to
+sysctl_file_path: "/etc/sysctl.conf"
 
 # For the openstack integration kubelet will need credentials to access
 # openstack apis like nova and cinder. Per default this values will be

--- a/roles/kubernetes/node/tasks/main.yml
+++ b/roles/kubernetes/node/tasks/main.yml
@@ -61,6 +61,7 @@
     name: net.ipv4.ip_local_reserved_ports
     value: "{{ kube_apiserver_node_port_range }}"
     sysctl_set: yes
+    sysctl_file: "{{ sysctl_file_path }}"
     state: present
     reload: yes
   when: kube_apiserver_node_port_range is defined
@@ -96,6 +97,7 @@
   sysctl:
     name: "{{ item }}"
     state: present
+    sysctl_file: "{{ sysctl_file_path }}"
     value: 1
     reload: yes
   when: sysctl_bridge_nf_call_iptables.rc == 0

--- a/roles/kubernetes/preinstall/defaults/main.yml
+++ b/roles/kubernetes/preinstall/defaults/main.yml
@@ -31,3 +31,5 @@ resolveconf_cloud_init_conf: /etc/resolveconf_cloud_init.conf
 populate_inventory_to_hosts_file: true
 
 preinstall_selinux_state: permissive
+
+sysctl_file_path: "/etc/sysctl.d/99-sysctl.conf"

--- a/roles/kubernetes/preinstall/tasks/main.yml
+++ b/roles/kubernetes/preinstall/tasks/main.yml
@@ -221,12 +221,6 @@
   tags:
     - bootstrap-os
 
-- name: set default sysctl file path
-  set_fact:
-    sysctl_file_path: "/etc/sysctl.d/99-sysctl.conf"
-  tags:
-    - bootstrap-os
-
 - name: Stat sysctl file configuration
   stat:
     path: "{{sysctl_file_path}}"


### PR DESCRIPTION
sysctl_file_path is currently set with set_fact in a task of /kubernetes/preinstall role
sysctl file is the default (/etc/sysctl.conf) in the /kubernetes/node role

sysctl_file_path as a default of each role (respectively set to their current value) could enable overriding through group_vars (not sure that a different name would be required...)

