### PR TITLE
Hotfix the formula for calculating the maximum possible number of hosts in a subnet

### DIFF
--- a/roles/kubernetes/preinstall/tasks/verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/verify-settings.yml
@@ -68,7 +68,7 @@
 # NOTICE: the check blatantly ignores the inet6-case
 - name: Guarantee that enough network address space is available for all pods
   assert:
-    that: "{{ kubelet_max_pods <= ((32 - kube_network_node_prefix) ** 2) - 2 }}"
+    that: "{{ kubelet_max_pods <= ( 2 ** (32 - kube_network_node_prefix)) - 2 }}"
     msg: "Do not schedule more pods on a node than inet addresses are available."
   ignore_errors: "{{ ignore_assert_errors }}"
   when:


### PR DESCRIPTION
**Calculating the maximum possible number of hosts in a subnet:**
To find the maximum number of hosts, look at the number of binary bits in the host number above. The easiest way to do this is to subtract the netmask length from 32 (number of bits in an IPv4 address). This gives you the number of host bits in the address. At that point...

Maximum Number of hosts = 2**(32 - netmask_length) - 2

The reason we subtract 2 above is because the all-ones and all-zeros host numbers are reserved. The all-zeros host number is the network number; the all-ones host number is the broadcast address.

Using the example subnet of 128.42.0.0/24 above, the number of hosts is...

Maximum Number of hosts = 2**(32 - 24) - 2 = 2048 - 2 = 2046

https://networkengineering.stackexchange.com/questions/7106/how-do-you-calculate-the-prefix-network-subnet-and-host-numbers