### PR TITLE
Fix issues #2522 Support Debian stretch

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Supported Linux Distributions
 -----------------------------
 
 -   **Container Linux by CoreOS**
--   **Debian** Jessie
+-   **Debian** Jessie, Stretch, Wheezy
 -   **Ubuntu** 16.04
 -   **CentOS/RHEL** 7
 -   **Fedora/CentOS** Atomic


### PR DESCRIPTION
It can be seen here that all supported versions except buster. https://download.docker.com/linux/debian/dists/
