### PR TITLE
Restart scheduler when policy changes

### DIFF
--- a/roles/kubernetes/master/tasks/static-pod-setup.yml
+++ b/roles/kubernetes/master/tasks/static-pod-setup.yml
@@ -13,6 +13,7 @@
   template:
     src: kube-scheduler-policy.yaml.j2
     dest: "{{ kube_config_dir }}/kube-scheduler-policy.yaml"
+  notify: Master | Restart kube-scheduler
   tags:
     - kube-scheduler
 


### PR DESCRIPTION
When the scheduler policy file is changed, a restart of the scheduler pods is necessary to it to take effect.

Relates to #2346