### PR TITLE
opensuse: Fix OpenSSL package name

### DIFF
--- a/roles/kubernetes/preinstall/defaults/main.yml
+++ b/roles/kubernetes/preinstall/defaults/main.yml
@@ -8,7 +8,7 @@ epel_enabled: false
 
 common_required_pkgs:
   - python-httplib2
-  - "{{ (ansible_distribution == 'openSUSE Tumbleweed') | ternary('openssl-1_1_0', 'openssl') }}"
+  - "{{ (ansible_distribution == 'openSUSE Tumbleweed') | ternary('openssl-1_1', 'openssl') }}"
   - curl
   - rsync
   - bash-completion


### PR DESCRIPTION
OpenSSL 1.1 package in openSUSE Tumbleweed is named openssl-1_1,
not openssl-1_1_0.