### PR TITLE
Update path to artifacts directory

### DIFF
--- a/roles/kubernetes/client/tasks/main.yml
+++ b/roles/kubernetes/client/tasks/main.yml
@@ -55,7 +55,7 @@
 - name: Copy kubectl binary to ansible host
   fetch:
     src: "{{ bin_dir }}/kubectl"
-    dest: inventory_dir + '/artifacts/admin.conf'
+    dest: inventory_dir + '/artifacts/kubectl'
     flat: yes
     validate_checksum: no
   become: no

--- a/roles/kubernetes/client/tasks/main.yml
+++ b/roles/kubernetes/client/tasks/main.yml
@@ -46,7 +46,7 @@
 - name: Copy admin kubeconfig to ansible host
   fetch:
     src: "{{ kube_config_dir }}/admin.conf"
-    dest: "{{ artifacts_dir }}/admin.conf"
+    dest: inventory_dir + '/artifacts/admin.conf'
     flat: yes
     validate_checksum: no
   run_once: yes
@@ -55,7 +55,7 @@
 - name: Copy kubectl binary to ansible host
   fetch:
     src: "{{ bin_dir }}/kubectl"
-    dest: "{{ artifacts_dir }}/kubectl"
+    dest: inventory_dir + '/artifacts/admin.conf'
     flat: yes
     validate_checksum: no
   become: no


### PR DESCRIPTION
When the PR #2233 was introduced to seperate the inventory, the artifacts dir was not taken into account. This will put artifacts into the right inventory path.