### PR TITLE
node_labels's labelvalue must be formatted to handle non string values

### DIFF
--- a/roles/kubernetes/node/templates/kubelet.standard.env.j2
+++ b/roles/kubernetes/node/templates/kubelet.standard.env.j2
@@ -95,9 +95,9 @@ KUBELET_HOSTNAME="--hostname-override={{ kube_override_hostname }}"
 {% endif %}
 {% set inventory_node_labels = [] %}
 {% if node_labels is defined %}
-{% for labelname, labelvalue in node_labels.iteritems() %}
-{% set dummy = inventory_node_labels.append(labelname + '=' + labelvalue) %}
-{% endfor %}
+{%   for labelname, labelvalue in node_labels.iteritems() %}
+{%     set dummy = inventory_node_labels.append('%s=%s'|format(labelname, labelvalue)) %}
+{%   endfor %}
 {% endif %}
 {% set all_node_labels = role_node_labels + inventory_node_labels %}
 


### PR DESCRIPTION
Current behaviour expects values from node_labels dict to be strings, otherwise the rendering fails with "coercing to Unicode: need string or buffer, int found" (e.g. when a label in node_labels has a integer value)

The proposed formatting prevents the error from happening.

Replaces #2657 