### PR TITLE
ingress-nginx: container download related things should defined in the download role

### DIFF
--- a/inventory/sample/hosts.ini
+++ b/inventory/sample/hosts.ini
@@ -26,11 +26,11 @@
 # node5
 # node6
 
-# optional for dedicated ingress node
 # [kube-ingress]
 # node2
 # node3
 
 # [k8s-cluster:children]
-# kube-node
 # kube-master
+# kube-node
+# kube-ingress

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -91,7 +91,6 @@ contiv_auth_proxy_image_repo: "contiv/auth_proxy"
 contiv_auth_proxy_image_tag: "{{ contiv_version }}"
 cilium_image_repo: "docker.io/cilium/cilium"
 cilium_image_tag: "{{ cilium_version }}"
-
 nginx_image_repo: nginx
 nginx_image_tag: 1.13
 dnsmasq_version: 2.78
@@ -131,6 +130,10 @@ tiller_image_repo: "gcr.io/kubernetes-helm/tiller"
 tiller_image_tag: "{{ helm_version }}"
 vault_image_repo: "vault"
 vault_image_tag: "{{ vault_version }}"
+ingress_nginx_controller_image_repo: "quay.io/kubernetes-ingress-controller/nginx-ingress-controller"
+ingress_nginx_controller_image_tag: "0.11.0"
+ingress_nginx_default_backend_image_repo: "gcr.io/google_containers/defaultbackend"
+ingress_nginx_default_backend_image_tag: "1.4"
 cert_manager_version: "v0.2.3"
 cert_manager_controller_image_repo: "quay.io/jetstack/cert-manager-controller"
 cert_manager_controller_image_tag: "{{ cert_manager_version }}"
@@ -426,6 +429,22 @@ downloads:
     version: "{{ vault_version }}"
     groups:
       - vault
+  ingress_nginx_controller:
+    enabled: "{{ ingress_nginx_enabled }}"
+    container: true
+    repo: "{{ ingress_nginx_controller_image_repo }}"
+    tag: "{{ ingress_nginx_controller_image_tag }}"
+    sha256: "{{ ingress_nginx_controller_digest_checksum|default(None) }}"
+    groups:
+      - kube-ingress
+  ingress_nginx_default_backend:
+    enabled: "{{ ingress_nginx_enabled }}"
+    container: true
+    repo: "{{ ingress_nginx_default_backend_image_repo }}"
+    tag: "{{ ingress_nginx_default_backend_image_tag }}"
+    sha256: "{{ ingress_nginx_default_backend_digest_checksum|default(None) }}"
+    groups:
+      - kube-ingress
   cert_manager_controller:
     enabled: "{{ cert_manager_enabled }}"
     container: true

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/defaults/main.yml
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/defaults/main.yml
@@ -1,10 +1,4 @@
 ---
-ingress_nginx_default_backend_image_repo: gcr.io/google_containers/defaultbackend
-ingress_nginx_default_backend_image_tag: 1.4
-
-ingress_nginx_controller_image_repo: quay.io/kubernetes-ingress-controller/nginx-ingress-controller
-ingress_nginx_controller_image_tag: 0.11.0
-
 ingress_nginx_namespace: "ingress-nginx"
 ingress_nginx_host_network: false
 ingress_nginx_insecure_port: 80

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ingress-nginx-controller-ds.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ingress-nginx-controller-ds.yml.j2
@@ -27,10 +27,8 @@ spec:
 {% if ingress_nginx_host_network %}
       hostNetwork: true
 {% endif %}
-{% if 'kube-ingress' in groups and groups['kube-ingress']|length > 0 %}
       nodeSelector:
         node-role.kubernetes.io/ingress: "true"
-{% endif %}
       terminationGracePeriodSeconds: 60
       containers:
         - name: ingress-nginx-controller

--- a/roles/kubernetes/node/templates/kubelet.standard.env.j2
+++ b/roles/kubernetes/node/templates/kubelet.standard.env.j2
@@ -87,10 +87,11 @@ KUBELET_HOSTNAME="--hostname-override={{ kube_override_hostname }}"
 {%   if not standalone_kubelet|bool %}
 {%     do role_node_labels.append('node-role.kubernetes.io/node=true') %}
 {%   endif %}
-{% elif inventory_hostname in groups['kube-ingress']|default([]) %}
-{%   do role_node_labels.append('node-role.kubernetes.io/ingress=true') %}
 {% else %}
 {%   do role_node_labels.append('node-role.kubernetes.io/node=true') %}
+{% endif %}
+{% if inventory_hostname in groups['kube-ingress']|default([]) %}
+{%   do role_node_labels.append('node-role.kubernetes.io/ingress=true') %}
 {% endif %}
 {% set inventory_node_labels = [] %}
 {% if node_labels is defined %}


### PR DESCRIPTION
Related to https://github.com/kubernetes-incubator/kubespray/pull/2543#issuecomment-377609947

This also change the behavior of inventory group `kube-ingress` as a MUST for running ingress-nginx, because we will pre-download corresponding image on specific node inside group `kube-ingress`.