### PR TITLE
ensure there is pin priority for docker package to prevent upgrade of docker

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -118,6 +118,15 @@
   notify: restart docker
   when: not (ansible_os_family in ["CoreOS", "Container Linux by CoreOS"] or is_atomic) and (docker_package_info.pkgs|length > 0)
 
+# This is required to ensure any apt upgrade will not break kubernetes
+- name: Set docker pin priority to apt_preferences on Debian family
+  template:
+    src: "apt_preferences.d/debian_docker.j2"
+    dest: "/etc/apt/preferences.d/docker"
+    owner: "root"
+    mode: 0644
+  when: not (ansible_os_family in ["CoreOS", "Container Linux by CoreOS", "RedHat", "Suse"] or is_atomic)
+
 - name: ensure service is started if docker packages are already present
   service:
     name: docker

--- a/roles/docker/templates/apt_preferences.d/debian_docker.j2
+++ b/roles/docker/templates/apt_preferences.d/debian_docker.j2
@@ -1,0 +1,3 @@
+Package: docker-ce
+Pin: version {{ docker_version }}.*
+Pin-Priority: 1001


### PR DESCRIPTION
If I perform apt-get upgrade / dist-upgrade, etc. Without this pin version, docker will be upgraded and kubernetes will break (it happened in a real test).

Pin priority is required and should be maintained to ensure there is no break during normal upgrades.
