### PR TITLE
Clarify ingress section in the hosts.ini

### DIFF
--- a/inventory/sample/hosts.ini
+++ b/inventory/sample/hosts.ini
@@ -26,6 +26,7 @@
 # node5
 # node6
 
+# only node hosts can be used here, masters not allowed!
 # [kube-ingress]
 # node2
 # node3


### PR DESCRIPTION
Because of the DaemonSet behind the scenes, only node hosts allowed as ingress controllers.