### PR TITLE
Fix error when running `terraform init`

### DIFF
--- a/contrib/terraform/openstack/modules/network/outputs.tf
+++ b/contrib/terraform/openstack/modules/network/outputs.tf
@@ -2,6 +2,6 @@ output "router_id" {
   value = "${openstack_networking_router_interface_v2.k8s.id}"
 }
 
-output "network_id" {
+output "subnet_id" {
   value = "${openstack_networking_subnet_v2.k8s.id}"
 }


### PR DESCRIPTION
> Error getting plugins: output 'private_subnet_id': "subnet_id" is not a valid output for module "network"