### PR TITLE
vault is unavailabe when no bootstrap certs have been generated

### DIFF
--- a/roles/vault/tasks/shared/check_etcd.yml
+++ b/roles/vault/tasks/shared/check_etcd.yml
@@ -1,12 +1,20 @@
 ---
+- name: check_etcd | Check if certificates are present
+  shell: ls -ld "{{ etcd_cert_dir }}/node-{{ inventory_hostname }}.pem"
+  register: cert_present
+  ignore_errors: yes
+
+- name: check_etcd | When etcd certs are missing, etcd cannot be available
+  set_fact:
+    vault_etcd_available: false
+  when: cert_present.rc != 0
 
 - name: check_etcd | Check if etcd is up and reachable
   uri:
-    url: "{{ vault_etcd_url }}/health"
+    url: "{{ vault_etcd_url.split(',')[0] }}/health"
     validate_certs: no
     client_cert: "{{ etcd_cert_dir }}/node-{{ inventory_hostname }}.pem"
     client_key: "{{ etcd_cert_dir }}/node-{{ inventory_hostname }}-key.pem"
-
     return_content: yes
   until: vault_etcd_health_check.status == 200 or vault_etcd_health_check.status == 401
   retries: 3
@@ -15,12 +23,16 @@
   run_once: true
   failed_when: false
   register: vault_etcd_health_check
+  when: cert_present.rc == 0
 
 - name: check_etcd | Set fact based off the etcd_health_check response
   set_fact:
     vault_etcd_available: "{{ vault_etcd_health_check.content  }}"
+  when: cert_present == 0
+
 - set_fact:
     vault_etcd_available: "{{ vault_etcd_available.health|d()|bool }}"
+  when: cert_present == 0
 
 - name: check_etcd | Fail if etcd is not available and needed
   fail:


### PR DESCRIPTION
In issue #2712, it has been noted that when the etcd_url is an array,
the call against etcd fails as a comma-separated string of URLs is not
an URL. The fix has been requested with pull request #2552.

In additioon to that issue, it has already been noted that the check for
etcd will not complete with either 200 or 401 when the certs to issue
the call against etcd with are not present (it then returns -1). When
boostrapping, it is possible to derive vault status from certificate
presence - if no certificates are present, etcd it will be unhealthy.

This check is lacking elegance, but will allow the play to proceed.