### PR TITLE
Fix #2261 by supporting Red Hat's limited PATH

### DIFF
--- a/roles/kubernetes/node/tasks/main.yml
+++ b/roles/kubernetes/node/tasks/main.yml
@@ -70,6 +70,8 @@
 
 - name: Verify if br_netfilter module exists
   shell: "modinfo br_netfilter"
+  environment:
+    PATH: "{{ ansible_env.PATH}}:/sbin"  # Make sure we can workaround RH's conservative path management
   register: modinfo_br_netfilter
   failed_when: modinfo_br_netfilter.rc not in [0, 1]
   changed_when: false


### PR DESCRIPTION
Red Hat has this theory that binaries in sbin are too dangerous to be on
the default path, but sometimes we need to use them.

RH7 has /sbin and /usr/sbin as symlinks, so that distinction is no longer important.

I'm adding it to the `PATH` instead of making the path to `modinfo`
absolute because I am worried about breaking support for other
distributions.