### PR TITLE
Fix kubecert_node.results indexes

### DIFF
--- a/roles/kubernetes/secrets/tasks/check-certs.yml
+++ b/roles/kubernetes/secrets/tasks/check-certs.yml
@@ -105,9 +105,9 @@
       {%- set certs = {'sync': False} -%}
       {% if gen_node_certs[inventory_hostname] or
         (not kubecert_node.results[0].stat.exists|default(False)) or
-          (not kubecert_node.results[10].stat.exists|default(False)) or
-            (not kubecert_node.results[7].stat.exists|default(False)) or
-              (kubecert_node.results[10].stat.checksum|default('') != kubecert_master.files|selectattr("path", "equalto", kubecert_node.results[10].stat.path)|map(attribute="checksum")|first|default('')) -%}
+          (not kubecert_node.results[12].stat.exists|default(False)) or
+            (not kubecert_node.results[8].stat.exists|default(False)) or
+              (kubecert_node.results[12].stat.checksum|default('') != kubecert_master.files|selectattr("path", "equalto", kubecert_node.results[12].stat.path)|map(attribute="checksum")|first|default('')) -%}
                 {%- set _ = certs.update({'sync': True}) -%}
       {% endif %}
       {{ certs.sync }}


### PR DESCRIPTION
after new keys has been added in https://github.com/kubernetes-incubator/kubespray/pull/2251 we still checking old indexes in results array, but array size has changed, thus different indexes should be there
