### PR TITLE
cephfs-provisioner: container download related things should defined in the download role

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -134,6 +134,8 @@ registry_image_repo: "registry"
 registry_image_tag: "2.6"
 registry_proxy_image_repo: "gcr.io/google_containers/kube-registry-proxy"
 registry_proxy_image_tag: "0.4"
+cephfs_provisioner_image_repo: "quay.io/kubespray/cephfs-provisioner"
+cephfs_provisioner_image_tag: "92295a30"
 ingress_nginx_controller_image_repo: "quay.io/kubernetes-ingress-controller/nginx-ingress-controller"
 ingress_nginx_controller_image_tag: "0.11.0"
 ingress_nginx_default_backend_image_repo: "gcr.io/google_containers/defaultbackend"
@@ -447,6 +449,14 @@ downloads:
     repo: "{{ registry_proxy_image_repo }}"
     tag: "{{ registry_proxy_image_tag }}"
     sha256: "{{ registry_proxy_digest_checksum|default(None) }}"
+    groups:
+      - kube-node
+  cephfs_provisioner:
+    enabled: "{{ cephfs_provisioner_enabled }}"
+    container: true
+    repo: "{{ cephfs_provisioner_image_repo }}"
+    tag: "{{ cephfs_provisioner_image_tag }}"
+    sha256: "{{ cephfs_provisioner_digest_checksum|default(None) }}"
     groups:
       - kube-node
   ingress_nginx_controller:

--- a/roles/kubernetes-apps/external_provisioner/cephfs_provisioner/defaults/main.yml
+++ b/roles/kubernetes-apps/external_provisioner/cephfs_provisioner/defaults/main.yml
@@ -1,7 +1,4 @@
 ---
-cephfs_provisioner_image_repo: quay.io/kubespray/cephfs-provisioner
-cephfs_provisioner_image_tag: 92295a30
-
 cephfs_provisioner_namespace: "kube-system"
 cephfs_provisioner_cluster: ceph
 cephfs_provisioner_monitors: []


### PR DESCRIPTION
Related to https://github.com/kubernetes-incubator/kubespray/pull/2543#issuecomment-377609947

Nothing special, just simply move the download information to download role