### PR TITLE
add posibility to expose kube-proxy metrics

### DIFF
--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -17,6 +17,9 @@ kube_resolv_conf: "/etc/resolv.conf"
 # Can be ipvs, iptables
 kube_proxy_mode: iptables
 
+# if you want kube-proxy metrics change this to node ip address (ansible_default_ipv4['address'])
+kube_proxy_metrics_bind_address: 127.0.0.1
+
 # If using the pure iptables proxy, SNAT everything. Note that it breaks any
 # policy engine.
 kube_proxy_masquerade_all: false

--- a/roles/kubernetes/node/templates/manifests/kube-proxy.manifest.j2
+++ b/roles/kubernetes/node/templates/manifests/kube-proxy.manifest.j2
@@ -43,6 +43,7 @@ spec:
     - --proxy-mode={{ kube_proxy_mode }}
     - --oom-score-adj=-998
     - --healthz-bind-address=127.0.0.1
+    - --metrics-bind-address={{ kube_proxy_metrics_bind_address }}
 {% if kube_proxy_masquerade_all and kube_proxy_mode == "iptables" %}
     - --masquerade-all
 {% elif kube_proxy_mode == 'ipvs' %}


### PR DESCRIPTION
If you want to get kube-proxy metrics you need to expose metrics on different ip (default is 127.0.0.1)

For metrics exposing add variable to group_vars/k8s-cluster.yml 
`kube_proxy_metrics_bind_address: {{ ansible_default_ipv4['address'] }}`

default value still is 127.0.0.1