### PR TITLE
Allow to set kube_api_anonymous_auth to false

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s-cluster.yml
@@ -108,6 +108,7 @@ kube_apiserver_ip: "{{ kube_service_addresses|ipaddr('net')|ipaddr(1)|ipaddr('ad
 kube_apiserver_port: 6443 # (https)
 kube_apiserver_insecure_port: 8080 # (http)
 # Set to 0 to disable insecure port - Requires RBAC in authorization_modes and kube_api_anonymous_auth: true
+# If you want to disable kube_api_anonymous_auth too, then you need to add Webhook to authorization_modes.
 #kube_apiserver_insecure_port: 0 # (disabled)
 
 # Kube-proxy proxyMode configuration.

--- a/roles/kubernetes/preinstall/tasks/verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/verify-settings.yml
@@ -84,9 +84,9 @@
   when: dashboard_enabled
   ignore_errors: "{{ ignore_assert_errors }}"
 
-- name: Stop if RBAC and anonymous-auth are not enabled when insecure port is disabled
+- name: Stop if RBAC and anonymous-auth are not enabled when insecure port is disabled and webook authentication is not added
   assert:
-    that: rbac_enabled and kube_api_anonymous_auth
+    that: rbac_enabled and kube_api_anonymous_auth and ['Webhook' not in authorization_modes]
   when: kube_apiserver_insecure_port == 0
   ignore_errors: "{{ ignore_assert_errors }}"
 

--- a/roles/kubernetes/preinstall/tasks/verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/verify-settings.yml
@@ -86,7 +86,7 @@
 
 - name: Stop if RBAC and anonymous-auth are not enabled when insecure port is disabled and webook authentication is not added
   assert:
-    that: rbac_enabled and kube_api_anonymous_auth and ['Webhook' not in authorization_modes]
+    that: rbac_enabled and ( kube_api_anonymous_auth == true or ( kube_api_anonymous_auth == false and ['Webhook' not in authorization_modes] ) )
   when: kube_apiserver_insecure_port == 0
   ignore_errors: "{{ ignore_assert_errors }}"
 


### PR DESCRIPTION
Allow to disable `kube_api_anonymous_auth` while also disabling `kube_apiserver_insecure_port`.

To allow this, you need to enable Webhook in `authorization_modes` and our verify settings must allow it too.

Configuration would be:

```
kube_api_anonymous_auth: false
kube_apiserver_insecure_port: 0
authorization_modes: ['Node', 'RBAC', 'Webhook']
```