### PR TITLE
Fix issue #2702: 'docker_bin_dir' is undefined when running ansible-playbook remove-node.yml

### DIFF
--- a/remove-node.yml
+++ b/remove-node.yml
@@ -18,7 +18,6 @@
 
 - hosts: kube-master
   roles:
-    - { role: kubespray-defaults }
     - { role: remove-node/pre-remove, tags: pre-remove }
 
 - hosts: kube-node
@@ -28,5 +27,4 @@
 
 - hosts: kube-master
   roles:
-    - { role: kubespray-defaults }
     - { role: remove-node/post-remove, tags: post-remove }

--- a/remove-node.yml
+++ b/remove-node.yml
@@ -18,12 +18,15 @@
 
 - hosts: kube-master
   roles:
+    - { role: kubespray-defaults }
     - { role: remove-node/pre-remove, tags: pre-remove }
 
 - hosts: kube-node
   roles:
+    - { role: kubespray-defaults }
     - { role: reset, tags: reset }
 
 - hosts: kube-master
   roles:
+    - { role: kubespray-defaults }
     - { role: remove-node/post-remove, tags: post-remove }


### PR DESCRIPTION
Added `- { role: kubespray-defaults }` to make it work.