### PR TITLE
add selector to pods so we can use windows nodes too

### DIFF
--- a/roles/dnsmasq/templates/dnsmasq-autoscaler.yml.j2
+++ b/roles/dnsmasq/templates/dnsmasq-autoscaler.yml.j2
@@ -54,3 +54,5 @@ spec:
             - --default-params={"linear":{"nodesPerReplica":{{ dnsmasq_nodes_per_replica }},"preventSinglePointFailure":true}}
             - --logtostderr=true
             - --v={{ kube_log_level }}
+      nodeSelector:
+        beta.kubernetes.io/os: linux

--- a/roles/dnsmasq/templates/dnsmasq-deploy.yml
+++ b/roles/dnsmasq/templates/dnsmasq-deploy.yml
@@ -65,3 +65,5 @@ spec:
           hostPath:
             path: /etc/dnsmasq.d-available
       dnsPolicy: Default  # Don't use cluster DNS.
+      nodeSelector:
+        beta.kubernetes.io/os: linux

--- a/roles/kubernetes-apps/ansible/templates/coredns-deployment.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-deployment.yml.j2
@@ -79,3 +79,5 @@ spec:
             items:
             - key: Corefile
               path: Corefile
+      nodeSelector:
+        beta.kubernetes.io/os: linux

--- a/roles/kubernetes-apps/ansible/templates/dashboard.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/dashboard.yml.j2
@@ -140,6 +140,8 @@ spec:
       labels:
         k8s-app: kubernetes-dashboard
     spec:
+      nodeSelector:
+          beta.kubernetes.io/os: linux
       containers:
       - name: kubernetes-dashboard
         image: {{ dashboard_image_repo }}:{{ dashboard_image_tag }}

--- a/roles/kubernetes-apps/ansible/templates/kubedns-autoscaler.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/kubedns-autoscaler.yml.j2
@@ -50,3 +50,5 @@ spec:
 {% if rbac_enabled %}
       serviceAccountName: cluster-proportional-autoscaler
 {% endif %}
+      nodeSelector:
+        beta.kubernetes.io/os: linux

--- a/roles/kubernetes-apps/ansible/templates/kubedns-deploy.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/kubedns-deploy.yml.j2
@@ -157,3 +157,5 @@ spec:
 {% if rbac_enabled %}
       serviceAccountName: kube-dns
 {% endif %}
+      nodeSelector:
+        beta.kubernetes.io/os: linux

--- a/roles/kubernetes-apps/ansible/templates/netchecker-agent-ds.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/netchecker-agent-ds.yml.j2
@@ -44,3 +44,5 @@ spec:
     rollingUpdate:
       maxUnavailable: 100%
     type: RollingUpdate
+      nodeSelector:
+        beta.kubernetes.io/os: linux

--- a/roles/kubernetes-apps/ansible/templates/netchecker-agent-hostnet-ds.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/netchecker-agent-hostnet-ds.yml.j2
@@ -48,3 +48,5 @@ spec:
     rollingUpdate:
       maxUnavailable: 100%
     type: RollingUpdate
+      nodeSelector:
+        beta.kubernetes.io/os: linux

--- a/roles/kubernetes-apps/ansible/templates/netchecker-server-deployment.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/netchecker-server-deployment.yml.j2
@@ -36,3 +36,5 @@ spec:
 {% if rbac_enabled %}
       serviceAccountName: netchecker-server
 {% endif %}
+      nodeSelector:
+        beta.kubernetes.io/os: linux

--- a/roles/kubernetes-apps/efk/elasticsearch/templates/elasticsearch-deployment.yml.j2
+++ b/roles/kubernetes-apps/efk/elasticsearch/templates/elasticsearch-deployment.yml.j2
@@ -53,4 +53,5 @@ spec:
 {% if rbac_enabled %}
       serviceAccountName: efk 
 {% endif %}
-
+      nodeSelector:
+          beta.kubernetes.io/os: linux

--- a/roles/kubernetes-apps/efk/fluentd/templates/fluentd-ds.yml.j2
+++ b/roles/kubernetes-apps/efk/fluentd/templates/fluentd-ds.yml.j2
@@ -58,3 +58,5 @@ spec:
 {% if rbac_enabled %}
       serviceAccountName: efk 
 {% endif %}
+      nodeSelector:
+          beta.kubernetes.io/os: linux

--- a/roles/kubernetes-apps/efk/kibana/templates/kibana-deployment.yml.j2
+++ b/roles/kubernetes-apps/efk/kibana/templates/kibana-deployment.yml.j2
@@ -47,4 +47,5 @@ spec:
 {% if rbac_enabled %}
       serviceAccountName: efk 
 {% endif %}
-
+      nodeSelector:
+          beta.kubernetes.io/os: linux

--- a/roles/kubernetes-apps/external_provisioner/cephfs_provisioner/templates/cephfs-provisioner-rs.yml.j2
+++ b/roles/kubernetes-apps/external_provisioner/cephfs_provisioner/templates/cephfs-provisioner-rs.yml.j2
@@ -33,3 +33,5 @@ spec:
 {% if rbac_enabled %}
       serviceAccount: cephfs-provisioner
 {% endif %}
+      nodeSelector:
+          beta.kubernetes.io/os: linux

--- a/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-ds.yml.j2
+++ b/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-ds.yml.j2
@@ -43,3 +43,5 @@ spec:
         - name: local-volume-provisioner-hostpath-mnt-disks
           hostPath:
             path: {{ local_volume_provisioner_base_dir }}
+      nodeSelector:
+          beta.kubernetes.io/os: linux

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ingress-nginx-controller-ds.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ingress-nginx-controller-ds.yml.j2
@@ -78,3 +78,5 @@ spec:
 {% if rbac_enabled %}
       serviceAccountName: ingress-nginx
 {% endif %}
+      nodeSelector:
+          beta.kubernetes.io/os: linux

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ingress-nginx-default-backend-rs.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ingress-nginx-default-backend-rs.yml.j2
@@ -35,3 +35,5 @@ spec:
             timeoutSeconds: 5
           ports:
             - containerPort: 8080
+      nodeSelector:
+          beta.kubernetes.io/os: linux

--- a/roles/kubernetes-apps/istio/templates/istio-initializer.yml.j2
+++ b/roles/kubernetes-apps/istio/templates/istio-initializer.yml.j2
@@ -64,6 +64,8 @@ spec:
       - name: config-volume
         configMap:
           name: istio
+      nodeSelector:
+          beta.kubernetes.io/os: linux
 ---
 apiVersion: admissionregistration.k8s.io/v1alpha1
 kind: InitializerConfiguration

--- a/roles/kubernetes-apps/istio/templates/istio.yml.j2
+++ b/roles/kubernetes-apps/istio/templates/istio.yml.j2
@@ -288,6 +288,8 @@ spec:
       - name: config-volume
         configMap:
           name: istio-mixer
+      nodeSelector:
+          beta.kubernetes.io/os: linux
 ---
 # Mixer CRD definitions are generated using
 # mixs crd all
@@ -1098,6 +1100,8 @@ spec:
       - name: config-volume
         configMap:
           name: istio
+      nodeSelector:
+          beta.kubernetes.io/os: linux
 ---
 ################################
 # Istio ingress
@@ -1182,6 +1186,8 @@ spec:
         secret:
           secretName: istio-ingress-certs
           optional: true
+      nodeSelector:
+          beta.kubernetes.io/os: linux
 ---
 ################################
 # Istio egress
@@ -1249,6 +1255,8 @@ spec:
         secret:
           secretName: istio.default
           optional: true
+      nodeSelector:
+          beta.kubernetes.io/os: linux
 ---
 ################################
 # Istio-CA cluster-wide
@@ -1281,5 +1289,7 @@ spec:
       - name: istio-ca
         image: {{ istio_ca_image_repo }}:{{ istio_ca_image_tag }}
         imagePullPolicy: IfNotPresent
+      nodeSelector:
+          beta.kubernetes.io/os: linux
 ---
 

--- a/roles/kubernetes-apps/policy_controller/calico/templates/calico-kube-controllers.yml.j2
+++ b/roles/kubernetes-apps/policy_controller/calico/templates/calico-kube-controllers.yml.j2
@@ -66,3 +66,5 @@ spec:
       - hostPath:
           path: {{ calico_cert_dir }}
         name: etcd-certs
+      nodeSelector:
+          beta.kubernetes.io/os: linux

--- a/roles/kubernetes-apps/registry/README.md
+++ b/roles/kubernetes-apps/registry/README.md
@@ -148,6 +148,8 @@ spec:
       - name: image-store
         persistentVolumeClaim:
           claimName: kube-registry-pvc
+      nodeSelector:
+          beta.kubernetes.io/os: linux
 ```
 <!-- END MUNGE: EXAMPLE registry-rc.yaml -->
 
@@ -220,6 +222,8 @@ spec:
         - name: registry
           containerPort: 80
           hostPort: 5000
+      nodeSelector:
+          beta.kubernetes.io/os: linux
 ```
 <!-- END MUNGE: EXAMPLE ../../saltbase/salt/kube-registry-proxy/kube-registry-proxy.yaml -->
 

--- a/roles/kubernetes-apps/registry/templates/registry-proxy-ds.yml.j2
+++ b/roles/kubernetes-apps/registry/templates/registry-proxy-ds.yml.j2
@@ -34,3 +34,5 @@ spec:
             - name: registry
               containerPort: 80
               hostPort: 5000
+      nodeSelector:
+          beta.kubernetes.io/os: linux

--- a/roles/kubernetes-apps/registry/templates/registry-rs.yml.j2
+++ b/roles/kubernetes-apps/registry/templates/registry-rs.yml.j2
@@ -46,3 +46,5 @@ spec:
 {% else %}
           emptyDir: {}
 {% endif %}
+      nodeSelector:
+          beta.kubernetes.io/os: linux

--- a/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
@@ -182,3 +182,5 @@ spec:
       path: /etc/ssl/certs/ca-bundle.crt
     name: rhel-ca-bundle
 {% endif %}
+  nodeSelector:
+    beta.kubernetes.io/os: linux

--- a/roles/kubernetes/master/templates/manifests/kube-controller-manager.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-controller-manager.manifest.j2
@@ -115,3 +115,5 @@ spec:
       path: "{{ kube_config_dir }}/cloud_config"
     name: cloudconfig
 {% endif %}
+  nodeSelector:
+          beta.kubernetes.io/os: linux

--- a/roles/kubernetes/master/templates/manifests/kube-scheduler.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-scheduler.manifest.j2
@@ -90,3 +90,5 @@ spec:
     hostPath:
       path: "{{ kube_config_dir }}/kube-scheduler-policy.yaml"
 {% endif %}
+  nodeSelector:
+          beta.kubernetes.io/os: linux

--- a/roles/kubernetes/node/templates/manifests/kube-proxy.manifest.j2
+++ b/roles/kubernetes/node/templates/manifests/kube-proxy.manifest.j2
@@ -97,3 +97,5 @@ spec:
       path: /run/xtables.lock
       type: FileOrCreate
     name: xtables-lock
+  nodeSelector:
+          beta.kubernetes.io/os: linux

--- a/roles/kubernetes/node/templates/manifests/nginx-proxy.manifest.j2
+++ b/roles/kubernetes/node/templates/manifests/nginx-proxy.manifest.j2
@@ -28,3 +28,5 @@ spec:
   - name: etc-nginx
     hostPath:
       path: /etc/nginx
+  nodeSelector:
+          beta.kubernetes.io/os: linux

--- a/roles/network_plugin/calico/templates/calico-node.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-node.yml.j2
@@ -31,6 +31,8 @@ spec:
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 0
+      nodeSelector:
+          beta.kubernetes.io/os: linux
       containers:
         # Runs calico/node container on each Kubernetes node.  This
         # container programs network policy and routes on each

--- a/roles/network_plugin/canal/templates/canal-node.yaml.j2
+++ b/roles/network_plugin/canal/templates/canal-node.yaml.j2
@@ -50,6 +50,8 @@ spec:
         - name: "canal-certs"
           hostPath:
             path: "{{ canal_cert_dir }}"
+      nodeSelector:
+          beta.kubernetes.io/os: linux
       containers:
         # Runs the flannel daemon to enable vxlan networking between
         # container hosts.

--- a/roles/network_plugin/cilium/templates/cilium-ds.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium-ds.yml.j2
@@ -26,6 +26,8 @@ spec:
 {% if rbac_enabled %}
       serviceAccountName: cilium
 {% endif %}
+      nodeSelector:
+          beta.kubernetes.io/os: linux
       containers:
       - image: {{ cilium_image_repo }}:{{ cilium_image_tag }}
         imagePullPolicy: Always

--- a/roles/network_plugin/contiv/templates/contiv-api-proxy.yml.j2
+++ b/roles/network_plugin/contiv/templates/contiv-api-proxy.yml.j2
@@ -30,6 +30,8 @@ spec:
 {% if rbac_enabled %}
       serviceAccountName: contiv-netmaster
 {% endif %}
+      nodeSelector:
+          beta.kubernetes.io/os: linux
       containers:
         - name: contiv-api-proxy
           image: {{ contiv_auth_proxy_image_repo }}:{{ contiv_auth_proxy_image_tag }}

--- a/roles/network_plugin/contiv/templates/contiv-etcd-proxy.yml.j2
+++ b/roles/network_plugin/contiv/templates/contiv-etcd-proxy.yml.j2
@@ -29,3 +29,5 @@ spec:
               value: "on"
             - name: ETCD_INITIAL_CLUSTER
               value: '{{ contiv_etcd_endpoints }}'
+      nodeSelector:
+          beta.kubernetes.io/os: linux

--- a/roles/network_plugin/contiv/templates/contiv-etcd.yml.j2
+++ b/roles/network_plugin/contiv/templates/contiv-etcd.yml.j2
@@ -64,3 +64,5 @@ spec:
         - name: contiv-etcd-conf-dir
           hostPath:
             path: {{ contiv_etcd_conf_dir }}
+      nodeSelector:
+          beta.kubernetes.io/os: linux

--- a/roles/network_plugin/contiv/templates/contiv-netmaster.yml.j2
+++ b/roles/network_plugin/contiv/templates/contiv-netmaster.yml.j2
@@ -58,3 +58,5 @@ spec:
         - name: var-contiv
           hostPath:
             path: /var/contiv
+      nodeSelector:
+          beta.kubernetes.io/os: linux

--- a/roles/network_plugin/contiv/templates/contiv-netplugin.yml.j2
+++ b/roles/network_plugin/contiv/templates/contiv-netplugin.yml.j2
@@ -29,6 +29,8 @@ spec:
 {% if rbac_enabled %}
       serviceAccountName: contiv-netplugin
 {% endif %}
+      nodeSelector:
+          beta.kubernetes.io/os: linux
       containers:
         # Runs netplugin container on each Kubernetes node. This
         # container programs network policy and routes on each

--- a/roles/network_plugin/flannel/templates/cni-flannel.yml.j2
+++ b/roles/network_plugin/flannel/templates/cni-flannel.yml.j2
@@ -120,6 +120,8 @@ spec:
         - name: host-cni-bin
           hostPath:
             path: /opt/cni/bin
+      nodeSelector:
+        beta.kubernetes.io/os: linux
   updateStrategy:
     rollingUpdate:
       maxUnavailable: {{ serial | default('20%') }}

--- a/roles/network_plugin/weave/templates/weave-net.yml.j2
+++ b/roles/network_plugin/weave/templates/weave-net.yml.j2
@@ -103,6 +103,8 @@ items:
           labels:
             name: weave-net
         spec:
+          nodeSelector:
+            beta.kubernetes.io/os: linux
           containers:
             - name: weave
               command:


### PR DESCRIPTION
I have started to experiment with kubernetes and windows.
Some information: https://docs.microsoft.com/en-us/virtualization/windowscontainers/kubernetes/getting-started-kubernetes-windows#network-topology 

This is my first experience with kubernetes, just starting to use it and found kubespray as the best way to setup the linux masters with linux nodes too. 

My objetive is to have a cluster with both: windows and linux nodes.

I found some issues with standard setup of kubespray, as it setups many containers that doesn't have windows image so them can't be run on windows.

Now I have just searched every container in kubespray and added a selector to ensure it will not try to run on windows.

Maybe some of these containers have win image? (don't think so).
Have tested with vagrant and got success at the first try. (at least there is no errors on kubelet / kubeproxy and also started pod example successfully) (haven't got networking fully working as couldn't reach pods subnet from master yet, but this will be investigated more and I will document/ create another pull request if something else needs to be changed).

Please understand as commented, I'm just starting with kubernetes, I have been reading everything I could read (books,blogs,wikis,etc) before testing and coming to make this pull request, hope it is good.

