### PR TITLE
Update kube-scheduler policy

### DIFF
--- a/roles/kubernetes/master/templates/kube-scheduler-policy.yaml.j2
+++ b/roles/kubernetes/master/templates/kube-scheduler-policy.yaml.j2
@@ -2,17 +2,27 @@
 "kind" : "Policy",
 "apiVersion" : "v1",
 "predicates" : [
-    {"name" : "PodFitsHostPorts"},
-    {"name" : "PodFitsResources"},
+    {"name" : "MaxEBSVolumeCount"},
+    {"name" : "MaxGCEPDVolumeCount"},
+    {"name" : "MaxAzureDiskVolumeCount"},
+    {"name" : "MatchInterPodAffinity"},
     {"name" : "NoDiskConflict"},
-    {"name" : "MatchNodeSelector"},
-    {"name" : "HostName"}
+    {"name" : "GeneralPredicates"},
+    {"name" : "CheckNodeMemoryPressure"},
+    {"name" : "CheckNodeDiskPressure"},
+    {"name" : "CheckNodePIDPressure"},
+    {"name" : "CheckNodeCondition"},
+    {"name" : "PodToleratesNodeTaints"},
+    {"name" : "CheckVolumeBinding"}
     ],
 "priorities" : [
+    {"name" : "SelectorSpreadPriority", "weight" : 1},
+    {"name" : "InterPodAffinityPriority", "weight" : 1},
     {"name" : "LeastRequestedPriority", "weight" : 1},
     {"name" : "BalancedResourceAllocation", "weight" : 1},
-    {"name" : "ServiceSpreadingPriority", "weight" : 1},
-    {"name" : "EqualPriority", "weight" : 1}
+    {"name" : "NodePreferAvoidPodsPriority", "weight" : 1},
+    {"name" : "NodeAffinityPriority", "weight" : 1},
+    {"name" : "TaintTolerationPriority", "weight" : 1}
     ],
 "hardPodAffinitySymmetricWeight" : 10
 }


### PR DESCRIPTION
When `volume_cross_zone_attachment: true` the kube-scheduler policy file is specified to remove the `NoVolumeZoneConflict` predicate. The policy file provided by kubespray is outdated and is missing support for Taints for instance. This PR catches-up with the defaults.

The updated policy is based off
- [TestDefaultPredicates()](https://github.com/kubernetes/kubernetes/blob/30e811c97c6820132f6b9128bc472878ab679800/pkg/scheduler/algorithmprovider/defaults/defaults_test.go#L68)
- [TestDefaultPriorities()](https://github.com/kubernetes/kubernetes/blob/30e811c97c6820132f6b9128bc472878ab679800/pkg/scheduler/algorithmprovider/defaults/defaults_test.go#L54)

I only removed `CheckNodePIDPressure` which is added in v1.10 and kubespray is v1.9.5 currently