### PR TITLE
Allow ansible_ssh_private_key_file for Openstack

### DIFF
--- a/contrib/terraform/openstack/ansible_bastion_template.txt
+++ b/contrib/terraform/openstack/ansible_bastion_template.txt
@@ -1,1 +1,1 @@
-ansible_ssh_common_args: '-o ProxyCommand="ssh -o StrictHostKeyChecking=no -W %h:%p -q USER@BASTION_ADDRESS"' 
+ansible_ssh_common_args: "-o ProxyCommand='ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -W %h:%p -q USER@BASTION_ADDRESS {% if ansible_ssh_private_key_file is defined %}-i {{ ansible_ssh_private_key_file }}{% endif %}'"


### PR DESCRIPTION
Same as https://github.com/kubernetes-incubator/kubespray/pull/2421 but for Openstack