### PR TITLE
roles/kubernetes/client: kubeconfig template should use access_ip

### DIFF
--- a/roles/kubernetes/client/tasks/main.yml
+++ b/roles/kubernetes/client/tasks/main.yml
@@ -5,7 +5,7 @@
       {%- if loadbalancer_apiserver is defined and loadbalancer_apiserver.port is defined -%}
       https://{{ apiserver_loadbalancer_domain_name }}:{{ loadbalancer_apiserver.port|default(kube_apiserver_port) }}
       {%- else -%}
-      https://{{ kube_apiserver_address }}:{{ kube_apiserver_port }}
+      https://{{ kube_apiserver_access_address }}:{{ kube_apiserver_port }}
       {%- endif -%}
   tags:
     - facts


### PR DESCRIPTION
Hit this while provisioning kubernetes on OCIC, the kubeconfig template was using the incorrect variable for the server address when no loadbalancing is configured. The statements in [docs/ha-mode.md](https://github.com/kubernetes-incubator/kubespray/blob/master/docs/ha-mode.md) seem to reinforce the fact that this should be the `access_ip` rather than just the `ip` of the chosen master.

> By default, it only configures a non-HA endpoint, which points to the access_ip or IP address of the first server node in the kube-master group.

We were working around it by manually replacing the private address with the public ip for a known master.
