### PR TITLE
Added a fix in openssl.conf template to check for loadbalancer IP.

### DIFF
--- a/roles/kubernetes/secrets/templates/openssl.conf.j2
+++ b/roles/kubernetes/secrets/templates/openssl.conf.j2
@@ -26,7 +26,7 @@ IP.{{ 2 * loop.index }} = {{ hostvars[host]['ip'] | default(hostvars[host]['ansi
 {% endfor %}
 {% set idx =  groups['kube-master'] | length | int * 2 + 1 %}
 IP.{{ idx }} = {{ kube_apiserver_ip }}
-{% if loadbalancer_apiserver is defined  %}
+{% if loadbalancer_apiserver is defined and loadbalancer_apiserver.address is defined %}
 IP.{{ idx + 1 }} = {{ loadbalancer_apiserver.address }}
 {% set idx = idx + 1 %}
 {% endif %}


### PR DESCRIPTION
This check has been added to deal with the situation when loadbalancer doesn't have a dedicated IP address.