### PR TITLE
ingress-nginx: Default DaemonSet on master, with customizable options

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s-cluster.yml
@@ -208,6 +208,8 @@ cephfs_provisioner_enabled: false
 # Nginx ingress controller deployment
 ingress_nginx_enabled: false
 # ingress_nginx_host_network: false
+# ingress_nginx_nodeselector:
+#   node-role.kubernetes.io/master: "true"
 # ingress_nginx_namespace: "ingress-nginx"
 # ingress_nginx_insecure_port: 80
 # ingress_nginx_secure_port: 443

--- a/inventory/sample/hosts.ini
+++ b/inventory/sample/hosts.ini
@@ -26,11 +26,6 @@
 # node5
 # node6
 
-# [kube-ingress]
-# node2
-# node3
-
 # [k8s-cluster:children]
 # kube-master
 # kube-node
-# kube-ingress

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -564,7 +564,7 @@ downloads:
     tag: "{{ ingress_nginx_controller_image_tag }}"
     sha256: "{{ ingress_nginx_controller_digest_checksum|default(None) }}"
     groups:
-      - kube-ingress
+      - kube-node
   ingress_nginx_default_backend:
     enabled: "{{ ingress_nginx_enabled }}"
     container: true
@@ -572,7 +572,7 @@ downloads:
     tag: "{{ ingress_nginx_default_backend_image_tag }}"
     sha256: "{{ ingress_nginx_default_backend_digest_checksum|default(None) }}"
     groups:
-      - kube-ingress
+      - kube-node
   cert_manager_controller:
     enabled: "{{ cert_manager_enabled }}"
     container: true

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/defaults/main.yml
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
 ingress_nginx_namespace: "ingress-nginx"
 ingress_nginx_host_network: false
+ingress_nginx_nodeselector:
+  node-role.kubernetes.io/master: "true"
 ingress_nginx_insecure_port: 80
 ingress_nginx_secure_port: 443
 ingress_nginx_configmap: {}

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ingress-nginx-controller-ds.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ingress-nginx-controller-ds.yml.j2
@@ -27,8 +27,10 @@ spec:
 {% if ingress_nginx_host_network %}
       hostNetwork: true
 {% endif %}
+{% if ingress_nginx_nodeselector %}
       nodeSelector:
-        node-role.kubernetes.io/ingress: "true"
+        {{ ingress_nginx_nodeselector | to_nice_yaml }}
+{%- endif %}
       terminationGracePeriodSeconds: 60
       containers:
         - name: ingress-nginx-controller

--- a/roles/kubernetes/node/templates/kubelet.kubeadm.env.j2
+++ b/roles/kubernetes/node/templates/kubelet.kubeadm.env.j2
@@ -75,9 +75,6 @@ KUBELET_HOSTNAME="--hostname-override={{ kube_override_hostname }}"
 {% else %}
 {%   set dummy = role_node_labels.append('node-role.kubernetes.io/node=true') %}
 {% endif %}
-{% if inventory_hostname in groups['kube-ingress']|default([]) %}
-{%   set dummy = role_node_labels.append('node-role.kubernetes.io/ingress=true') %}
-{% endif %}
 {% set inventory_node_labels = [] %}
 {% if node_labels is defined %}
 {%   for labelname, labelvalue in node_labels.iteritems() %}

--- a/roles/kubernetes/node/templates/kubelet.standard.env.j2
+++ b/roles/kubernetes/node/templates/kubelet.standard.env.j2
@@ -91,9 +91,6 @@ KUBELET_HOSTNAME="--hostname-override={{ kube_override_hostname }}"
 {% else %}
 {%   set dummy = role_node_labels.append('node-role.kubernetes.io/node=true') %}
 {% endif %}
-{% if inventory_hostname in groups['kube-ingress']|default([]) %}
-{%   set dummy = role_node_labels.append('node-role.kubernetes.io/ingress=true') %}
-{% endif %}
 {% set inventory_node_labels = [] %}
 {% if node_labels is defined %}
 {%   for labelname, labelvalue in node_labels.iteritems() %}


### PR DESCRIPTION
This patch simplify ingress-nginx deployment by default deploy on master, with customizable options; on the other hand, remove the additional Ansible group "kube-ingress" and its k8s node label injection.

By changing `ingress_nginx_nodeselector` plus custom k8s node label, user could customize the DaemonSet deployment target.

If `ingress_nginx_nodeselector` is empty, will deploy DaemonSet on every k8s node.

Reference to https://kubernetes.io/docs/concepts/services-networking/ingress/#prerequisites: 
> GCE/Google Kubernetes Engine deploys an ingress controller on the master.

Similar to our istio deployment (https://github.com/kubernetes-incubator/kubespray/blob/master/roles/download/defaults/main.yml#L219), we also just simply download the image to "kube-master".

Also, without #2576, user may not easy to discover that they MUST define the additional Ansible group "kube-ingress" correctly else ingress-nginx will not functioning; with my daily experience, it is over complicated and over design, too.

Close #2576 