### PR TITLE
Maybe vault health check needs delay

### DIFF
--- a/roles/vault/tasks/cluster/systemd.yml
+++ b/roles/vault/tasks/cluster/systemd.yml
@@ -55,3 +55,4 @@
   register: vault_health_check
   until: vault_health_check|succeeded
   retries: 10
+  delay: "{{ retry_stagger | random + 3 }}"


### PR DESCRIPTION
add `delay: "{{ retry_stagger | random + 3 }}"` for `cluster/systemd | Query local vault until service is up`