### PR TITLE
coreos: explicitely set pip executable.

### DIFF
--- a/roles/bootstrap-os/tasks/bootstrap-coreos.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-coreos.yml
@@ -7,23 +7,32 @@
   tags:
     - facts
 
+- name: Force binaries directory for Container Linux by CoreOS
+  set_fact:
+    bin_dir: "/opt/bin"
+  tags:
+    - facts
+  when: need_bootstrap.rc != 0
+
 - name: Bootstrap | Run bootstrap.sh
   script: bootstrap.sh
   when: need_bootstrap.rc != 0
 
 - set_fact:
-    ansible_python_interpreter: "/opt/bin/python"
+    ansible_python_interpreter: "{{ bin_dir }}/python"
   tags:
     - facts
 
 - name: Bootstrap | Check if we need to install pip
-  shell: "{{ansible_python_interpreter}} -m pip --version"
+  shell: "pip --version"
   register: need_pip
   failed_when: false
   changed_when: false
   check_mode: no
   tags:
     - facts
+  environment:
+    PATH: "{{ ansible_env.PATH }}:{{ bin_dir }}"
 
 - name: Bootstrap | Copy get-pip.py
   copy:
@@ -44,7 +53,7 @@
 - name: Bootstrap | Install pip launcher
   copy:
     src: runner
-    dest: /opt/bin/pip
+    dest: "{{ bin_dir }}/pip"
     mode: 0755
   when: need_pip.rc != 0
 
@@ -52,3 +61,5 @@
   pip:
     name: "{{ item }}"
   with_items: "{{pip_python_coreos_modules}}"
+  environment:
+    PATH: "{{ ansible_env.PATH }}:{{ bin_dir }}"


### PR DESCRIPTION
By default, /opt/bin is not in $PATH.

Fixes https://github.com/kubernetes-incubator/kubespray/issues/1409