### PR TITLE
Mark "calico-rr" as optional in fact gather

### DIFF
--- a/upgrade-cluster.yml
+++ b/upgrade-cluster.yml
@@ -26,7 +26,7 @@
       setup:
       delegate_to: "{{item}}"
       delegate_facts: True
-      with_items: "{{ groups['k8s-cluster'] + groups['etcd'] + groups['calico-rr'] }}"
+      with_items: "{{ groups['k8s-cluster'] + groups['etcd'] + groups['calico-rr']|default([]) }}"
 
 - hosts: k8s-cluster:etcd:calico-rr
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"


### PR DESCRIPTION
If `calico-rr` group isn't defined the `upgrade-cluster.yml` playbook fails complaining about missing `calico-rr` object in `group` dict. The fix is to make it optional by defining a default value. 