### PR TITLE
Move front-proxy-client certs back to kube mount

### DIFF
--- a/roles/kubernetes/master/defaults/main.yml
+++ b/roles/kubernetes/master/defaults/main.yml
@@ -98,3 +98,6 @@ kube_encrypt_secret_data: false
 kube_encrypt_token: "{{ lookup('password', inventory_dir + '/credentials/kube_encrypt_token.creds length=32 chars=ascii_letters,digits') }}"
 # Must be either: aescbc, secretbox or aesgcm
 kube_encryption_algorithm: "aescbc"
+
+# You may want to use ca.pem depending on your situation
+kube_front_proxy_ca: "front-proxy-ca.pem"

--- a/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
@@ -111,8 +111,9 @@ spec:
     - --feature-gates={{ kube_feature_gates|join(',') }}
 {% endif %}
 {% if kube_version | version_compare('v1.9', '>=') %}
-    - --requestheader-client-ca-file={{ kube_cert_dir }}/front-proxy-ca.pem
-    - --requestheader-allowed-names=front-proxy-client
+    - --requestheader-client-ca-file={{ kube_cert_dir }}/{{ kube_front_proxy_ca }}
+{# intentionally empty #}
+    - --requestheader-allowed-names=
     - --requestheader-extra-headers-prefix=X-Remote-Extra-
     - --requestheader-group-headers=X-Remote-Group
     - --requestheader-username-headers=X-Remote-User

--- a/roles/kubernetes/secrets/defaults/main.yml
+++ b/roles/kubernetes/secrets/defaults/main.yml
@@ -1,4 +1,3 @@
 ---
 kube_cert_group: kube-cert
 kube_vault_mount_path: kube
-front_proxy_vault_mount_path: front-proxy

--- a/roles/kubernetes/secrets/tasks/gen_certs_vault.yml
+++ b/roles/kubernetes/secrets/tasks/gen_certs_vault.yml
@@ -117,7 +117,7 @@
     issue_cert_path: "{{ item }}"
     issue_cert_role: front-proxy-client
     issue_cert_url: "{{ hostvars[groups.vault|first]['vault_leader_url'] }}"
-    issue_cert_mount_path: "{{ front_proxy_vault_mount_path }}"
+    issue_cert_mount_path: "{{ kube_vault_mount_path }}"
   with_items: "{{ kube_front_proxy_clients_certs_needed|d([]) }}"
   when: inventory_hostname in groups['kube-master']
   notify: set secret_changed

--- a/roles/vault/defaults/main.yml
+++ b/roles/vault/defaults/main.yml
@@ -97,11 +97,6 @@ vault_ca_options:
     format: pem
     ttl: "{{ vault_max_lease_ttl }}"
     exclude_cn_from_sans: true
-  front_proxy:
-    common_name: front-proxy
-    format: pem
-    ttl: "{{ vault_max_lease_ttl }}"
-    exclude_cn_from_sans: true
 
 vault_client_headers:
   Accept: "application/json"
@@ -153,6 +148,14 @@ vault_pki_mounts:
           allow_any_name: true
           enforce_hostnames: false
           organization: "system:masters"
+      - name: front-proxy-client
+        group: kube-master
+        password: "{{ lookup('password', inventory_dir + '/credentials/vault/kube-proxy.creds length=15') }}"
+        policy_rules: default
+        role_options:
+          allow_any_name: true
+          enforce_hostnames: false
+          organization: "system:front-proxy-client"
       - name: kube-node
         group: k8s-cluster
         password: "{{ lookup('password', inventory_dir + '/credentials/vault/kube-node.creds length=15') }}"
@@ -169,18 +172,4 @@ vault_pki_mounts:
           allow_any_name: true
           enforce_hostnames: false
           organization: "system:node-proxier"
-  front_proxy:
-    name: front-proxy
-    default_lease_ttl: "{{ vault_default_lease_ttl }}"
-    max_lease_ttl: "{{ vault_max_lease_ttl }}"
-    description: "Kubernetes Front Proxy CA"
-    cert_dir: "{{ vault_kube_cert_dir }}"
-    roles:
-      - name: front-proxy-client
-        group: k8s-cluster
-        password: "{{ lookup('password', inventory_dir + '/credentials/vault/front-proxy-client.creds length=15') }}"
-        policy_rules: default
-        role_options:
-          allow_any_name: true
-          enforce_hostnames: false
-          organization: "system:front-proxy"
+

--- a/roles/vault/tasks/cluster/create_mounts.yml
+++ b/roles/vault/tasks/cluster/create_mounts.yml
@@ -6,9 +6,8 @@
     create_mount_max_lease_ttl: "{{ item.max_lease_ttl }}"
     create_mount_description: "{{ item.description }}"
     create_mount_cert_dir: "{{ item.cert_dir }}"
-    create_mount_config_ca_needed: item.name != vault_pki_mounts.kube.name and item.name != vault_pki_mounts.front_proxy.name
+    create_mount_config_ca_needed: item.name != vault_pki_mounts.kube.name
   with_items:
     - "{{ vault_pki_mounts.vault }}"
     - "{{ vault_pki_mounts.etcd }}"
     - "{{ vault_pki_mounts.kube }}"
-    - "{{ vault_pki_mounts.front_proxy }}"

--- a/roles/vault/tasks/cluster/main.yml
+++ b/roles/vault/tasks/cluster/main.yml
@@ -35,14 +35,6 @@
     gen_ca_copy_group: "kube-master"
   when: inventory_hostname in groups.vault
 
-- include_tasks: ../shared/gen_ca.yml
-  vars:
-    gen_ca_cert_dir: "{{ vault_pki_mounts.front_proxy.cert_dir }}"
-    gen_ca_mount_path: "{{ vault_pki_mounts.front_proxy.name }}"
-    gen_ca_vault_headers: "{{ vault_headers }}"
-    gen_ca_vault_options: "{{ vault_ca_options.front_proxy }}"
-  when: inventory_hostname in groups.vault
-
 - include_tasks: ../shared/auth_backend.yml
   vars:
     auth_backend_description: A Username/Password Auth Backend primarily used for services needing to issue certificates
@@ -55,7 +47,6 @@
     - "{{ vault_pki_mounts.vault }}"
     - "{{ vault_pki_mounts.etcd }}"
     - "{{ vault_pki_mounts.kube }}"
-    - "{{ vault_pki_mounts.front_proxy }}"
   loop_control:
     loop_var: mount
   when: inventory_hostname in groups.vault


### PR DESCRIPTION
We want the same CA for all k8s certs