### PR TITLE
ingress-nginx: Add support for hostPort

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s-cluster.yml
@@ -202,6 +202,7 @@ cephfs_provisioner_enabled: false
 # Nginx ingress controller deployment
 ingress_nginx_enabled: false
 # ingress_nginx_host_network: false
+# ingress_nginx_host_port: false
 # ingress_nginx_namespace: "ingress-nginx"
 # ingress_nginx_insecure_port: 80
 # ingress_nginx_secure_port: 443

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/defaults/main.yml
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 ingress_nginx_namespace: "ingress-nginx"
 ingress_nginx_host_network: false
+ingress_nginx_host_port: false
 ingress_nginx_insecure_port: 80
 ingress_nginx_secure_port: 443
 ingress_nginx_configmap: {}

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ingress-nginx-controller-ds.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ingress-nginx-controller-ds.yml.j2
@@ -54,9 +54,15 @@ spec:
             - name: http
               containerPort: 80
               hostPort: {{ ingress_nginx_insecure_port }}
+              {% if ingress_nginx_host_port %}
+              hostPort: {{ ingress_nginx_insecure_port }}
+              {% endif %}
             - name: https
               containerPort: 443
               hostPort: {{ ingress_nginx_secure_port }}
+              {% if ingress_nginx_host_port %}
+              hostPort: {{ ingress_nginx_secure_port }}
+              {% endif %}
           livenessProbe:
             failureThreshold: 3
             httpGet:
@@ -79,4 +85,3 @@ spec:
 {% if rbac_enabled %}
       serviceAccountName: ingress-nginx
 {% endif %}
-


### PR DESCRIPTION
This adds support for `hostPort` in the ingress-nginx. `hostPort` is a little less intrusive than `hostNetwork` as it exposes only the `ingress_nginx_insecure_port` and `ingress_nginx_secure_port`.