### PR TITLE
Remove {{}} which causes warnings from when statements

### DIFF
--- a/roles/bootstrap-os/tasks/bootstrap-ubuntu.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-ubuntu.yml
@@ -19,7 +19,7 @@
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y python-minimal python-pip dbus
   when:
-    "{{ need_bootstrap.results | map(attribute='rc') | sort | last | bool }}"
+    need_bootstrap.results | map(attribute='rc') | sort | last | bool
 
 - set_fact:
     ansible_python_interpreter: "/usr/bin/python"


### PR DESCRIPTION
This corrects a situation where use of the jinja templating syntax in when statements causes a warning to be thrown:

    [WARNING]: when statements should not include jinja2 templating delimiters
    such as {{ }} or {% %}. Found: {{ need_bootstrap.results | map(attribute='rc')
    | sort | last | bool }}

**Is this a BUG REPORT or FEATURE REQUEST?** (choose one):
BUG REPORT

**Environment**:
- Vagrant

- Observed on OSX as host using defaults (Ubuntu as target)

- Ansible version (installed from devel head, though this issue should present back a number of versions):

    ansible 2.6.0
      config file = /Users/bschlueter/workspace/kubespray/ansible.cfg
      configured module search path = ['/Users/bschlueter/workspace/kubespray/library']
      ansible python module location = /Users/bschlueter/.config/zsh/pyenv/versions/3.6.4/lib/python3.6/site-packages/ansible
      executable location = /Users/bschlueter/.config/zsh/pyenv/versions/3.6.4/bin/ansible
      python version = 3.6.4 (default, Feb 15 2018, 12:21:02) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]


**Kubespray version (commit) (`git rev-parse --short HEAD`):**
595e96eb

**Network plugin used**:
Vagrant default


**Copy of your inventory file:**
Vagrant default


**Command used to invoke ansible**:
`vagrant up`


**Output of ansible run**:
The relevant bits are:

    TASK [bootstrap-os : Bootstrap | Install python 2.x and pip] *******************
    Thursday 03 May 2018  14:18:45 +0200 (0:00:00.431)       0:00:01.271 **********
     [WARNING]: when statements should not include jinja2 templating delimiters
    such as {{ }} or {% %}. Found: {{ need_bootstrap.results | map(attribute='rc')
    | sort | last | bool }}