### PR TITLE
Vagrantfile: Fix default inventory path.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -54,7 +54,7 @@ end
 
 $box = SUPPORTED_OS[$os][:box]
 # if $inventory is not set, try to use example
-$inventory = File.join(File.dirname(__FILE__), "inventory") if ! $inventory
+$inventory = File.join(File.dirname(__FILE__), "inventory", "sample") if ! $inventory
 
 # if $inventory has a hosts file use it, otherwise copy over vars etc
 # to where vagrant expects dynamic inventory to be.


### PR DESCRIPTION
Change to support multiple inventory path led to Vagrant environment not
getting a default group_vars in it's inventory path. Using sample as the
default path if none specified.

Fix issue #2541

Signed-off-by: Ganesh Maharaj Mahalingam <ganesh.mahalingam@intel.com>