### PR TITLE
Changed /etc/systemd/system/docker.service.d/docker-options.conf file for successful parsing mount arguments

### DIFF
--- a/roles/docker/templates/docker-options.conf.j2
+++ b/roles/docker/templates/docker-options.conf.j2
@@ -1,6 +1,5 @@
 [Service]
-Environment="DOCKER_OPTS={{ docker_options | default('') }} \
---iptables=false"
+Environment="DOCKER_OPTS={{ docker_options | default('') }} --iptables=false"
 {% if docker_mount_flags is defined and docker_mount_flags != "" %}
 MountFlags={{ docker_mount_flags }}
 {% endif %}

--- a/roles/docker/templates/docker-options.conf.j2
+++ b/roles/docker/templates/docker-options.conf.j2
@@ -1,5 +1,5 @@
 [Service]
-Environment="DOCKER_OPTS={{ docker_options | default('') }} --iptables=false"
+Environment="DOCKER_OPTS={{ docker_options|default('') }} --iptables=false"
 {% if docker_mount_flags is defined and docker_mount_flags != "" %}
 MountFlags={{ docker_mount_flags }}
 {% endif %}


### PR DESCRIPTION
Changed /etc/systemd/system/docker.service.d/docker-options.conf file for successful parsing mount arguments.
Earlier you could saw in syslog this message:
'[/etc/systemd/system/docker.service.d/docker-options.conf:3] Failed to parse mount flag , ignoring.'