### PR TITLE
Dashboard in cluster info

### DIFF
--- a/roles/kubernetes-apps/ansible/templates/dashboard.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/dashboard.yml.j2
@@ -199,6 +199,7 @@ apiVersion: v1
 metadata:
   labels:
     k8s-app: kubernetes-dashboard
+    kubernetes.io/cluster-service: "true"
   name: kubernetes-dashboard
   namespace: kube-system
 spec:


### PR DESCRIPTION
With kubernetes 1.10 the redirection of api-server from /ui to full dashboard url exists no more.
Add dashboard url as part of `kubectl cluster-info` ouptut to avoid searching through doc each time you need to access dashboard (more than useful with short-live clusters)