### PR TITLE
Only apply roles from first master node to fix regression

### DIFF
--- a/roles/kubernetes-apps/cluster_roles/tasks/main.yml
+++ b/roles/kubernetes-apps/cluster_roles/tasks/main.yml
@@ -16,7 +16,9 @@
     src: "node-crb.yml.j2"
     dest: "{{ kube_config_dir }}/node-crb.yml"
   register: node_crb_manifest
-  when: rbac_enabled
+  when:
+    - rbac_enabled
+    - inventory_hostname == groups['kube-master'][0]
 
 - name: Apply workaround to allow all nodes with cert O=system:nodes to register
   kube:
@@ -28,6 +30,7 @@
   when:
     - rbac_enabled
     - node_crb_manifest.changed
+    - inventory_hostname == groups['kube-master'][0]
 
 - name: Kubernetes Apps | Add webhook ClusterRole that grants access to proxy, stats, log, spec, and metrics on a kubelet
   template:
@@ -37,6 +40,7 @@
   when:
     - rbac_enabled
     - kubelet_authorization_mode_webhook
+    - inventory_hostname == groups['kube-master'][0]
   tags: node-webhook
 
 - name: Apply webhook ClusterRole
@@ -50,6 +54,7 @@
     - rbac_enabled
     - kubelet_authorization_mode_webhook
     - node_webhook_cr_manifest.changed
+    - inventory_hostname == groups['kube-master'][0]
   tags: node-webhook
 
 - name: Kubernetes Apps | Add ClusterRoleBinding for system:nodes to webhook ClusterRole
@@ -60,6 +65,7 @@
   when:
     - rbac_enabled
     - kubelet_authorization_mode_webhook
+    - inventory_hostname == groups['kube-master'][0]
   tags: node-webhook
 
 - name: Grant system:nodes the webhook ClusterRole
@@ -73,6 +79,7 @@
     - rbac_enabled
     - kubelet_authorization_mode_webhook
     - node_webhook_crb_manifest.changed
+    - inventory_hostname == groups['kube-master'][0]
   tags: node-webhook
 
 - name: Check if vsphere-cloud-provider ClusterRole exists
@@ -85,6 +92,7 @@
     - cloud_provider == 'vsphere'
     - kube_version | version_compare('v1.9.0', '>=')
     - kube_version | version_compare('v1.9.3', '<=')
+    - inventory_hostname == groups['kube-master'][0]
   tags: vsphere
 
 - name: Write vsphere-cloud-provider ClusterRole manifest
@@ -99,6 +107,7 @@
     - vsphere_cloud_provider.rc != 0
     - kube_version | version_compare('v1.9.0', '>=')
     - kube_version | version_compare('v1.9.3', '<=')
+    - inventory_hostname == groups['kube-master'][0]
   tags: vsphere
 
 - name: Apply vsphere-cloud-provider ClusterRole
@@ -115,6 +124,7 @@
     - vsphere_cloud_provider.rc != 0
     - kube_version | version_compare('v1.9.0', '>=')
     - kube_version | version_compare('v1.9.3', '<=')
+    - inventory_hostname == groups['kube-master'][0]
   tags: vsphere
 
 # This is not a cluster role, but should be run after kubeconfig is set on master


### PR DESCRIPTION
The following regression happend where master 2 completed before 01. No need to apply the same clusterroles multiple times. Only do it from master 1.

```
TASK [kubernetes-apps/cluster_roles : Apply workaround to allow all nodes with cert O=system:nodes to register] *************************
Sunday 18 March 2018  16:09:13 +0100 (0:00:01.164)       0:17:40.526 **********
ok: [odn1-kube-cluster01-master02] => {"changed": false, "msg": "success: clusterrolebinding \"kubespray:system:node\" created"}
fatal: [odn1-kube-cluster01-master01]: FAILED! => {"changed": false, "msg": "error running kubectl (/opt/bin/kubectl apply --force --filename=/etc/kubernetes/node-crb.yml) command (rc=1), out='', err='Error from server (AlreadyExists): error when creating \"/etc/kubernetes/node-crb.yml\": clusterrolebindings.rbac.authorization.k8s.io \"kubespray:system:node\" already exists\n'"}
ok: [odn1-kube-cluster01-master03] => {"changed": false, "msg": "success: clusterrolebinding \"kubespray:system:node\" configured"}
```