### PR TITLE
Improve Azure/Ubuntu support

### DIFF
--- a/roles/kubernetes/master/tasks/azure-kube-apiserver.yml
+++ b/roles/kubernetes/master/tasks/azure-kube-apiserver.yml
@@ -1,0 +1,25 @@
+---
+- name: Get hyperkube
+  copy:
+    remote_src: yes
+    src: "{{ bin_dir }}/kubectl"
+    dest: "{{ bin_dir }}/hyperkube"
+    mode: 0755
+
+- name: Create kube-api-server service
+  template:
+    src: kube-apiserver.service.j2
+    dest: /etc/systemd/system/kube-apiserver.service
+
+- name: Reload systemd units
+  command: systemctl daemon-reload
+
+- name: Restart kube-apiserver
+  service:
+    name: kube-apiserver
+    state: restarted
+    enabled: yes
+  notify: Master | Restart apiserver
+  tags:
+    - kube-apiserver
+

--- a/roles/kubernetes/master/tasks/static-pod-setup.yml
+++ b/roles/kubernetes/master/tasks/static-pod-setup.yml
@@ -1,12 +1,7 @@
 ---
-- name: Write kube-apiserver manifest
-  template:
-    src: manifests/kube-apiserver.manifest.j2
-    dest: "{{ kube_manifest_dir }}/kube-apiserver.manifest"
-  notify: Master | Restart apiserver
-  tags:
-    - kube-apiserver
-
+- import_tasks: azure-kube-apiserver.yml
+  when: cloud_provider is defined and cloud_provider == 'azure'
+  
 - meta: flush_handlers
 
 - name: Write kube-scheduler policy file

--- a/roles/kubernetes/master/tasks/static-pod-setup.yml
+++ b/roles/kubernetes/master/tasks/static-pod-setup.yml
@@ -1,6 +1,20 @@
 ---
+# This approach of deploying kube-apiserver as a service has only been tested
+# using Azure and Ubuntu 16.04 so far, but solves the issue where
+# kube-apiserver refuses to start up.
 - import_tasks: azure-kube-apiserver.yml
-  when: cloud_provider is defined and cloud_provider == 'azure'
+  when: cloud_provider is defined and cloud_provider == 'azure' and 
+        bootstrap_os is defined and bootstrap_os == 'ubuntu'
+
+- name: Write kube-apiserver manifest
+  template:
+    src: manifests/kube-apiserver.manifest.j2
+    dest: "{{ kube_manifest_dir }}/kube-apiserver.manifest"
+  notify: Master | Restart apiserver
+  tags:
+    - kube-apiserver
+  when: (cloud_provider is undefined or (cloud_provider is defined and cloud_provider != 'azure')) and 
+        (boostrap_os is undefined or (bootstrap_os is defined and bootstrap_os != 'ubuntu'))
   
 - meta: flush_handlers
 

--- a/roles/kubernetes/master/templates/kube-apiserver.service.j2
+++ b/roles/kubernetes/master/templates/kube-apiserver.service.j2
@@ -1,0 +1,117 @@
+[Unit]
+Description=Kubernetes API Server
+
+[Service]
+ExecStart={{ bin_dir }}/hyperkube \
+    apiserver \
+    --advertise-address={{ ip | default(ansible_default_ipv4.address) }} \
+    --etcd-servers={{ etcd_access_addresses }} \
+{%   if etcd_events_cluster_setup  %}
+    --etcd-servers-overrides=/events#{{ etcd_events_access_addresses }} \
+{% endif %}
+{%   if kube_version | version_compare('v1.9', '<')  %}
+    --etcd-quorum-read=true \
+{% endif %}
+    --etcd-cafile={{ etcd_cert_dir }}/ca.pem \
+    --etcd-certfile={{ etcd_cert_dir }}/node-{{ inventory_hostname }}.pem \
+    --etcd-keyfile={{ etcd_cert_dir }}/node-{{ inventory_hostname }}-key.pem \
+    --insecure-bind-address={{ kube_apiserver_insecure_bind_address }} \
+    --bind-address={{ kube_apiserver_bind_address }} \
+    --apiserver-count={{ kube_apiserver_count }} \
+{% if kube_version | version_compare('v1.9', '>=') %}
+    --endpoint-reconciler-type=lease \
+{% endif %}
+    --admission-control={{ kube_apiserver_admission_control | join(',') }} \
+    --service-cluster-ip-range={{ kube_service_addresses }} \
+    --service-node-port-range={{ kube_apiserver_node_port_range }} \
+    --client-ca-file={{ kube_cert_dir }}/ca.pem \
+    --profiling=false \
+    --repair-malformed-updates=false \
+    --kubelet-client-certificate={{ kube_cert_dir }}/node-{{ inventory_hostname }}.pem \
+    --kubelet-client-key={{ kube_cert_dir }}/node-{{ inventory_hostname }}-key.pem \
+    --service-account-lookup=true \
+    --kubelet-preferred-address-types={{ kubelet_preferred_address_types }} \
+{% if kube_basic_auth|default(true) %}
+    --basic-auth-file={{ kube_users_dir }}/known_users.csv \
+{% endif %}
+    --tls-cert-file={{ kube_cert_dir }}/apiserver.pem \
+    --tls-private-key-file={{ kube_cert_dir }}/apiserver-key.pem \
+{% if kube_token_auth|default(true) %}
+    --token-auth-file={{ kube_token_dir }}/known_tokens.csv \
+{% endif %}
+    --service-account-key-file={{ kube_cert_dir }}/service-account-key.pem \
+{% if kube_oidc_auth|default(false) and kube_oidc_url is defined and kube_oidc_client_id is defined %}
+    --oidc-issuer-url={{ kube_oidc_url }} \
+    --oidc-client-id={{ kube_oidc_client_id }} \
+{%   if kube_oidc_ca_file is defined %}
+    --oidc-ca-file={{ kube_oidc_ca_file }} \
+{%   endif %}
+{%   if kube_oidc_username_claim is defined %}
+    --oidc-username-claim={{ kube_oidc_username_claim }} \
+{%   endif %}
+{%   if kube_oidc_username_prefix is defined %}
+    "--oidc-username-prefix={{ kube_oidc_username_prefix }}" \
+{%   endif %}
+{%   if kube_oidc_groups_claim is defined %}
+    --oidc-groups-claim={{ kube_oidc_groups_claim }} \
+{%   endif %}
+{%   if kube_oidc_groups_prefix is defined %}
+    "--oidc-groups-prefix={{ kube_oidc_groups_prefix }}" \
+{%   endif %}
+{% endif %}
+    --secure-port={{ kube_apiserver_port }} \
+    --insecure-port={{ kube_apiserver_insecure_port }} \
+    --storage-backend={{ kube_apiserver_storage_backend }} \
+{% if kube_api_runtime_config is defined %}
+{%   for conf in kube_api_runtime_config %}
+    --runtime-config={{ conf }} \
+{%   endfor %}
+{% endif %}
+{% if enable_network_policy %}
+{%   if kube_version | version_compare('v1.8', '<')  %}
+    --runtime-config=extensions/v1beta1/networkpolicies=true \
+{%   endif %}
+{% endif %}
+    --v={{ kube_log_level }} \
+    --allow-privileged=true \
+{% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere"] %}
+    --cloud-provider={{ cloud_provider }} \
+    --cloud-config={{ kube_config_dir }}/cloud_config \
+{% elif cloud_provider is defined and cloud_provider == "aws" %}
+    --cloud-provider={{ cloud_provider }} \
+{% endif %}
+{% if kube_api_anonymous_auth is defined and kube_version | version_compare('v1.5', '>=')  %}
+    --anonymous-auth={{ kube_api_anonymous_auth }} \
+{% endif %}
+{% if authorization_modes %}
+    --authorization-mode={{ authorization_modes|join(',') }} \
+{% endif %}
+{% if kube_encrypt_secret_data %}
+    --experimental-encryption-provider-config={{ kube_config_dir }}/ssl/secrets_encryption.yaml \
+{% endif %}
+{% if kube_feature_gates %}
+    --feature-gates={{ kube_feature_gates|join(',') }} \
+{% endif %}
+{% if kube_version | version_compare('v1.9', '>=') %}
+    --requestheader-client-ca-file={{ kube_cert_dir }}/{{ kube_front_proxy_ca }} \
+{# FIXME(mattymo): Vault certs do not work with front-proxy-client #}
+{% if cert_management == "vault" %}
+    --requestheader-allowed-names= \
+{% else %}
+    --requestheader-allowed-names=front-proxy-client \
+{% endif %}
+    --requestheader-extra-headers-prefix=X-Remote-Extra- \
+    --requestheader-group-headers=X-Remote-Group \
+    --requestheader-username-headers=X-Remote-User \
+    --enable-aggregator-routing={{ kube_api_aggregator_routing }} \
+    --proxy-client-cert-file={{ kube_cert_dir }}/front-proxy-client.pem \
+    --proxy-client-key-file={{ kube_cert_dir }}/front-proxy-client-key.pem
+{% else %}
+    --proxy-client-cert-file={{ kube_cert_dir }}/apiserver.pem \
+    --proxy-client-key-file={{ kube_cert_dir }}/apiserver-key.pem
+{% endif %}
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+

--- a/roles/kubernetes/preinstall/tasks/verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/verify-settings.yml
@@ -17,13 +17,13 @@
 
 - name: Stop if unknown network plugin
   assert:
-    that: network_plugin in ['calico', 'canal', 'flannel', 'weave', 'cloud']
-  when: network_plugin is defined
+    that: kube_network_plugin in ['calico', 'canal', 'flannel', 'weave', 'cloud']
+  when: kube_network_plugin is defined
   ignore_errors: "{{ ignore_assert_errors }}"
 
 - name: Stop if incompatible network plugin and cloudprovider
   assert:
-    that: network_plugin != 'calico'
+    that: kube_network_plugin != 'calico'
     msg: "Azure and Calico are not compatible. See https://github.com/projectcalico/calicoctl/issues/949 for details."
   when: cloud_provider is defined and cloud_provider == 'azure'
   ignore_errors: "{{ ignore_assert_errors }}"


### PR DESCRIPTION
These commits:
1. fix #2800,
2. improve the Azure support slightly when using Ubuntu VMs by running the `kube-apiserver` as a `systemd` daemon as opposed to a Docker container (could be related to #2066),
3. update the Azure documentation relating to Azure app/service principal setup.