### PR TITLE
optional calico_ip_auto_method variable with IP_AUTODETECTION_METHOD

### DIFF
--- a/roles/network_plugin/calico/defaults/main.yml
+++ b/roles/network_plugin/calico/defaults/main.yml
@@ -45,3 +45,9 @@ rbac_resources:
   - sa
   - clusterrole
   - clusterrolebinding
+
+# If you want to use non default IP_AUTODETECTION_METHOD for calico node set this option to one of:
+# * can-reach=DESTINATION
+# * interface=INTERFACE-REGEX
+# see https://docs.projectcalico.org/v3.0/reference/node/configuration#ip-autodetection-methods
+#calico_ip_auto_method: "interface=eth.*"

--- a/roles/network_plugin/calico/templates/calico-node.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-node.yml.j2
@@ -109,8 +109,8 @@ spec:
                   name: calico-config
                   key: etcd_cert
 {% if calico_ip_auto_method is defined %}
-           - name: IP_AUTODETECTION_METHOD
-             value: "{{ calico_ip_auto_method }}"
+            - name: IP_AUTODETECTION_METHOD
+              value: "{{ calico_ip_auto_method }}"
 {% else %}
             - name: IP
               valueFrom:

--- a/roles/network_plugin/calico/templates/calico-node.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-node.yml.j2
@@ -108,10 +108,15 @@ spec:
                 configMapKeyRef:
                   name: calico-config
                   key: etcd_cert
+{% if calico_ip_auto_method is defined %}
+           - name: IP_AUTODETECTION_METHOD
+             value: "{{ calico_ip_auto_method }}"
+{% else %}
             - name: IP
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+{% endif %}
             - name: NODENAME
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
can be set to one of
first-found
can-reach 
interface