### PR TITLE
make admin.conf -> .kube/config non-executable

### DIFF
--- a/roles/kubernetes/client/tasks/main.yml
+++ b/roles/kubernetes/client/tasks/main.yml
@@ -40,7 +40,7 @@
     src: "{{ kube_config_dir }}/admin.conf"
     dest: "/root/.kube/config"
     remote_src: yes
-    mode: "0700"
+    mode: "0600"
     backup: yes
 
 - name: Copy admin kubeconfig to ansible host

--- a/roles/kubernetes/master/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-setup.yml
@@ -128,7 +128,7 @@
     content: "{{ item.content | b64decode }}"
     owner: root
     group: root
-    mode: 0700
+    mode: 0600
   no_log: true
   register: copy_kubeadm_certs
   with_items: "{{ kubeadm_certs.results }}"


### PR DESCRIPTION
Almost certainly, the .kube/config file (YAML) should not be executable.