### PR TITLE
Add ALL_PROXY env docker systemcd drop-in for using socks4/socks5 proxy

### DIFF
--- a/docs/vars.md
+++ b/docs/vars.md
@@ -103,7 +103,7 @@ Stack](https://github.com/kubernetes-incubator/kubespray/blob/master/docs/dns-st
 
 * *docker_options* - Commonly used to set
   ``--insecure-registry=myregistry.mydomain:5000``
-* *http_proxy/https_proxy/no_proxy* - Proxy variables for deploying behind a
+* *http_proxy/https_proxy/no_proxy/all_proxy* - Proxy variables for deploying behind a
   proxy. Note that no_proxy defaults to all internal cluster IPs and hostnames
   that correspond to each node.
 * *kubelet_deployment_type* - Controls which platform to deploy kubelet on.

--- a/roles/docker/tasks/systemd.yml
+++ b/roles/docker/tasks/systemd.yml
@@ -9,7 +9,7 @@
     src: http-proxy.conf.j2
     dest: /etc/systemd/system/docker.service.d/http-proxy.conf
   notify: restart docker
-  when: http_proxy is defined or https_proxy is defined
+  when: http_proxy is defined or https_proxy is defined or all_proxy is defined
 
 - name: get systemd version
   shell: systemctl --version | head -n 1 | cut -d " " -f 2

--- a/roles/docker/templates/http-proxy.conf.j2
+++ b/roles/docker/templates/http-proxy.conf.j2
@@ -1,2 +1,2 @@
 [Service]
-Environment={% if http_proxy is defined %}"HTTP_PROXY={{ http_proxy }}"{% endif %} {% if https_proxy is defined %}"HTTPS_PROXY={{ https_proxy }}"{% endif %} {% if no_proxy is defined %}"NO_PROXY={{ no_proxy }}"{% endif %}
+Environment={% if http_proxy is defined %}"HTTP_PROXY={{ http_proxy }}"{% endif %} {% if https_proxy is defined %}"HTTPS_PROXY={{ https_proxy }}"{% endif %} {% if all_proxy is defined %}"ALL_PROXY={{ all_proxy }}"{% endif %} {% if no_proxy is defined %}"NO_PROXY={{ no_proxy }}"{% endif %}


### PR DESCRIPTION
Add ALL_PROXY env for docker drop-in systemd so we can use socks5/socks4 proxys.
`"ALL_PROXY=socks5://127.0.0.1:1080"`
