### PR TITLE
Update possible bootstrap_os options

### DIFF
--- a/inventory/sample/group_vars/all.yml
+++ b/inventory/sample/group_vars/all.yml
@@ -1,4 +1,4 @@
-# Valid bootstrap options (required): ubuntu, coreos, centos, none
+# Valid bootstrap options (required): debian, opensuse, ubuntu, coreos, centos, none
 bootstrap_os: none
 
 #Directory where etcd data stored


### PR DESCRIPTION
According to roles/bootstrap-os/tasks/main.yml debian, and opensuse are also possible values for bootstrap_os.