### PR TITLE
fix etcd ssl serts generation on cluster scale

### DIFF
--- a/roles/etcd/tasks/gen_certs_script.yml
+++ b/roles/etcd/tasks/gen_certs_script.yml
@@ -68,7 +68,6 @@
   delegate_to: "{{groups['etcd'][0]}}"
   when:
     - gen_certs|default(false)
-    - inventory_hostname == groups['etcd'][0]
   notify: set etcd_secret_changed
 
 - set_fact:

--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -6,7 +6,6 @@
     - facts
 
 - include_tasks: "gen_certs_{{ cert_management }}.yml"
-  when:
   tags:
     - etcd-secrets
 


### PR DESCRIPTION
On cluster scale ETCD ssl certs not created for new node. Bug in https://github.com/kubernetes-incubator/kubespray/pull/2577