### PR TITLE
Properly check need_pip, always run pip to check if needed

### DIFF
--- a/roles/bootstrap-os/tasks/bootstrap-coreos.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-coreos.yml
@@ -22,7 +22,6 @@
   failed_when: false
   changed_when: false
   check_mode: no
-  when: need_bootstrap.rc != 0
   tags:
     - facts
 
@@ -30,24 +29,24 @@
   copy:
     src: get-pip.py
     dest: ~/get-pip.py
-  when: need_pip != 0
+  when: need_pip.rc != 0
 
 - name: Bootstrap | Install pip
   shell: "{{ansible_python_interpreter}} ~/get-pip.py"
-  when: need_pip != 0
+  when: need_pip.rc != 0
 
 - name: Bootstrap | Remove get-pip.py
   file:
     path: ~/get-pip.py
     state: absent
-  when: need_pip != 0
+  when: need_pip.rc != 0
 
 - name: Bootstrap | Install pip launcher
   copy:
     src: runner
     dest: /opt/bin/pip
     mode: 0755
-  when: need_pip != 0
+  when: need_pip.rc != 0
 
 - name: Install required python modules
   pip:


### PR DESCRIPTION
pip was always being downloaded on subsequent runs, This PR always runs the pip command, and checks the rc of it before downloading pip

Fix in favor of #2582 