### PR TITLE
contiv-etcd-init image as default instead hardcoded

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -105,6 +105,8 @@ contiv_image_repo: "contiv/netplugin"
 contiv_image_tag: "{{ contiv_version }}"
 contiv_auth_proxy_image_repo: "contiv/auth_proxy"
 contiv_auth_proxy_image_tag: "{{ contiv_version }}"
+contiv_etcd_init_image_repo: "ferest/etcd-initer"
+contiv_etcd_init_image_tag: latest
 cilium_image_repo: "docker.io/cilium/cilium"
 cilium_image_tag: "{{ cilium_version }}"
 nginx_image_repo: nginx
@@ -381,6 +383,14 @@ downloads:
     repo: "{{ contiv_auth_proxy_image_repo }}"
     tag: "{{ contiv_auth_proxy_image_tag }}"
     sha256: "{{ contiv_auth_proxy_digest_checksum|default(None) }}"
+    groups:
+      - k8s-cluster
+  contiv_etcd_init:
+    enabled: "{{ kube_network_plugin == 'contiv' }}"
+    container: true
+    repo: "{{ contiv_etcd_init_image_repo }}"
+    tag: "{{ contiv_etcd_init_image_tag }}"
+    sha256: "{{ contiv_etcd_init_digest_checksum|default(None) }}"
     groups:
       - k8s-cluster
   pod_infra:

--- a/roles/network_plugin/contiv/defaults/main.yml
+++ b/roles/network_plugin/contiv/defaults/main.yml
@@ -15,9 +15,6 @@ contiv_etcd_endpoints: |-
     contiv_etcd{{ loop.index }}=http://{{ hostvars[host]['ip'] | default(hostvars[host].ansible_default_ipv4['address']) }}:{{ contiv_etcd_peer_port }}{% if not loop.last %},{% endif %}
   {%- endfor %}
 
-contiv_etcd_init_image_repo: ferest/etcd-initer
-contiv_etcd_init_image_tag: latest
-
 # Parameters for Contiv api-proxy
 contiv_enable_api_proxy: true
 contiv_api_proxy_port: 10000

--- a/roles/network_plugin/contiv/defaults/main.yml
+++ b/roles/network_plugin/contiv/defaults/main.yml
@@ -15,6 +15,9 @@ contiv_etcd_endpoints: |-
     contiv_etcd{{ loop.index }}=http://{{ hostvars[host]['ip'] | default(hostvars[host].ansible_default_ipv4['address']) }}:{{ contiv_etcd_peer_port }}{% if not loop.last %},{% endif %}
   {%- endfor %}
 
+contiv_etcd_init_image_repo: ferest/etcd-initer
+contiv_etcd_init_image_tag: latest
+
 # Parameters for Contiv api-proxy
 contiv_enable_api_proxy: true
 contiv_api_proxy_port: 10000

--- a/roles/network_plugin/contiv/templates/contiv-etcd.yml.j2
+++ b/roles/network_plugin/contiv/templates/contiv-etcd.yml.j2
@@ -26,7 +26,7 @@ spec:
           effect: NoSchedule
       initContainers:
         - name: contiv-etcd-init
-          image: ferest/etcd-initer:latest
+          image: {{ contiv_etcd_init_image_repo }}:{{ contiv_etcd_init_image_tag }}
           imagePullPolicy: Always
           env:
             - name: ETCD_INIT_ARGSFILE


### PR DESCRIPTION
Introduces contiv_etcd_init_image_repo and contiv_etcd_init_image_tag variables in roles/network_plugin/contiv/defaults/main.yml so that one can override the variables