### PR TITLE
ingress-nginx default: should encourage TLSv1.1+

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s-cluster.yml
@@ -203,7 +203,7 @@ ingress_nginx_enabled: false
 # ingress_nginx_secure_port: 443
 # ingress_nginx_configmap:
 #   map-hash-bucket-size: "128"
-#   ssl-protocols: "SSLv2"
+#   ssl-protocols: "TLSv1.1 TLSv1.2 SSLv2"
 # ingress_nginx_configmap_tcp_services:
 #   9000: "default/example-go:8080"
 # ingress_nginx_configmap_udp_services:


### PR DESCRIPTION
Default is SSLv2 - numerous exploits in the wild for SSLv3. A trivial PR, I know the purpose isn't to configure clusters for people, but I think we should at least encourage adoption of TLSv1.1+, in the best interests of people that wouldn't otherwise be aware.

PCI compliance will soon mandate a minimum of TLSv1.1 and prefer TLSv1.2 (c.f [https://blog.pcisecuritystandards.org/are-you-ready-for-30-june-2018-sayin-goodbye-to-ssl-early-tls](https://blog.pcisecuritystandards.org/are-you-ready-for-30-june-2018-sayin-goodbye-to-ssl-early-tls))

Cheers