### PR TITLE
Add support for custom manifests

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s-cluster.yml
@@ -248,3 +248,11 @@ persistent_volumes_enabled: false
 ## See https://github.com/kubernetes-incubator/kubespray/issues/2141
 ## Set this variable to true to get rid of this issue
 volume_cross_zone_attachment: false
+
+# custom_manifests:
+#  - apiVersion: v1
+#    kind: Namespace
+#    metadata:
+#     name: example
+#     labels:
+#       name: example

--- a/roles/kubernetes-apps/custom_manifests/defaults/main.yml
+++ b/roles/kubernetes-apps/custom_manifests/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+custom_manifests: []

--- a/roles/kubernetes-apps/custom_manifests/tasks/main.yml
+++ b/roles/kubernetes-apps/custom_manifests/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Custom | Create manifest
+  template:
+    src: "custom.yml.j2"
+    dest: "{{ kube_config_dir }}/custom.yml"
+  when: inventory_hostname == groups['kube-master'][0]
+
+- name: Custom | Apply manifest
+  kube:
+    name: "{{ item.item.name }}"
+    kubectl: "{{ bin_dir }}/kubectl"
+    filename: "{{ kube_config_dir }}/custom.yml"
+    state: "latest"
+  when: inventory_hostname == groups['kube-master'][0]

--- a/roles/kubernetes-apps/custom_manifests/templates/custom.yml.j2
+++ b/roles/kubernetes-apps/custom_manifests/templates/custom.yml.j2
@@ -1,0 +1,4 @@
+{{% for document in custom_manifests %}}
+---
+{{ document | to_yaml }}
+{{% endfor %}}

--- a/roles/kubernetes-apps/meta/main.yml
+++ b/roles/kubernetes-apps/meta/main.yml
@@ -35,3 +35,9 @@ dependencies:
     tags:
       - apps
       - persistent_volumes
+
+  - role: kubernetes-apps/custom_manifests
+    when: custom_manifests
+    tags:
+      - apps
+      - custom_manifests


### PR DESCRIPTION
This PR adds support for custom manifests to be injected at deploy time with kubespray.
It is useful if you want to initialize simple things like namespaces or configmaps etc... right after deploy time.