### PR TITLE
Vault installation on baremetal seems to be broken

### DIFF
--- a/roles/vault/tasks/shared/check_etcd.yml
+++ b/roles/vault/tasks/shared/check_etcd.yml
@@ -2,7 +2,7 @@
 
 - name: check_etcd | Check if etcd is up and reachable
   uri:
-    url: "{{ vault_etcd_url }}/health"
+    url: "{{ vault_etcd_url.split(',')[0] }}/health"
     validate_certs: no
     client_cert: "{{ etcd_cert_dir }}/node-{{ inventory_hostname }}.pem"
     client_key: "{{ etcd_cert_dir }}/node-{{ inventory_hostname }}-key.pem"

--- a/roles/vault/tasks/shared/create_role.yml
+++ b/roles/vault/tasks/shared/create_role.yml
@@ -16,6 +16,8 @@
             {%- else -%}
             {{ create_role_policy_rules | to_json + '\n' }}
             {%- endif -%}
+  delegate_to: "{{ groups.vault|first }}"
+  run_once: true
 
 - name: create_role | Create {{ create_role_name }} role in the {{ create_role_mount_path }} pki mount
   hashivault_write:
@@ -31,6 +33,8 @@
      {%- else -%}
      {{ create_role_options | to_json }}
      {%- endif -%}
+  delegate_to: "{{ groups.vault|first }}"
+  run_once: true
 
 ## Userpass based auth method
 

--- a/roles/vault/tasks/shared/issue_cert.yml
+++ b/roles/vault/tasks/shared/issue_cert.yml
@@ -69,6 +69,9 @@
     display_name: "{{ user_vault_creds.username }}"
   register: vault_client_token_request
   run_once: true
+  environment:
+    http_proxy: ""
+    https_proxy: ""
 
 - name: gen_certs_vault | Pull token from request
   set_fact:
@@ -87,6 +90,9 @@
       format: "{{ issue_cert_format | d('pem') }}"
       ip_sans: "{{ issue_cert_ip_sans | default([]) | join(',') }}"
   register: issue_cert_result
+  environment:
+    http_proxy: ""
+    https_proxy: ""
 
 - name: "issue_cert | Copy {{ issue_cert_path }} cert to all hosts"
   copy:


### PR DESCRIPTION
When deploying Kubernetes on baremetal **Vault installation is broken**.
This aim to fix this issue: [#2792](https://github.com/kubernetes-incubator/kubespray/issues/2792)

This fix do requests on the first vault node only and disable proxy environment vars for requesting vault API.

**Environment:**
**Cloud provider or hardware configuration:**
`Baremetal/VMWare - 3 VM`
**OS:**
```
Linux 4.9.0-6-amd64 x86_64
PRETTY_NAME="Debian GNU/Linux 9 (stretch)"
NAME="Debian GNU/Linux"
VERSION_ID="9"
VERSION="9 (stretch)"
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
```
**Ansible:**
`ansible 2.5.3`

