### PR TITLE
Write cloud-config during kubelet configuration

### DIFF
--- a/roles/kubernetes/node/tasks/main.yml
+++ b/roles/kubernetes/node/tasks/main.yml
@@ -134,6 +134,19 @@
   tags:
     - kube-proxy
 
+- name: Write cloud-config
+  template:
+    src: "{{ cloud_provider }}-cloud-config.j2"
+    dest: "{{ kube_config_dir }}/cloud_config"
+    group: "{{ kube_cert_group }}"
+    mode: 0640
+  when:
+    - cloud_provider is defined
+    - cloud_provider in [ 'openstack', 'azure', 'vsphere' ]
+  notify: restart kubelet
+  tags:
+    - cloud-provider
+
 # reload-systemd
 - meta: flush_handlers
 

--- a/roles/kubernetes/preinstall/tasks/main.yml
+++ b/roles/kubernetes/preinstall/tasks/main.yml
@@ -256,19 +256,6 @@
   tags:
     - bootstrap-os
 
-- name: Write cloud-config
-  template:
-    src: "{{ cloud_provider }}-cloud-config.j2"
-    dest: "{{ kube_config_dir }}/cloud_config"
-    group: "{{ kube_cert_group }}"
-    mode: 0640
-  when:
-    - inventory_hostname in groups['k8s-cluster']
-    - cloud_provider is defined
-    - cloud_provider in [ 'openstack', 'azure', 'vsphere' ]
-  tags:
-    - cloud-provider
-
 - import_tasks: etchosts.yml
   tags:
     - bootstrap-os


### PR DESCRIPTION
This file should only be updated during kubelet upgrade so that
master components are not accidentally restarted first during
preinstall stage.