### PR TITLE
run_once pre_upgrade tasks which are executing in localhost

### DIFF
--- a/roles/kubernetes/preinstall/tasks/main.yml
+++ b/roles/kubernetes/preinstall/tasks/main.yml
@@ -5,6 +5,7 @@
 
 # This is run before bin_dir is pinned because these tasks are run on localhost
 - import_tasks: pre_upgrade.yml
+  run_once: true
   tags:
     - upgrade
 


### PR DESCRIPTION
The `preinstall/pre_upgrade` tasks are executing in localhost in that sense it is not necessary to run more than once this tasks.