### PR TITLE
Use 'items()' for python compatibility

### DIFF
--- a/roles/etcd/templates/etcd.env.j2
+++ b/roles/etcd/templates/etcd.env.j2
@@ -28,6 +28,6 @@ ETCD_PEER_CERT_FILE={{ etcd_cert_dir }}/member-{{ inventory_hostname }}.pem
 ETCD_PEER_KEY_FILE={{ etcd_cert_dir }}/member-{{ inventory_hostname }}-key.pem
 ETCD_PEER_CLIENT_CERT_AUTH={{ etcd_peer_client_auth }}
 
-{% for key, value in etcd_extra_vars.iteritems() %}
+{% for key, value in etcd_extra_vars.items() %}
 {{ key }}={{ value }}
 {% endfor %}


### PR DESCRIPTION
When Ansible runs on python 3.x, raises an error when compile template.

Fix to use `items()` rather than `iteritems()`