### PR TITLE
Fix new envvar for setting openstack_tenant_id

### DIFF
--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -101,7 +101,7 @@ openstack_auth_url: "{{ lookup('env','OS_AUTH_URL')  }}"
 openstack_username: "{{ lookup('env','OS_USERNAME')  }}"
 openstack_password: "{{ lookup('env','OS_PASSWORD')  }}"
 openstack_region: "{{ lookup('env','OS_REGION_NAME')  }}"
-openstack_tenant_id: "{{ lookup('env','OS_TENANT_ID')|default(lookup('env','OS_PROJECT_ID'),true)  }}"
+openstack_tenant_id: "{{ lookup('env','OS_TENANT_ID')|lookup('env','OS_PROJECT_ID')|default(lookup('env','OS_PROJECT_NAME'),true) }}"
 openstack_domain_name: "{{ lookup('env','OS_USER_DOMAIN_NAME') }}"
 openstack_domain_id: "{{ lookup('env','OS_USER_DOMAIN_ID') }}"
 


### PR DESCRIPTION
Both OS_PROJECT_ID and OS_PROJECT_NAME are supported by OpenStack API V3.