### PR TITLE
Only download container/file if host is in defined group

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -140,18 +140,24 @@ downloads:
     repo: "{{ netcheck_server_img_repo }}"
     tag: "{{ netcheck_server_tag }}"
     sha256: "{{ netcheck_server_digest_checksum|default(None) }}"
+    groups:
+      - kube-master
   netcheck_agent:
     enabled: "{{ deploy_netchecker }}"
     container: true
     repo: "{{ netcheck_agent_img_repo }}"
     tag: "{{ netcheck_agent_tag }}"
     sha256: "{{ netcheck_agent_digest_checksum|default(None) }}"
+    groups:
+      - kube-master
   etcd:
     enabled: true
     container: true
     repo: "{{ etcd_image_repo }}"
     tag: "{{ etcd_image_tag }}"
     sha256: "{{ etcd_digest_checksum|default(None) }}"
+    groups:
+      - etcd
   kubeadm:
     enabled: "{{ kubeadm_enabled }}"
     file: true
@@ -163,6 +169,8 @@ downloads:
     unarchive: false
     owner: "root"
     mode: "0755"
+    groups:
+      - k8s-cluster
   istioctl:
     enabled: "{{ istio_enabled }}"
     file: true
@@ -174,140 +182,186 @@ downloads:
     unarchive: false
     owner: "root"
     mode: "0755"
+    groups:
+      - kube-master
   hyperkube:
     enabled: true
     container: true
     repo: "{{ hyperkube_image_repo }}"
     tag: "{{ hyperkube_image_tag }}"
     sha256: "{{ hyperkube_digest_checksum|default(None) }}"
+    groups:
+      - k8s-cluster
   cilium:
     enabled: "{{ kube_network_plugin == 'cilium' }}"
     container: true
     repo: "{{ cilium_image_repo }}"
     tag: "{{ cilium_image_tag }}"
     sha256: "{{ cilium_digest_checksum|default(None) }}"
+    groups:
+      - k8s-cluster
   flannel:
     enabled: "{{ kube_network_plugin == 'flannel' or kube_network_plugin == 'canal' }}"
     container: true
     repo: "{{ flannel_image_repo }}"
     tag: "{{ flannel_image_tag }}"
     sha256: "{{ flannel_digest_checksum|default(None) }}"
+    groups:
+      - k8s-cluster
   flannel_cni:
     enabled: "{{ kube_network_plugin == 'flannel' }}"
     container: true
     repo: "{{ flannel_cni_image_repo }}"
     tag: "{{ flannel_cni_image_tag }}"
     sha256: "{{ flannel_cni_digest_checksum|default(None) }}"
+    groups:
+      - k8s-cluster
   calicoctl:
     enabled: "{{ kube_network_plugin == 'calico' or kube_network_plugin == 'canal' }}"
     container: true
     repo: "{{ calicoctl_image_repo }}"
     tag: "{{ calicoctl_image_tag }}"
     sha256: "{{ calicoctl_digest_checksum|default(None) }}"
+    groups:
+      - k8s-cluster
   calico_node:
     enabled: "{{ kube_network_plugin == 'calico' or kube_network_plugin == 'canal' }}"
     container: true
     repo: "{{ calico_node_image_repo }}"
     tag: "{{ calico_node_image_tag }}"
     sha256: "{{ calico_node_digest_checksum|default(None) }}"
+    groups:
+      - k8s-cluster
   calico_cni:
     enabled: "{{ kube_network_plugin == 'calico' or kube_network_plugin == 'canal' }}"
     container: true
     repo: "{{ calico_cni_image_repo }}"
     tag: "{{ calico_cni_image_tag }}"
     sha256: "{{ calico_cni_digest_checksum|default(None) }}"
+    groups:
+      - k8s-cluster
   calico_policy:
     enabled: "{{ enable_network_policy or kube_network_plugin == 'canal' }}"
     container: true
     repo: "{{ calico_policy_image_repo }}"
     tag: "{{ calico_policy_image_tag }}"
     sha256: "{{ calico_policy_digest_checksum|default(None) }}"
+    groups:
+      - k8s-cluster
   calico_rr:
     enabled: "{{ peer_with_calico_rr is defined and peer_with_calico_rr and kube_network_plugin == 'calico' }}"
     container: true
     repo: "{{ calico_rr_image_repo }}"
     tag: "{{ calico_rr_image_tag }}"
     sha256: "{{ calico_rr_digest_checksum|default(None) }}"
+    groups:
+      - k8s-cluster
   weave_kube:
     enabled: "{{ kube_network_plugin == 'weave' }}"
     container: true
     repo: "{{ weave_kube_image_repo }}"
     tag: "{{ weave_kube_image_tag }}"
     sha256: "{{ weave_kube_digest_checksum|default(None) }}"
+    groups:
+      - k8s-cluster
   weave_npc:
     enabled: "{{ kube_network_plugin == 'weave' }}"
     container: true
     repo: "{{ weave_npc_image_repo }}"
     tag: "{{ weave_npc_image_tag }}"
     sha256: "{{ weave_npc_digest_checksum|default(None) }}"
+    groups:
+      - k8s-cluster
   contiv:
     enabled: "{{ kube_network_plugin == 'contiv' }}"
     container: true
     repo: "{{ contiv_image_repo }}"
     tag: "{{ contiv_image_tag }}"
     sha256: "{{ contiv_digest_checksum|default(None) }}"
+    groups:
+      - k8s-cluster
   contiv_auth_proxy:
     enabled: "{{ kube_network_plugin == 'contiv' }}"
     container: true
     repo: "{{ contiv_auth_proxy_image_repo }}"
     tag: "{{ contiv_auth_proxy_image_tag }}"
     sha256: "{{ contiv_auth_proxy_digest_checksum|default(None) }}"
+    groups:
+      - k8s-cluster
   pod_infra:
     enabled: true
     container: true
     repo: "{{ pod_infra_image_repo }}"
     tag: "{{ pod_infra_image_tag }}"
     sha256: "{{ pod_infra_digest_checksum|default(None) }}"
+    groups:
+      - k8s-cluster
   install_socat:
     enabled: "{{ ansible_os_family in ['CoreOS', 'Container Linux by CoreOS'] }}"
     container: true
     repo: "{{ install_socat_image_repo }}"
     tag: "{{ install_socat_image_tag }}"
     sha256: "{{ install_socat_digest_checksum|default(None) }}"
+    groups:
+      - k8s-cluster
   nginx:
-    enabled: true
+    enabled: "{{ loadbalancer_apiserver_localhost }}"
     container: true
     repo: "{{ nginx_image_repo }}"
     tag: "{{ nginx_image_tag }}"
     sha256: "{{ nginx_digest_checksum|default(None) }}"
+    groups:
+      - kube-node
   dnsmasq:
     enabled: "{{ dns_mode == 'dnsmasq_kubedns' }}"
     container: true
     repo: "{{ dnsmasq_image_repo }}"
     tag: "{{ dnsmasq_image_tag }}"
     sha256: "{{ dnsmasq_digest_checksum|default(None) }}"
+    groups:
+      - kube-node
   kubedns:
     enabled: "{{ dns_mode in ['kubedns', 'dnsmasq_kubedns'] }}"
     container: true
     repo: "{{ kubedns_image_repo }}"
     tag: "{{ kubedns_image_tag }}"
     sha256: "{{ kubedns_digest_checksum|default(None) }}"
+    groups:
+      - kube-node
   coredns:
     enabled: "{{ dns_mode in ['coredns', 'coredns_dual'] }}"
     container: true
     repo: "{{ coredns_image_repo }}"
     tag: "{{ coredns_image_tag }}"
     sha256: "{{ coredns_digest_checksum|default(None) }}"
+    groups:
+      - kube-node
   dnsmasq_nanny:
     enabled: "{{ dns_mode in ['kubedns', 'dnsmasq_kubedns'] }}"
     container: true
     repo: "{{ dnsmasq_nanny_image_repo }}"
     tag: "{{ dnsmasq_nanny_image_tag }}"
     sha256: "{{ dnsmasq_nanny_digest_checksum|default(None) }}"
+    groups:
+      - kube-node
   dnsmasq_sidecar:
     enabled: "{{ dns_mode in ['kubedns', 'dnsmasq_kubedns'] }}"
     container: true
     repo: "{{ dnsmasq_sidecar_image_repo }}"
     tag: "{{ dnsmasq_sidecar_image_tag }}"
     sha256: "{{ dnsmasq_sidecar_digest_checksum|default(None) }}"
+    groups:
+      - kube-node
   kubednsautoscaler:
     enabled: "{{ dns_mode in ['kubedns', 'dnsmasq_kubedns'] }}"
     container: true
     repo: "{{ kubednsautoscaler_image_repo }}"
     tag: "{{ kubednsautoscaler_image_tag }}"
     sha256: "{{ kubednsautoscaler_digest_checksum|default(None) }}"
+    groups:
+      - kube-node
   testbox:
-    enabled: true
+    enabled: false
     container: true
     repo: "{{ test_image_repo }}"
     tag: "{{ test_image_tag }}"
@@ -318,30 +372,40 @@ downloads:
     repo: "{{ elasticsearch_image_repo }}"
     tag: "{{ elasticsearch_image_tag }}"
     sha256: "{{ elasticsearch_digest_checksum|default(None) }}"
+    groups:
+      - kube-node
   fluentd:
     enabled: "{{ efk_enabled }}"
     container: true
     repo: "{{ fluentd_image_repo }}"
     tag: "{{ fluentd_image_tag }}"
     sha256: "{{ fluentd_digest_checksum|default(None) }}"
+    groups:
+      - kube-node
   kibana:
     enabled: "{{ efk_enabled }}"
     container: true
     repo: "{{ kibana_image_repo }}"
     tag: "{{ kibana_image_tag }}"
     sha256: "{{ kibana_digest_checksum|default(None) }}"
+    groups:
+      - kube-node
   helm:
     enabled: "{{ helm_enabled }}"
     container: true
     repo: "{{ helm_image_repo }}"
     tag: "{{ helm_image_tag }}"
     sha256: "{{ helm_digest_checksum|default(None) }}"
+    groups:
+      - kube-node
   tiller:
     enabled: "{{ helm_enabled }}"
     container: true
     repo: "{{ tiller_image_repo }}"
     tag: "{{ tiller_image_tag }}"
     sha256: "{{ tiller_digest_checksum|default(None) }}"
+    groups:
+      - kube-node
   vault:
     enabled: "{{ cert_management == 'vault' }}"
     container: "{{ vault_deployment_type != 'host' }}"
@@ -356,6 +420,8 @@ downloads:
     unarchive: true
     url: "{{ vault_download_url }}"
     version: "{{ vault_version }}"
+    groups:
+      - vault
 
 download_defaults:
   container: false

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -141,7 +141,7 @@ downloads:
     tag: "{{ netcheck_server_tag }}"
     sha256: "{{ netcheck_server_digest_checksum|default(None) }}"
     groups:
-      - kube-master
+      - k8s-cluster
   netcheck_agent:
     enabled: "{{ deploy_netchecker }}"
     container: true
@@ -149,7 +149,7 @@ downloads:
     tag: "{{ netcheck_agent_tag }}"
     sha256: "{{ netcheck_agent_digest_checksum|default(None) }}"
     groups:
-      - kube-master
+      - k8s-cluster
   etcd:
     enabled: true
     container: true
@@ -255,7 +255,7 @@ downloads:
     tag: "{{ calico_rr_image_tag }}"
     sha256: "{{ calico_rr_digest_checksum|default(None) }}"
     groups:
-      - k8s-cluster
+      - calico-rr
   weave_kube:
     enabled: "{{ kube_network_plugin == 'weave' }}"
     container: true

--- a/roles/download/tasks/download_container.yml
+++ b/roles/download/tasks/download_container.yml
@@ -7,7 +7,7 @@
   when:
     - download.enabled
     - download.container
-    - inventory_hostname in download.groups
+    - group_names | intersect(download.groups) | length
   tags:
     - facts
 
@@ -23,8 +23,8 @@
     - download_run_once
     - download.enabled
     - download.container
-    - inventory_hostname in download.groups
     - pull_required|default(download_always_pull)
+    - group_names | intersect(download.groups) | length
   delegate_to: "{{ download_delegate }}"
   delegate_facts: yes
   run_once: yes
@@ -39,5 +39,5 @@
     - not download_run_once
     - download.enabled
     - download.container
-    - inventory_hostname in download.groups
     - pull_required|default(download_always_pull)
+    - group_names | intersect(download.groups) | length

--- a/roles/download/tasks/download_container.yml
+++ b/roles/download/tasks/download_container.yml
@@ -7,6 +7,7 @@
   when:
     - download.enabled
     - download.container
+    - inventory_hostname in download.groups
   tags:
     - facts
 
@@ -22,6 +23,7 @@
     - download_run_once
     - download.enabled
     - download.container
+    - inventory_hostname in download.groups
     - pull_required|default(download_always_pull)
   delegate_to: "{{ download_delegate }}"
   delegate_facts: yes
@@ -37,4 +39,5 @@
     - not download_run_once
     - download.enabled
     - download.container
+    - inventory_hostname in download.groups
     - pull_required|default(download_always_pull)

--- a/roles/download/tasks/download_file.yml
+++ b/roles/download/tasks/download_file.yml
@@ -12,6 +12,7 @@
     recurse: yes
   when:
     - download.enabled
+    - inventory_hostname in download.groups
     - download.file
 
 - name: file_download | Download item
@@ -27,6 +28,7 @@
   delay: "{{ retry_stagger | random + 3 }}"
   when:
     - download.enabled
+    - inventory_hostname in download.groups
     - download.file
 
 - name: file_download | Extract archives
@@ -39,4 +41,5 @@
   when:
     - download.enabled
     - download.file
+    - inventory_hostname in download.groups
     - download.unarchive|default(False)

--- a/roles/download/tasks/download_file.yml
+++ b/roles/download/tasks/download_file.yml
@@ -12,8 +12,8 @@
     recurse: yes
   when:
     - download.enabled
-    - inventory_hostname in download.groups
     - download.file
+    - group_names | intersect(download.groups) | length
 
 - name: file_download | Download item
   get_url:
@@ -28,8 +28,8 @@
   delay: "{{ retry_stagger | random + 3 }}"
   when:
     - download.enabled
-    - inventory_hostname in download.groups
     - download.file
+    - group_names | intersect(download.groups) | length
 
 - name: file_download | Extract archives
   unarchive:
@@ -41,5 +41,5 @@
   when:
     - download.enabled
     - download.file
-    - inventory_hostname in download.groups
     - download.unarchive|default(False)
+    - group_names | intersect(download.groups) | length

--- a/roles/download/tasks/sync_container.yml
+++ b/roles/download/tasks/sync_container.yml
@@ -7,6 +7,7 @@
   when:
     - download.enabled
     - download.container
+    - inventory_hostname in download.groups
   tags:
     - facts
 
@@ -16,6 +17,7 @@
   when:
     - download.enabled
     - download.container
+    - inventory_hostname in download.groups
     - download_run_once
   tags:
     - facts
@@ -26,6 +28,7 @@
   when:
     - download.enabled
     - download.container
+    - inventory_hostname in download.groups
     - download_run_once
 
 - name: "container_download | Update the 'container_changed' fact"
@@ -34,6 +37,7 @@
   when:
     - download.enabled
     - download.container
+    - inventory_hostname in download.groups
     - download_run_once
     - pull_required|default(download_always_pull)
   run_once: "{{ download_run_once }}"
@@ -52,6 +56,7 @@
   when:
     - download.enabled
     - download.container
+    - inventory_hostname in download.groups
     - download_run_once
   tags:
     - facts
@@ -65,6 +70,7 @@
   when:
     - download.enabled
     - download.container
+    - inventory_hostname in download.groups
     - download_run_once
     - (ansible_os_family not in ["CoreOS", "Container Linux by CoreOS"] or download_delegate == "localhost")
     - (container_changed or not img.stat.exists)
@@ -82,6 +88,7 @@
   when:
     - download.enabled
     - download.container
+    - inventory_hostname in download.groups
     - download_run_once
     - ansible_os_family not in ["CoreOS", "Container Linux by CoreOS"]
     - inventory_hostname == download_delegate
@@ -104,6 +111,7 @@
   when:
     - download.enabled
     - download.container
+    - inventory_hostname in download.groups
     - download_run_once
     - (ansible_os_family not in ["CoreOS", "Container Linux by CoreOS"] and
       inventory_hostname != download_delegate or
@@ -117,6 +125,7 @@
   when:
     - download.enabled
     - download.container
+    - inventory_hostname in download.groups
     - download_run_once
     - (ansible_os_family not in ["CoreOS", "Container Linux by CoreOS"] and
       inventory_hostname != download_delegate or download_delegate == "localhost")

--- a/roles/download/tasks/sync_container.yml
+++ b/roles/download/tasks/sync_container.yml
@@ -70,10 +70,10 @@
   when:
     - download.enabled
     - download.container
-    - inventory_hostname in download.groups
     - download_run_once
     - (ansible_os_family not in ["CoreOS", "Container Linux by CoreOS"] or download_delegate == "localhost")
     - (container_changed or not img.stat.exists)
+    - group_names | intersect(download.groups) | length
 
 - name: container_download | copy container images to ansible host
   synchronize:
@@ -88,12 +88,12 @@
   when:
     - download.enabled
     - download.container
-    - inventory_hostname in download.groups
     - download_run_once
     - ansible_os_family not in ["CoreOS", "Container Linux by CoreOS"]
     - inventory_hostname == download_delegate
     - download_delegate != "localhost"
     - saved.changed
+    - group_names | intersect(download.groups) | length
 
 - name: container_download | upload container images to nodes
   synchronize:
@@ -111,11 +111,11 @@
   when:
     - download.enabled
     - download.container
-    - inventory_hostname in download.groups
     - download_run_once
     - (ansible_os_family not in ["CoreOS", "Container Linux by CoreOS"] and
       inventory_hostname != download_delegate or
       download_delegate == "localhost")
+    - group_names | intersect(download.groups) | length
   tags:
     - upload
     - upgrade
@@ -125,10 +125,10 @@
   when:
     - download.enabled
     - download.container
-    - inventory_hostname in download.groups
     - download_run_once
     - (ansible_os_family not in ["CoreOS", "Container Linux by CoreOS"] and
       inventory_hostname != download_delegate or download_delegate == "localhost")
+    - group_names | intersect(download.groups) | length
   tags:
     - upload
     - upgrade

--- a/roles/download/tasks/sync_container.yml
+++ b/roles/download/tasks/sync_container.yml
@@ -7,7 +7,7 @@
   when:
     - download.enabled
     - download.container
-    - inventory_hostname in download.groups
+    - group_names | intersect(download.groups) | length
   tags:
     - facts
 
@@ -17,8 +17,8 @@
   when:
     - download.enabled
     - download.container
-    - inventory_hostname in download.groups
     - download_run_once
+    - group_names | intersect(download.groups) | length
   tags:
     - facts
 
@@ -28,8 +28,8 @@
   when:
     - download.enabled
     - download.container
-    - inventory_hostname in download.groups
     - download_run_once
+    - group_names | intersect(download.groups) | length
 
 - name: "container_download | Update the 'container_changed' fact"
   set_fact:
@@ -37,9 +37,9 @@
   when:
     - download.enabled
     - download.container
-    - inventory_hostname in download.groups
     - download_run_once
     - pull_required|default(download_always_pull)
+    - group_names | intersect(download.groups) | length
   run_once: "{{ download_run_once }}"
   tags:
     - facts
@@ -56,8 +56,8 @@
   when:
     - download.enabled
     - download.container
-    - inventory_hostname in download.groups
     - download_run_once
+    - group_names | intersect(download.groups) | length
   tags:
     - facts
 


### PR DESCRIPTION
To speed up deployment, define which groups that should download a given container/file.

Currently if you have a dedicated etcd node, the node would download alot of unneeded containers.

Example:
```
odn1-kube-cluster01-etcd01 ak # docker images
REPOSITORY                                                         TAG                 IMAGE ID            CREATED             SIZE
odn1-kube-registry.privatedns.zone/coreos/etcd                     v3.2.18             e21fb69683f3        18 hours ago        37.2MB
odn1-kube-registry.privatedns.zone/nginx                           1.13                7f70b30f2cc6        8 days ago          109MB
odn1-kube-registry.privatedns.zone/hyperkube                       v1.9.5              a7e7fdbc5fee        10 days ago         620MB
odn1-kube-registry.privatedns.zone/coredns/coredns                 1.1.0               0b63f0820704        2 weeks ago         46.4MB
odn1-kube-registry.privatedns.zone/weaveworks/weave-npc            2.2.1               26d868a4eb75        2 weeks ago         46.6MB
odn1-kube-registry.privatedns.zone/weaveworks/weave-kube           2.2.1               86e2da7dd27b        2 weeks ago         93.8MB
odn1-kube-registry.privatedns.zone/busybox                         latest              f6e427c148a7        4 weeks ago         1.15MB
odn1-kube-registry.privatedns.zone/lachlanevenson/k8s-helm         v2.8.1              d8dab43d4cf3        6 weeks ago         68.7MB
odn1-kube-registry.privatedns.zone/kubernetes-helm/tiller          v2.8.1              df8896eb004e        7 weeks ago         71.5MB
odn1-kube-registry.privatedns.zone/xueshanf/install-socat          latest              e6636c1ef0f1        7 months ago        7.99MB
odn1-kube-registry.privatedns.zone/google_containers/pause-amd64   3.0                 99e59f495ffa        23 months ago       747kB
```