### PR TITLE
Fix etcd from import task to include task

### DIFF
--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -29,13 +29,13 @@
   tags:
     - upgrade
 
-- import_tasks: set_cluster_health.yml
+- include_tasks: set_cluster_health.yml
   when: is_etcd_master and etcd_cluster_setup
 
-- import_tasks: configure.yml
+- include_tasks: configure.yml
   when: is_etcd_master and etcd_cluster_setup
 
-- import_tasks: refresh_config.yml
+- include_tasks: refresh_config.yml
   when: is_etcd_master and etcd_cluster_setup
 
 - name: Restart etcd if certs changed
@@ -68,8 +68,8 @@
 # After etcd cluster is assembled, make sure that
 # initial state of the cluster is in `existing`
 # state insted of `new`.
-- import_tasks: set_cluster_health.yml
+- include_tasks: set_cluster_health.yml
   when: is_etcd_master and etcd_cluster_setup
 
-- import_tasks: refresh_config.yml
+- include_tasks: refresh_config.yml
   when: is_etcd_master and etcd_cluster_setup


### PR DESCRIPTION
Currently the `cluster.yml` includes the etcd role for all k8s-cluster host in the  group.
It uses the variable `etcd_cluster_setup` which is dynamically set in `cluster.yml`

The etcd contains import_task which is evaluated at playbook start, so the conditional is not evaluated on runtime in the playbook, causing the playbook to want to join etcd nodes from all hosts in k8s-cluster.