### PR TITLE
tiny spacing change "can be"

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ Deploy a Production Ready Kubernetes Cluster
 
 If you have questions, join us on the [kubernetes slack](https://kubernetes.slack.com), channel **\#kubespray**.
 
--   Can be deployed on **AWS, GCE, Azure, OpenStack, vSphere or Baremetal**
--   **High available** cluster
--   **Composable** (Choice of the network plugin for instance)
--   Support most popular **Linux distributions**
--   **Continuous integration tests**
+- Can be deployed on **AWS, GCE, Azure, OpenStack, vSphere or Baremetal**
+- **High available** cluster
+- **Composable** (Choice of the network plugin for instance)
+- Support most popular **Linux distributions**
+- **Continuous integration tests**
 
 Quick Start
 -----------


### PR DESCRIPTION
tiny change under "Deploy a Production Ready Kubernetes Cluster" just fixed the spacing on the word "Can" in the first bullet.