### PR TITLE
Fix for kubectl location on localhost and permission check

### DIFF
--- a/roles/kubernetes/client/tasks/main.yml
+++ b/roles/kubernetes/client/tasks/main.yml
@@ -55,7 +55,7 @@
 - name: Copy kubectl binary to ansible host
   fetch:
     src: "{{ bin_dir }}/kubectl"
-    dest: "{{ bin_dir }}/kubectl"
+    dest: "{{ artifacts_dir }}/kubectl"
     flat: yes
     validate_checksum: no
   become: no
@@ -68,8 +68,6 @@
       #!/bin/bash
       kubectl --kubeconfig=admin.conf $@
     dest: "{{ artifacts_dir }}/kubectl.sh"
-    owner: root
-    group: root
     mode: 0755
   become: no
   run_once: yes


### PR DESCRIPTION
* kubectl should be downloaded to artifacts_dir, cause you cannot assume there is sudo access
* kubectl.sh script should not set permissions to root, also you cannot assume there is sudo access