### PR TITLE
Fix kubespray's ServiceAccount token signing keys

### DIFF
--- a/roles/kubernetes/master/tasks/kubeadm-migrate-certs.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-migrate-certs.yml
@@ -9,4 +9,6 @@
     - {src: apiserver-key.pem, dest: apiserver.key}
     - {src: ca.pem, dest: ca.crt}
     - {src: ca-key.pem, dest: ca.key}
+    - {src: service-account-key.pem, dest: sa.pub}
+    - {src: service-account-key.pem, dest: sa.key}
   register: kubeadm_copy_old_certs

--- a/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
@@ -63,7 +63,7 @@ spec:
 {% if kube_token_auth|default(true) %}
     - --token-auth-file={{ kube_token_dir }}/known_tokens.csv
 {% endif %}
-    - --service-account-key-file={{ kube_cert_dir }}/apiserver-key.pem
+    - --service-account-key-file={{ kube_cert_dir }}/service-account-key.pem
 {% if kube_oidc_auth|default(false) and kube_oidc_url is defined and kube_oidc_client_id is defined %}
     - --oidc-issuer-url={{ kube_oidc_url }}
     - --oidc-client-id={{ kube_oidc_client_id }}

--- a/roles/kubernetes/master/templates/manifests/kube-controller-manager.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-controller-manager.manifest.j2
@@ -29,7 +29,7 @@ spec:
     - controller-manager
     - --kubeconfig={{ kube_config_dir }}/kube-controller-manager-kubeconfig.yaml
     - --leader-elect=true
-    - --service-account-private-key-file={{ kube_cert_dir }}/apiserver-key.pem
+    - --service-account-private-key-file={{ kube_cert_dir }}/service-account-key.pem
     - --root-ca-file={{ kube_cert_dir }}/ca.pem
     - --cluster-signing-cert-file={{ kube_cert_dir }}/ca.pem
     - --cluster-signing-key-file={{ kube_cert_dir }}/ca-key.pem

--- a/roles/kubernetes/secrets/files/make-ssl.sh
+++ b/roles/kubernetes/secrets/files/make-ssl.sh
@@ -82,6 +82,17 @@ gen_key_and_cert() {
 
 # Admins
 if [ -n "$MASTERS" ]; then
+
+    # service-account
+    # If --service-account-private-key-file was previously configured to use apiserver-key.pem then copy that to the new dedicated service-account signing key location to avoid disruptions
+    if [ -e "$SSLDIR/apiserver-key.pem" ] && ! [ -e "$SSLDIR/service-account-key.pem" ]; then
+       cp $SSLDIR/apiserver-key.pem $SSLDIR/service-account-key.pem
+    fi
+    # Generate dedicated service account signing key if one doesn't exist
+    if ! [ -e "$SSLDIR/apiserver-key.pem" ] && ! [ -e "$SSLDIR/service-account-key.pem" ]; then
+        openssl genrsa -out service-account-key.pem 2048 > /dev/null 2>&1
+    fi
+
     # kube-apiserver
     # Generate only if we don't have existing ca and apiserver certs
     if ! [ -e "$SSLDIR/ca-key.pem" ] || ! [ -e "$SSLDIR/apiserver-key.pem" ]; then

--- a/roles/kubernetes/secrets/tasks/gen_certs_script.yml
+++ b/roles/kubernetes/secrets/tasks/gen_certs_script.yml
@@ -75,6 +75,7 @@
                        'kube-controller-manager-key.pem',
                        'front-proxy-client.pem',
                        'front-proxy-client-key.pem',
+                       'service-account-key.pem',
                        {% for node in groups['kube-master'] %}
                        'admin-{{ node }}.pem',
                        'admin-{{ node }}-key.pem',
@@ -86,6 +87,7 @@
                       'apiserver-key.pem',
                       'front-proxy-client.pem',
                       'front-proxy-client-key.pem',
+                      'service-account-key.pem',
                       'kube-scheduler.pem',
                       'kube-scheduler-key.pem',
                       'kube-controller-manager.pem',


### PR DESCRIPTION
Configure kubespray to sign service account tokens with a dedicated and stable key so that SA tokens are not invalidated when the apiserver-key.pem key is updated for other reasons (adding SANs etc.)

If cluster is already provisioned using apiserver-key.pem as the SA signing key copy that key to the new SA token signinig key's file location to avoid disruption.

