### PR TITLE
Fix typo in included tasks file name in etcd role when etcd-events is enabled

### DIFF
--- a/roles/etcd/tasks/configure.yml
+++ b/roles/etcd/tasks/configure.yml
@@ -59,7 +59,7 @@
   when: inventory_hostname == item and etcd_member_in_cluster.rc != 0 and etcd_cluster_is_healthy.rc == 0
 
 - name: Configure | Join member(s) to etcd-events cluster one at a time
-  include_tasks: join_etcd-evetns_member.yml
+  include_tasks: join_etcd-events_member.yml
   vars:
     target_node: "{{ item }}"
   loop_control:


### PR DESCRIPTION
Just a typo in front of which I passed