### PR TITLE
Update kube-apiserver.manifest.j2 and kubeadm-config.yaml.j2 to incorporate `endpoint-reconciler-type: lease` 

### DIFF
--- a/roles/kubernetes/master/templates/kubeadm-config.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.yaml.j2
@@ -36,6 +36,9 @@ apiServerExtraArgs:
   insecure-port: "{{ kube_apiserver_insecure_port }}"
   admission-control: {{ kube_apiserver_admission_control | join(',') }}
   apiserver-count: "{{ kube_apiserver_count }}"
+{% if kube_version | version_compare('v1.9', '>=') %}
+  endpoint-reconciler-type: lease
+{% endif %}  
   service-node-port-range: {{ kube_apiserver_node_port_range }}
   kubelet-preferred-address-types: "{{ kubelet_preferred_address_types }}"
 {% if kube_basic_auth|default(true) %}

--- a/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
@@ -42,9 +42,9 @@ spec:
     - --insecure-bind-address={{ kube_apiserver_insecure_bind_address }}
     - --bind-address={{ kube_apiserver_bind_address }}
     - --apiserver-count={{ kube_apiserver_count }}
-{% if kube_version | version_compare('v1.9', '>=') %}    
+{% if kube_version | version_compare('v1.9', '>=') %}
     - --endpoint-reconciler-type=lease
-{% endif %}    
+{% endif %}
     - --admission-control={{ kube_apiserver_admission_control | join(',') }}
     - --service-cluster-ip-range={{ kube_service_addresses }}
     - --service-node-port-range={{ kube_apiserver_node_port_range }}

--- a/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
@@ -42,6 +42,7 @@ spec:
     - --insecure-bind-address={{ kube_apiserver_insecure_bind_address }}
     - --bind-address={{ kube_apiserver_bind_address }}
     - --apiserver-count={{ kube_apiserver_count }}
+    - --endpoint-reconciler-type=lease
     - --admission-control={{ kube_apiserver_admission_control | join(',') }}
     - --service-cluster-ip-range={{ kube_service_addresses }}
     - --service-node-port-range={{ kube_apiserver_node_port_range }}

--- a/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
@@ -42,7 +42,9 @@ spec:
     - --insecure-bind-address={{ kube_apiserver_insecure_bind_address }}
     - --bind-address={{ kube_apiserver_bind_address }}
     - --apiserver-count={{ kube_apiserver_count }}
+{% if kube_version | version_compare('v1.9', '>=') %}    
     - --endpoint-reconciler-type=lease
+{% endif %}    
     - --admission-control={{ kube_apiserver_admission_control | join(',') }}
     - --service-cluster-ip-range={{ kube_service_addresses }}
     - --service-node-port-range={{ kube_apiserver_node_port_range }}


### PR DESCRIPTION
Ensure that kube-apiserver and kubeadm will respond even if one of the nodes are down.