### PR TITLE
Only copy tokens if tokens_list contains any

### DIFF
--- a/roles/kubernetes/secrets/tasks/gen_tokens.yml
+++ b/roles/kubernetes/secrets/tasks/gen_tokens.yml
@@ -55,4 +55,4 @@
 - name: Gen_tokens | Copy tokens on masters
   shell: "echo '{{ tokens_data.stdout|quote }}' | base64 -d | tar xz -C /"
   when: inventory_hostname in groups['kube-master'] and sync_tokens|default(false) and
-        inventory_hostname != groups['kube-master'][0]
+        inventory_hostname != groups['kube-master'][0] and tokens_data.stdout != ''


### PR DESCRIPTION
When setting `kube_token_auth: false` the task `Gen_tokens | Copy tokens on masters` fails on install - on CoreOS.

`tokens_data` is empty so the shell command fails. Only run the command if `tokens_data` actually contains data.