### PR TITLE
Added retries in pre-upgrade.yml and retries while applying kube-dns.yml

### DIFF
--- a/roles/kubernetes-apps/ansible/tasks/main.yml
+++ b/roles/kubernetes-apps/ansible/tasks/main.yml
@@ -50,9 +50,9 @@
     - dns_mode != 'none'
     - inventory_hostname == groups['kube-master'][0]
     - not item|skipped
-  register: resource_result 
-  until: resource_result|succeeded 
-  retries: 4 
+  register: resource_result
+  until: resource_result|succeeded
+  retries: 4
   delay: 5
   tags:
     - dnsmasq

--- a/roles/kubernetes-apps/ansible/tasks/main.yml
+++ b/roles/kubernetes-apps/ansible/tasks/main.yml
@@ -50,6 +50,10 @@
     - dns_mode != 'none'
     - inventory_hostname == groups['kube-master'][0]
     - not item|skipped
+  register: resource_result 
+  until: resource_result|succeeded 
+  retries: 4 
+  delay: 5
   tags:
     - dnsmasq
 

--- a/roles/kubernetes/master/tasks/pre-upgrade.yml
+++ b/roles/kubernetes/master/tasks/pre-upgrade.yml
@@ -30,7 +30,7 @@
   with_items:
     - ["kube-apiserver", "kube-controller-manager", "kube-scheduler"]
   when: kube_apiserver_manifest_replaced.changed
-  register: remove_master_container 
-  retries: 4 
-  until: remove_master_container.rc == 0 
+  register: remove_master_container
+  retries: 4
+  until: remove_master_container.rc == 0
   delay: 5

--- a/roles/kubernetes/master/tasks/pre-upgrade.yml
+++ b/roles/kubernetes/master/tasks/pre-upgrade.yml
@@ -30,4 +30,7 @@
   with_items:
     - ["kube-apiserver", "kube-controller-manager", "kube-scheduler"]
   when: kube_apiserver_manifest_replaced.changed
-  run_once: true
+  register: remove_master_container 
+  retries: 4 
+  until: remove_master_container.rc == 0 
+  delay: 5


### PR DESCRIPTION
This change has been added to add retries while deleting master containers during upgrade and also while setting up kube-dns on existing clusters.