### PR TITLE
Bump kube-dns to 1.14.10

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -112,7 +112,7 @@ nginx_image_tag: 1.13
 dnsmasq_version: 2.78
 dnsmasq_image_repo: "andyshinn/dnsmasq"
 dnsmasq_image_tag: "{{ dnsmasq_version }}"
-kubedns_version: 1.14.8
+kubedns_version: 1.14.10
 kubedns_image_repo: "gcr.io/google_containers/k8s-dns-kube-dns-amd64"
 kubedns_image_tag: "{{ kubedns_version }}"
 coredns_version: 1.1.2

--- a/roles/kubernetes-apps/ansible/defaults/main.yml
+++ b/roles/kubernetes-apps/ansible/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # Versions
-kubedns_version: 1.14.8
+kubedns_version: 1.14.10
 kubednsautoscaler_version: 1.1.2
 
 # Limits for dnsmasq/kubedns apps


### PR DESCRIPTION
Upgrade kube-dns to 1.14.10
https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/dns