### PR TITLE
Check etcd_extra_vars if empty

### DIFF
--- a/roles/etcd/templates/etcd.env.j2
+++ b/roles/etcd/templates/etcd.env.j2
@@ -28,6 +28,8 @@ ETCD_PEER_CERT_FILE={{ etcd_cert_dir }}/member-{{ inventory_hostname }}.pem
 ETCD_PEER_KEY_FILE={{ etcd_cert_dir }}/member-{{ inventory_hostname }}-key.pem
 ETCD_PEER_CLIENT_CERT_AUTH={{ etcd_peer_client_auth }}
 
+{% if etcd_extra_vars | length > 0 %}
 {% for key, value in etcd_extra_vars.iteritems() %}
 {{ key }}={{ value }}
 {% endfor %}
+{% endif %}


### PR DESCRIPTION
When etcd_extra_vars does not have any item, the installation brakes. I would like to add a test of the length of the list.