### PR TITLE
Document how to allow ipip traffic with calico on OpenStack

### DIFF
--- a/docs/calico.md
+++ b/docs/calico.md
@@ -169,3 +169,12 @@ By default the felix agent(calico-node) will abort if the Kernel RPF setting is 
 ```
 calico_node_ignorelooserpf: true
 ```
+
+Note that in OpenStack you must allow `ipip` traffic in your security groups,
+otherwise you will experience timeouts.
+To do this you must add a rule which allows it, for example:
+
+```
+neutron  security-group-rule-create  --protocol 4  --direction egress  k8s-a0tp4t
+neutron  security-group-rule-create  --protocol 4  --direction igress  k8s-a0tp4t
+```


### PR DESCRIPTION
It took me some while to understand why somethings like `kubectl proxy` won't work with calico.
This is how I eventually solved the issue in OpenStack. I would benefit others too.