### PR TITLE
sync certs tasks (fix #2596 #2667)

### DIFF
--- a/roles/kubernetes/secrets/tasks/check-certs.yml
+++ b/roles/kubernetes/secrets/tasks/check-certs.yml
@@ -14,27 +14,6 @@
     gen_certs: false
     secret_changed: false
 
-- name: "Check certs | check if a cert already exists on node"
-  stat:
-    path: "{{ kube_cert_dir }}/{{ item }}"
-  register: kubecert_node
-  with_items:
-    - ca.pem
-    - apiserver.pem
-    - apiserver-key.pem
-    - kube-scheduler.pem
-    - kube-scheduler-key.pem
-    - kube-controller-manager.pem
-    - kube-controller-manager-key.pem
-    - front-proxy-client.pem
-    - front-proxy-client-key.pem
-    - admin-{{ inventory_hostname }}.pem
-    - admin-{{ inventory_hostname }}-key.pem
-    - node-{{ inventory_hostname }}.pem
-    - node-{{ inventory_hostname }}-key.pem
-    - kube-proxy-{{ inventory_hostname }}.pem
-    - kube-proxy-{{ inventory_hostname }}-key.pem
-
 - name: "Check_certs | Set 'gen_certs' to true"
   set_fact:
     gen_certs: true
@@ -85,7 +64,6 @@
       {{ gen }}
   run_once: true
 
-
 - name: "Check_certs | Set 'gen_node_certs' to true"
   set_fact:
     gen_node_certs: |-
@@ -102,17 +80,3 @@
       {% endfor %}
       }
   run_once: true
-
-- name: "Check_certs | Set 'sync_certs' to true"
-  set_fact:
-    sync_certs: true
-  when: |-
-      {%- set certs = {'sync': False} -%}
-      {% if gen_node_certs[inventory_hostname] or
-        (not kubecert_node.results[0].stat.exists|default(False)) or
-          (not kubecert_node.results[12].stat.exists|default(False)) or
-            (not kubecert_node.results[8].stat.exists|default(False)) or
-              (kubecert_node.results[12].stat.checksum|default('') != kubecert_master.files|selectattr("path", "equalto", kubecert_node.results[12].stat.path)|map(attribute="checksum")|first|default('')) -%}
-                {%- set _ = certs.update({'sync': True}) -%}
-      {% endif %}
-      {{ certs.sync }}

--- a/roles/kubernetes/secrets/tasks/gen_certs_script.yml
+++ b/roles/kubernetes/secrets/tasks/gen_certs_script.yml
@@ -111,6 +111,34 @@
   tags:
     - facts
 
+- name: "Check certs | check if a cert already exists on node"
+  find:
+    paths: "{{ kube_cert_dir }}"
+    patterns: "*.pem"
+    get_checksum: true
+  register: kubecert_node
+  when: inventory_hostname != groups['kube-master'][0]
+
+- name: "Check_certs | Set 'sync_certs' to true on masters"
+  set_fact:
+    sync_certs: true
+  when: inventory_hostname in groups['kube-master'] and
+        inventory_hostname != groups['kube-master'][0] and
+        (not item in kubecert_node.files | map(attribute='path') | map("basename") | list or
+        kubecert_node.files | selectattr("path", "equalto", "{{ kube_cert_dir }}/{{ item }}") | map(attribute="checksum")|first|default('') != kubecert_master.files | selectattr("path", "equalto", "{{ kube_cert_dir }}/{{ item }}") | map(attribute="checksum")|first|default(''))
+  with_items:
+    - "{{ my_master_certs + all_node_certs }}"
+
+- name: "Check_certs | Set 'sync_certs' to true on nodes"
+  set_fact:
+    sync_certs: true
+  when: inventory_hostname in groups['kube-node'] and
+        inventory_hostname != groups['kube-master'][0] and
+        (not item in kubecert_node.files | map(attribute='path') | map("basename") | list or
+        kubecert_node.files | selectattr("path", "equalto", "{{ kube_cert_dir }}/{{ item }}") | map(attribute="checksum")|first|default('') != kubecert_master.files | selectattr("path", "equalto", "{{ kube_cert_dir }}/{{ item }}") | map(attribute="checksum")|first|default(''))
+  with_items:
+    - "{{ my_node_certs }}"
+
 - name: Gen_certs | Gather master certs
   shell: "tar cfz - -C {{ kube_cert_dir }} -T /dev/stdin <<< {{ my_master_certs|join(' ') }} {{ all_node_certs|join(' ') }} | base64 --wrap=0"
   args:
@@ -138,7 +166,7 @@
 # char limit when using shell command
 
 # FIXME(mattymo): Use tempfile module in ansible 2.3
-- name: Gen_certs | Prepare tempfile for unpacking certs
+- name: Gen_certs | Prepare tempfile for unpacking certs on masters
   command: mktemp /tmp/certsXXXXX.tar.gz
   register: cert_tempfile
   when: inventory_hostname in groups['kube-master'] and sync_certs|default(false) and
@@ -162,7 +190,7 @@
         inventory_hostname != groups['kube-master'][0]
   notify: set secret_changed
 
-- name: Gen_certs | Cleanup tempfile
+- name: Gen_certs | Cleanup tempfile on masters
   file:
     path: "{{cert_tempfile.stdout}}"
     state: absent


### PR DESCRIPTION
Certificates and keys wasn't synchronized when `cert_management` is set to  `script`. Especially the new ones: front-proxy-ca* and service-account-key.pem

I made a review of the usage of the different facts set in `roles/kubernetes/secrets/tasks/check-certs.yml`
- only in check-certs
    - kubecert_master
    - kubecert_node
- both check_certs_script & check_certs_vault:
    - gen_certs
- only check_certs_script:
    - gen_master_certs
    - gen_node_certs
    - sync_certs

So I moved `sync_certs` to `check_certs_script` and used the fact `*_certs` (list of certificates) to check if they are present on masters and nodes.

Verification about checksum is done over each file.

Questions:
1. `run_once: true` seems to have the same goal as `delegate_to: "{{groups['kube-master'][0]}}"`, should I make this keyword uniform among the tasks?
2. I have only modified files in `roles/kubernetes/secrets/tasks` directory, should I copy these changes to the other directories? (i.e. `extra_playbooks/roles/kubernetes/secrets/tasks`)
3. When this issue will be fixed: https://github.com/ansible/ansible/issues/15405, may we kind of revert this commit https://github.com/kubernetes-incubator/kubespray/commit/c7b00caeaac992e8dbb623994515dd9affe1b1b3 and simplify file synchronization with ansible `synchronize` module?

Thanks in advance for your feedbacks.

Fixes #2596 Fixes #2667