### PR TITLE
Replaced 'mem' with 'memory/ in elasticsearch and kibana deployment

### DIFF
--- a/roles/kubernetes-apps/efk/elasticsearch/templates/elasticsearch-deployment.yml.j2
+++ b/roles/kubernetes-apps/efk/elasticsearch/templates/elasticsearch-deployment.yml.j2
@@ -30,12 +30,12 @@ spec:
           limits:
             cpu: {{ elasticsearch_cpu_limit }}
 {% if elasticsearch_mem_limit is defined and elasticsearch_mem_limit != "0M" %}
-            mem: {{ elasticsearch_mem_limit }}
+            memory: "{{ elasticsearch_mem_limit }}"
 {% endif %}
           requests:
             cpu: {{ elasticsearch_cpu_requests }}
 {% if elasticsearch_mem_requests is defined and elasticsearch_mem_requests != "0M" %}
-            mem: {{ elasticsearch_mem_requests }}
+            memory: "{{ elasticsearch_mem_requests }}"
 {% endif %}
         ports:
         - containerPort: 9200

--- a/roles/kubernetes-apps/efk/kibana/templates/kibana-deployment.yml.j2
+++ b/roles/kubernetes-apps/efk/kibana/templates/kibana-deployment.yml.j2
@@ -26,12 +26,12 @@ spec:
           limits:
             cpu: {{ kibana_cpu_limit }}
 {% if kibana_mem_limit is defined and kibana_mem_limit != "0M" %}
-            mem: {{ kibana_mem_limit }}
+            memory: "{{ kibana_mem_limit }}"
 {% endif %}
           requests:
             cpu: {{ kibana_cpu_requests }}
 {% if kibana_mem_requests is defined and kibana_mem_requests != "0M" %}
-            mem: {{ kibana_mem_requests }}
+            memory: "{{ kibana_mem_requests }}"
 {% endif %}
         env:
           - name: "ELASTICSEARCH_URL"


### PR DESCRIPTION
Fix for #2652 