### PR TITLE
Fix privilege escalation timeout for remove-node playbook

### DIFF
--- a/remove-node.yml
+++ b/remove-node.yml
@@ -1,6 +1,8 @@
 ---
 
 - hosts: all
+  vars:
+    ansible_ssh_pipelining: true
   gather_facts: true
 
 - hosts: etcd:k8s-cluster:vault:calico-rr


### PR DESCRIPTION
Facing https://github.com/ansible/ansible/issues/14426 issue on `gather_facts` when running `remove-node` playbook. Forcing `ansible_ssh_pipelining` to true on this fixes the issue.