### PR TITLE
Set exact user for Kubelet services

### DIFF
--- a/roles/kubernetes/node/templates/kubelet.docker.service.j2
+++ b/roles/kubernetes/node/templates/kubelet.docker.service.j2
@@ -5,6 +5,7 @@ After=docker.service
 Wants=docker.socket
 
 [Service]
+User=root
 EnvironmentFile={{kube_config_dir}}/kubelet.env
 ExecStart={{ bin_dir }}/kubelet \
 		$KUBE_LOGTOSTDERR \

--- a/roles/kubernetes/node/templates/kubelet.host.service.j2
+++ b/roles/kubernetes/node/templates/kubelet.host.service.j2
@@ -5,6 +5,7 @@ After=docker.service
 Wants=docker.socket
 
 [Service]
+User=root
 EnvironmentFile=-{{kube_config_dir}}/kubelet.env
 {% if kubelet_flexvolumes_plugins_dir is defined %}
 ExecStartPre=-/bin/mkdir -p {{ kubelet_flexvolumes_plugins_dir }}

--- a/roles/kubernetes/node/templates/kubelet.rkt.service.j2
+++ b/roles/kubernetes/node/templates/kubelet.rkt.service.j2
@@ -4,6 +4,7 @@ Documentation=https://github.com/GoogleCloudPlatform/kubernetes
 Wants=network.target
 
 [Service]
+User=root
 Restart=on-failure
 RestartSec=10s
 TimeoutStartSec=0


### PR DESCRIPTION
When using private docker-registry Kubelet searching for ~/.docker/config.json inside $HOME folder, and when exact user has not been set for systemd service it will use /var/lib/kubelet as $HOME

Related issue:
https://github.com/kubernetes/kubernetes/issues/45487