### PR TITLE
Fix path for pip and python when already bootstrapped

### DIFF
--- a/roles/bootstrap-os/tasks/bootstrap-coreos.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-coreos.yml
@@ -12,7 +12,6 @@
     bin_dir: "/opt/bin"
   tags:
     - facts
-  when: need_bootstrap.rc != 0
 
 - name: Bootstrap | Run bootstrap.sh
   script: bootstrap.sh


### PR DESCRIPTION
#2725 introduced a bug if server is already bootstrapped, the path for pip and python is not set.