### PR TITLE
Fixed kubelet cannot locate .docker directory

### DIFF
--- a/roles/kubernetes/node/templates/kubelet.standard.env.j2
+++ b/roles/kubernetes/node/templates/kubelet.standard.env.j2
@@ -125,3 +125,5 @@ KUBELET_CLOUDPROVIDER=""
 {% endif %}
 
 PATH={{ bin_dir }}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+HOME="/root"


### PR DESCRIPTION
Kubelet cannot locate .docker/config file, that user creates in /root directory to authenticate in private registry. According tokubernetes docs, kubelet able to pull from private registry when can read $HOME/.docker/config 
Kubespray writes systemd unit for kubelet and environment file, but there is no HOME variable, so kubelet don't know where docker config.
This pull request add HOME variable to env template and sove this problem

Related issue:
https://github.com/kubernetes/kubernetes/issues/45487