### PR TITLE
Use relative paths for data_files in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,22 +21,22 @@ setup-hooks =
 
 [files]
 data_files =
-    /usr/share/kubespray/playbooks/ =
+    usr/share/kubespray/playbooks/ =
         cluster.yml
         upgrade-cluster.yml
         scale.yml
         reset.yml
         remove-node.yml
         extra_playbooks/upgrade-only-k8s.yml
-    /usr/share/kubespray/roles = roles/*
-    /usr/share/doc/kubespray/ =
+    usr/share/kubespray/roles = roles/*
+    usr/share/doc/kubespray/ =
         LICENSE
         README.md
-    /usr/share/doc/kubespray/inventory/ =
+    usr/share/doc/kubespray/inventory/ =
         inventory/sample/hosts.ini
-    /etc/kubespray/ =
+    etc/kubespray/ =
         ansible.cfg
-    /etc/kubespray/inventory/sample/group_vars/ =
+    etc/kubespray/inventory/sample/group_vars/ =
         inventory/sample/group_vars/all.yml
         inventory/sample/group_vars/k8s-cluster.yml
 


### PR DESCRIPTION
pip install doesn't work with absolute paths

Follows-up https://github.com/kubernetes-incubator/kubespray/pull/2170

Signed-off-by: Bogdan Dobrelya <bogdando@mail.ru>