### PR TITLE
Add Openstack tenant name

### DIFF
--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -104,6 +104,7 @@ openstack_username: "{{ lookup('env','OS_USERNAME')  }}"
 openstack_password: "{{ lookup('env','OS_PASSWORD')  }}"
 openstack_region: "{{ lookup('env','OS_REGION_NAME')  }}"
 openstack_tenant_id: "{{ lookup('env','OS_TENANT_ID')| default(lookup('env','OS_PROJECT_ID')|default(lookup('env','OS_PROJECT_NAME'),true)) }}"
+openstack_tenant_name: "{{ lookup('env','OS_TENANT_NAME') }}"
 openstack_domain_name: "{{ lookup('env','OS_USER_DOMAIN_NAME') }}"
 openstack_domain_id: "{{ lookup('env','OS_USER_DOMAIN_ID') }}"
 

--- a/roles/kubernetes/node/templates/openstack-cloud-config.j2
+++ b/roles/kubernetes/node/templates/openstack-cloud-config.j2
@@ -4,6 +4,9 @@ username="{{ openstack_username }}"
 password="{{ openstack_password }}"
 region="{{ openstack_region }}"
 tenant-id="{{ openstack_tenant_id }}"
+{% if openstack_tenant_name is defined and openstack_tenant_name != "" %}
+tenant-name="{{ openstack_tenant_name }}"
+{% endif %}
 {% if openstack_domain_name is defined and openstack_domain_name != "" %}
 domain-name="{{ openstack_domain_name }}"
 {% elif openstack_domain_id is defined and openstack_domain_id != "" %}


### PR DESCRIPTION
KubeSpray doesn't handle Openstack Tenant Name: https://github.com/kubernetes-incubator/kubespray/blob/master/roles/kubernetes/node/defaults/main.yml#L100-L106

Some cloud providers (like OVH) require this setting to be set.

cf #2515 