### PR TITLE
Add prometheus annotations to spec in ingress

### DIFF
--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ingress-nginx-controller-ds.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ingress-nginx-controller-ds.yml.j2
@@ -73,3 +73,4 @@ spec:
 {% if rbac_enabled %}
       serviceAccountName: ingress-nginx
 {% endif %}
+

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ingress-nginx-controller-ds.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ingress-nginx-controller-ds.yml.j2
@@ -20,6 +20,9 @@ spec:
       labels:
         k8s-app: ingress-nginx
         version: v{{ ingress_nginx_controller_image_tag }}
+      annotations:
+        prometheus.io/port: '10254'
+        prometheus.io/scrape: 'true'
     spec:
       containers:
         - name: ingress-nginx-controller


### PR DESCRIPTION
Added annotations from metadata to spec.template.metadata. Without it, pod does not get any annotations, and Prometheus didn't see it