### PR TITLE
kubectl get pods from 'test' namespace as the pods were created in test ns

### DIFF
--- a/tests/testcases/030_check-network.yml
+++ b/tests/testcases/030_check-network.yml
@@ -14,7 +14,7 @@
 
 
   - name: Wait for pods to be ready
-    shell: "{{bin_dir}}/kubectl get pods"
+    shell: "{{bin_dir}}/kubectl get pods -n test"
     register: pods
     until:
       - '"ContainerCreating" not in pods.stdout'
@@ -25,18 +25,18 @@
     no_log: true
 
   - name: Get pod names
-    shell: "{{bin_dir}}/kubectl get pods -o json"
+    shell: "{{bin_dir}}/kubectl get pods -n test -o json"
     register: pods
     no_log: true
 
   - name: Get hostnet pods
-    command: "{{bin_dir}}/kubectl get pods -o
+    command: "{{bin_dir}}/kubectl get pods -n test -o
              jsonpath='{range .items[?(.spec.hostNetwork)]}{.metadata.name} {.status.podIP} {.status.containerStatuses} {end}'"
     register: hostnet_pods
     no_log: true
 
   - name: Get running pods
-    command: "{{bin_dir}}/kubectl get pods -o
+    command: "{{bin_dir}}/kubectl get pods -n test -o
              jsonpath='{range .items[?(.status.phase==\"Running\")]}{.metadata.name} {.status.podIP} {.status.containerStatuses} {end}'"
     register: running_pods
     no_log: true


### PR DESCRIPTION
`test/testcases/020_check-create-pod.yml` creates test pods in a new `test` namespace. So, while testing the pod to pod communication in `test/testcases/030_check-network.yml`, we need to get pods from `test` ns instead of `default`.