### PR TITLE
Dedicated node for ingress nginx controller

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s-cluster.yml
@@ -189,7 +189,7 @@ cephfs_provisioner_enabled: false
 
 # Nginx ingress controller deployment
 ingress_nginx_enabled: false
-# ingres_nginx_host_network: true
+# ingress_nginx_host_network: false
 # ingress_nginx_namespace: "ingress-nginx"
 # ingress_nginx_insecure_port: 80
 # ingress_nginx_secure_port: 443

--- a/inventory/sample/group_vars/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s-cluster.yml
@@ -189,6 +189,7 @@ cephfs_provisioner_enabled: false
 
 # Nginx ingress controller deployment
 ingress_nginx_enabled: false
+# ingres_nginx_host_network: true
 # ingress_nginx_namespace: "ingress-nginx"
 # ingress_nginx_insecure_port: 80
 # ingress_nginx_secure_port: 443

--- a/inventory/sample/hosts.ini
+++ b/inventory/sample/hosts.ini
@@ -26,6 +26,11 @@
 # node5
 # node6
 
+# optional for dedicated ingress node
+# [kube-ingress]
+# node2
+# node3
+
 # [k8s-cluster:children]
 # kube-node
 # kube-master

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/defaults/main.yml
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/defaults/main.yml
@@ -6,6 +6,7 @@ ingress_nginx_controller_image_repo: quay.io/kubernetes-ingress-controller/nginx
 ingress_nginx_controller_image_tag: 0.11.0
 
 ingress_nginx_namespace: "ingress-nginx"
+ingress_nginx_host_network: false
 ingress_nginx_insecure_port: 80
 ingress_nginx_secure_port: 443
 ingress_nginx_configmap: {}

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ingress-nginx-controller-ds.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ingress-nginx-controller-ds.yml.j2
@@ -21,6 +21,14 @@ spec:
         k8s-app: ingress-nginx
         version: v{{ ingress_nginx_controller_image_tag }}
     spec:
+{% if ingres_nginx_host_network is defined and ingres_nginx_host_network %}
+      hostNetwork: true
+{% endif %}
+{% if 'kube-ingress' in groups %}
+      nodeSelector:
+        node-role.kubernetes.io/ingress: "true"
+{% endif %}
+      terminationGracePeriodSeconds: 60
       containers:
         - name: ingress-nginx-controller
           image: {{ ingress_nginx_controller_image_repo }}:{{ ingress_nginx_controller_image_tag }}

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ingress-nginx-controller-ds.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ingress-nginx-controller-ds.yml.j2
@@ -21,10 +21,10 @@ spec:
         k8s-app: ingress-nginx
         version: v{{ ingress_nginx_controller_image_tag }}
     spec:
-{% if ingres_nginx_host_network is defined and ingres_nginx_host_network %}
+{% if ingress_nginx_host_network %}
       hostNetwork: true
 {% endif %}
-{% if 'kube-ingress' in groups %}
+{% if 'kube-ingress' in groups and groups['kube-ingress']|length > 0 %}
       nodeSelector:
         node-role.kubernetes.io/ingress: "true"
 {% endif %}

--- a/roles/kubernetes/node/templates/kubelet.standard.env.j2
+++ b/roles/kubernetes/node/templates/kubelet.standard.env.j2
@@ -84,6 +84,8 @@ KUBELET_HOSTNAME="--hostname-override={{ kube_override_hostname }}"
 {%   if not standalone_kubelet|bool %}
 {%     set node_labels %}{{ node_labels }},node-role.kubernetes.io/node=true{% endset %}
 {%   endif %}
+{% elif inventory_hostname in groups['kube-ingress']|default([]) %}
+{%   set node_labels %}--node-labels=node-role.kubernetes.io/ingress=true{% endset %}
 {% else %}
 {%   set node_labels %}--node-labels=node-role.kubernetes.io/node=true{% endset %}
 {% endif %}


### PR DESCRIPTION
The ability to create dedicated node for ingress nginx controller
host type network for nginx controller

and add from example https://github.com/kubernetes/ingress-nginx/blob/master/docs/examples/static-ip/nginx-ingress-controller.yaml
terminationGracePeriodSeconds: 60