### PR TITLE
Remove old docker packages and other docker upgrade fixes

### DIFF
--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -21,6 +21,10 @@ docker_dns_servers_strict: yes
 
 docker_container_storage_setup: false
 
+# Used to override obsoletes=0
+yum_conf: /etc/yum.conf
+docker_yum_conf: /etc/yum_docker.conf
+
 # CentOS/RedHat docker-ce repo
 docker_rh_repo_base_url: 'https://download.docker.com/linux/centos/7/$basearch/stable'
 docker_rh_repo_gpgkey: 'https://download.docker.com/linux/centos/gpg'

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -30,6 +30,8 @@
   tags:
     - facts
 
+- import_tasks: pre-upgrade.yml
+
 - name: ensure docker-ce repository public key is installed
   action: "{{ docker_repo_key_info.pkg_key }}"
   args:

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -80,11 +80,27 @@
     dest: "/etc/yum.repos.d/docker.repo"
   when: ansible_distribution in ["CentOS","RedHat"] and not is_atomic
 
+- name: Copy yum.conf for editing
+  copy:
+    src: "{{ yum_conf }}"
+    dest: "{{ docker_yum_conf }}"
+    remote_src: yes
+  when: ansible_distribution in ["CentOS","RedHat"] and not is_atomic
+
+- name: Edit copy of yum.conf to set obsoletes=0
+  lineinfile:
+    path: "{{ docker_yum_conf }}"
+    state: present
+    regexp: '^obsoletes='
+    line: 'obsoletes=0'
+  when: ansible_distribution in ["CentOS","RedHat"] and not is_atomic
+
 - name: ensure docker packages are installed
   action: "{{ docker_package_info.pkg_mgr }}"
   args:
     pkg: "{{item.name}}"
     force: "{{item.force|default(omit)}}"
+    conf_file: "{{item.yum_conf|default(omit)}}"
     state: present
   register: docker_task_result
   until: docker_task_result|succeeded

--- a/roles/docker/tasks/pre-upgrade.yml
+++ b/roles/docker/tasks/pre-upgrade.yml
@@ -1,0 +1,20 @@
+---
+- name: Ensure old versions of Docker are not installed. | Debian
+  package:
+    name: '{{ item }}'
+    state: absent
+  with_items:
+    - docker
+    - docker-engine
+  when: ansible_os_family == 'Debian' and (docker_versioned_pkg[docker_version | string] | search('docker-ce'))
+
+- name: Ensure old versions of Docker are not installed. | RedHat
+  package:
+    name: '{{ item }}'
+    state: absent
+  with_items:
+    - docker
+    - docker-common
+    - docker-engine
+    - docker-selinux
+  when: ansible_os_family == 'RedHat' and (docker_versioned_pkg[docker_version | string] | search('docker-ce'))

--- a/roles/docker/vars/redhat.yml
+++ b/roles/docker/vars/redhat.yml
@@ -28,7 +28,9 @@ docker_package_info:
   pkg_mgr: yum
   pkgs:
     - name: "{{ docker_selinux_versioned_pkg[docker_selinux_version | string] }}"
+      yum_conf: "{{ docker_yum_conf }}"
     - name: "{{ docker_versioned_pkg[docker_version | string] }}"
+      yum_conf: "{{ docker_yum_conf }}"
 
 docker_repo_key_info:
   pkg_key: ''


### PR DESCRIPTION
This removes docker packages that are obsolete if docker-ce packages are to be installed, which fixes some package conflict issues that can occur during upgrades.

Also, sets `obsoletes=0` in yum.conf when installing docker with yum. Fixes #2527 