### PR TITLE
node_labels documentation and kube-ingress label definition as role_node_label

### DIFF
--- a/docs/vars.md
+++ b/docs/vars.md
@@ -119,7 +119,13 @@ Stack](https://github.com/kubernetes-incubator/kubespray/blob/master/docs/dns-st
   cgroup-driver option for Kubelet. By default autodetection is used
   to match Docker configuration.
 * *node_labels* - Labels applied to nodes via kubelet --node-labels parameter.
-  For example, labels can be set in the inventory as variables or more widely in group_vars
+  For example, labels can be set in the inventory as variables or more widely in group_vars.
+  *node_labels* must be defined as a dict:
+```
+node_labels:
+  label1_name: label1_value
+  label2_name: label2_value
+```
 
 ##### Custom flags for Kube Components
 For all kube components, custom flags can be passed in. This allows for edge cases where users need changes to the default deployment that may not be applicable to all deployments. This can be done by providing a list of flags. Example:

--- a/roles/kubernetes/node/templates/kubelet.standard.env.j2
+++ b/roles/kubernetes/node/templates/kubelet.standard.env.j2
@@ -88,7 +88,7 @@ KUBELET_HOSTNAME="--hostname-override={{ kube_override_hostname }}"
 {%     do role_node_labels.append('node-role.kubernetes.io/node=true') %}
 {%   endif %}
 {% elif inventory_hostname in groups['kube-ingress']|default([]) %}
-{%   set node_labels %}--node-labels=node-role.kubernetes.io/ingress=true{% endset %}
+{%   do role_node_labels.append('node-role.kubernetes.io/ingress=true') %}
 {% else %}
 {%   do role_node_labels.append('node-role.kubernetes.io/node=true') %}
 {% endif %}


### PR DESCRIPTION
Should fix a subsequent part of issue #2560 