### PR TITLE
weave: Upgrade to 2.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Versions of supported components
 -   [canal](https://github.com/projectcalico/canal) (given calico/flannel versions)
 -   [cilium](https://github.com/cilium/cilium) v1.0.0-rc8
 -   [contiv](https://github.com/contiv/install/releases) v1.1.7
--   [weave](http://weave.works/) v2.2.1
+-   [weave](http://weave.works/) v2.3.0
 -   [docker](https://www.docker.com/) v17.03 (see note)
 -   [rkt](https://coreos.com/rkt/docs/latest/) v1.21.0 (see Note 2)
 

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -38,7 +38,7 @@ flannel_version: "v0.10.0"
 flannel_cni_version: "v0.3.0"
 istio_version: "0.2.6"
 vault_version: 0.8.1
-weave_version: 2.2.1
+weave_version: 2.3.0
 pod_infra_version: 3.0
 contiv_version: 1.1.7
 cilium_version: "v1.0.0-rc8"


### PR DESCRIPTION
Upgrade Weave to 2.3.0: https://github.com/weaveworks/weave/releases/tag/v2.3.0

Also double check https://github.com/kubernetes-incubator/kubespray/blob/master/roles/network_plugin/weave/templates/weave-net.yml.j2 with config generated by https://www.weave.works/docs/net/latest/kubernetes/kube-addon/#install, basically no update is required