### PR TITLE
Vagrantfile: Add vagrant inventory file in any directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .vagrant
 *.retry
-inventory/vagrant_ansible_inventory
+**/vagrant_ansible_inventory
 inventory/credentials/
 inventory/group_vars/fake_hosts.yml
 inventory/host_vars/


### PR DESCRIPTION
Follow-on fix for #2654

Signed-off-by: Ganesh Maharaj Mahalingam <ganesh.mahalingam@intel.com>