### PR TITLE
add become to escalate privelegies when needed

### DIFF
--- a/roles/adduser/tasks/main.yml
+++ b/roles/adduser/tasks/main.yml
@@ -1,10 +1,12 @@
 ---
 - name: User | Create User Group
+  become: yes
   group:
     name: "{{user.group|default(user.name)}}"
     system: "{{user.system|default(omit)}}"
 
 - name: User | Create User
+  become: yes
   user:
     comment: "{{user.comment|default(omit)}}"
     createhome: "{{user.create_home|default(omit)}}"

--- a/roles/bootstrap-os/tasks/main.yml
+++ b/roles/bootstrap-os/tasks/main.yml
@@ -30,6 +30,7 @@
     filter: ansible_*
 
 - name: Assign inventory name to unconfigured hostnames (non-CoreOS and Tumbleweed)
+  become: yes
   hostname:
     name: "{{inventory_hostname}}"
   when:

--- a/roles/bootstrap-os/tasks/setup-pipelining.yml
+++ b/roles/bootstrap-os/tasks/setup-pipelining.yml
@@ -6,3 +6,4 @@
     regexp: '^\w+\s+requiretty'
     dest: /etc/sudoers
     state: absent
+  become: yes

--- a/roles/docker/handlers/main.yml
+++ b/roles/docker/handlers/main.yml
@@ -9,6 +9,7 @@
     - Docker | wait for docker
 
 - name: Docker | reload systemd
+  become: yes
   shell: systemctl daemon-reload
 
 - name: Docker | reload docker.socket
@@ -18,6 +19,7 @@
   when: ansible_os_family in ['CoreOS', 'Container Linux by CoreOS']
 
 - name: Docker | reload docker
+  become: yes
   service:
     name: docker
     state: restarted
@@ -28,6 +30,7 @@
     prompt: "Waiting for docker restart"
 
 - name: Docker | wait for docker
+  become: yes
   command: "{{ docker_bin_dir }}/docker images"
   register: docker_ready
   retries: 10

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -83,12 +83,14 @@
   when: not (ansible_os_family in ["CoreOS", "Container Linux by CoreOS", "RedHat", "Suse"] or is_atomic) and (dockerproject_repo_info.repos|length > 0)
 
 - name: Configure docker repository on RedHat/CentOS
+  become: yes
   template:
     src: "rh_docker.repo.j2"
     dest: "{{ yum_repo_dir }}/docker.repo"
   when: ansible_distribution in ["CentOS","RedHat"] and not is_atomic
 
 - name: Copy yum.conf for editing
+  become: yes
   copy:
     src: "{{ yum_conf }}"
     dest: "{{ docker_yum_conf }}"
@@ -96,6 +98,7 @@
   when: ansible_distribution in ["CentOS","RedHat"] and not is_atomic
 
 - name: Edit copy of yum.conf to set obsoletes=0
+  become: yes
   lineinfile:
     path: "{{ docker_yum_conf }}"
     state: present
@@ -104,6 +107,7 @@
   when: ansible_distribution in ["CentOS","RedHat"] and not is_atomic
 
 - name: ensure docker packages are installed
+  become: yes
   action: "{{ docker_package_info.pkg_mgr }}"
   args:
     pkg: "{{item.name}}"
@@ -119,6 +123,7 @@
   when: not (ansible_os_family in ["CoreOS", "Container Linux by CoreOS"] or is_atomic) and (docker_package_info.pkgs|length > 0)
 
 - name: ensure service is started if docker packages are already present
+  become: yes
   service:
     name: docker
     state: started
@@ -128,6 +133,7 @@
   meta: flush_handlers
 
 - name: set fact for docker_version
+  become: yes
   command: "docker version -f '{{ '{{' }}.Client.Version{{ '}}' }}'"
   register: installed_docker_version
   changed_when: false
@@ -144,6 +150,7 @@
   import_tasks: systemd.yml
 
 - name: ensure docker service is started and enabled
+  become: yes
   service:
     name: "{{ item }}"
     enabled: yes

--- a/roles/docker/tasks/systemd.yml
+++ b/roles/docker/tasks/systemd.yml
@@ -1,5 +1,6 @@
 ---
 - name: Create docker service systemd directory if it doesn't exist
+  become: yes
   file:
     path: /etc/systemd/system/docker.service.d
     state: directory
@@ -18,6 +19,7 @@
   changed_when: false
 
 - name: Write docker.service systemd file
+  become: yes
   template:
     src: docker.service.j2
     dest: /etc/systemd/system/docker.service
@@ -26,12 +28,14 @@
   when: not (ansible_os_family in ["CoreOS", "Container Linux by CoreOS"] or is_atomic)
 
 - name: Write docker options systemd drop-in
+  become: yes
   template:
     src: docker-options.conf.j2
     dest: "/etc/systemd/system/docker.service.d/docker-options.conf"
   notify: restart docker
 
 - name: Write docker dns systemd drop-in
+  become: yes
   template:
     src: docker-dns.conf.j2
     dest: "/etc/systemd/system/docker.service.d/docker-dns.conf"

--- a/roles/download/tasks/download_container.yml
+++ b/roles/download/tasks/download_container.yml
@@ -28,6 +28,7 @@
   run_once: yes
 
 - name: container_download | Download containers if pull is required or told to always pull (all nodes)
+  become: yes
   command: "{{ docker_bin_dir }}/docker pull {{ pull_args }}"
   register: pull_task_result
   until: pull_task_result|succeeded

--- a/roles/etcd/tasks/check_certs.yml
+++ b/roles/etcd/tasks/check_certs.yml
@@ -15,6 +15,7 @@
     etcd_secret_changed: false
 
 - name: "Check certs | check if a cert already exists on node"
+  become: yes
   stat:
     path: "{{ etcd_cert_dir }}/{{ item }}"
   register: etcdcert_node

--- a/roles/etcd/tasks/gen_certs_script.yml
+++ b/roles/etcd/tasks/gen_certs_script.yml
@@ -1,5 +1,6 @@
 ---
 - name: Gen_certs | create etcd cert dir
+  become: yes
   file:
     path: "{{ etcd_cert_dir }}"
     group: "{{ etcd_cert_group }}"
@@ -9,6 +10,7 @@
     recurse: yes
 
 - name: "Gen_certs | create etcd script dir (on {{groups['etcd'][0]}})"
+  become: yes
   file:
     path: "{{ etcd_script_dir }}"
     state: directory
@@ -19,6 +21,7 @@
   delegate_to: "{{groups['etcd'][0]}}"
 
 - name: "Gen_certs | create etcd cert dir (on {{groups['etcd'][0]}})"
+  become: yes
   file:
     path: "{{ etcd_cert_dir }}"
     group: "{{ etcd_cert_group }}"
@@ -31,6 +34,7 @@
   delegate_to: "{{groups['etcd'][0]}}"
 
 - name: Gen_certs | write openssl config
+  become: yes
   template:
     src: "openssl.conf.j2"
     dest: "{{ etcd_config_dir }}/openssl.conf"
@@ -41,6 +45,7 @@
     - inventory_hostname == groups['etcd'][0]
 
 - name: Gen_certs | copy certs generation script
+  become: yes
   copy:
     src: "make-ssl-etcd.sh"
     dest: "{{ etcd_script_dir }}/make-ssl-etcd.sh"
@@ -52,6 +57,7 @@
     - inventory_hostname == groups['etcd'][0]
 
 - name: Gen_certs | run cert generation script
+  become: yes
   command: "bash -x {{ etcd_script_dir }}/make-ssl-etcd.sh -f {{ etcd_config_dir }}/openssl.conf -d {{ etcd_cert_dir }}"
   environment:
     - MASTERS: "{% for m in groups['etcd'] %}
@@ -129,6 +135,7 @@
         inventory_hostname != groups['etcd'][0]
 
 - name: Gen_certs | Write master certs to tempfile
+  become: yes
   copy:
     content: "{{etcd_master_cert_data.stdout}}"
     dest: "{{cert_tempfile.stdout}}"
@@ -138,6 +145,7 @@
         inventory_hostname != groups['etcd'][0]
 
 - name: Gen_certs | Unpack certs on masters
+  become: yes
   shell: "base64 -d < {{ cert_tempfile.stdout }} | tar xz -C {{ etcd_cert_dir }}"
   no_log: true
   changed_when: false
@@ -147,6 +155,7 @@
   notify: set secret_changed
 
 - name: Gen_certs | Cleanup tempfile
+  become: yes
   file:
     path: "{{cert_tempfile.stdout}}"
     state: absent
@@ -162,6 +171,7 @@
         inventory_hostname not in groups['etcd']
 
 - name: Gen_certs | check certificate permissions
+  become: yes
   file:
     path: "{{ etcd_cert_dir }}"
     group: "{{ etcd_cert_group }}"

--- a/roles/etcd/tasks/upd_ca_trust.yml
+++ b/roles/etcd/tasks/upd_ca_trust.yml
@@ -15,6 +15,7 @@
     - facts
 
 - name: Gen_certs | add CA to trusted CA dir
+  become: yes
   copy:
     src: "{{ etcd_cert_dir }}/ca.pem"
     dest: "{{ ca_cert_path }}"

--- a/roles/kubernetes/preinstall/tasks/etchosts.yml
+++ b/roles/kubernetes/preinstall/tasks/etchosts.yml
@@ -1,5 +1,6 @@
 ---
 - name: Hosts | populate inventory into hosts file
+  become: yes
   blockinfile:
     dest: /etc/hosts
     block: |-
@@ -23,6 +24,7 @@
     - loadbalancer_apiserver.address is defined
 
 - name: Hosts | localhost ipv4 in hosts file
+  become: yes
   lineinfile:
     dest: /etc/hosts
     line: "127.0.0.1 localhost localhost.localdomain"
@@ -31,6 +33,7 @@
     backup: yes
 
 - name: Hosts | localhost ipv6 in hosts file
+  become: yes
   lineinfile:
     dest: /etc/hosts
     line: "::1 localhost6 localhost6.localdomain"

--- a/roles/kubernetes/preinstall/tasks/main.yml
+++ b/roles/kubernetes/preinstall/tasks/main.yml
@@ -46,6 +46,7 @@
     - facts
 
 - name: Create kubernetes directories
+  become: yes
   file:
     path: "{{ item }}"
     state: directory
@@ -78,6 +79,7 @@
     - facts
 
 - name: Create cni directories
+  become: yes
   file:
     path: "{{ item }}"
     state: directory
@@ -202,6 +204,7 @@
     - bootstrap-os
 
 - name: Install packages requirements
+  become: yes
   action:
     module: "{{ ansible_pkg_mgr }}"
     name: "{{ item }}"
@@ -223,6 +226,7 @@
   register: slc
 
 - name: Set selinux policy
+  become: yes
   selinux:
     policy: targeted
     state: "{{ preinstall_selinux_state }}"
@@ -262,6 +266,7 @@
     - bootstrap-os
 
 - name: Enable ip forwarding
+  become: yes
   sysctl:
     sysctl_file: "{{sysctl_file_path}}"
     name: net.ipv4.ip_forward

--- a/roles/kubernetes/preinstall/tasks/set_resolv_facts.yml
+++ b/roles/kubernetes/preinstall/tasks/set_resolv_facts.yml
@@ -60,6 +60,7 @@
   when: dhclient_stat.stat.exists
 
 - name: check if /etc/dhcp/dhclient.conf exists
+  become: yes
   stat:
     path: /etc/dhcp/dhclient.conf
   register: dhcp_dhclient_stat


### PR DESCRIPTION
Since it is often prohibited to access remote server with root user via ssh, then we need `become` to be able to escalate privileges.