### PR TITLE
CoreDNS uses cluster_name instead of dns_domain

### DIFF
--- a/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
@@ -11,7 +11,7 @@ data:
     .:53 {
         errors
         health
-        kubernetes {{ cluster_name }} in-addr.arpa ip6.arpa {
+        kubernetes {{ dns_domain }} in-addr.arpa ip6.arpa {
           pods insecure
           upstream /etc/resolv.conf
           fallthrough in-addr.arpa ip6.arpa


### PR DESCRIPTION
If the clusters dns_domain is `cluster.local` and the cluster name is `example.com` services will not be properly resolved within the cluster as the config map generated used cluster_name and not dns_domain.