### PR TITLE
Fix the Python and pip version flag in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To deploy the cluster you can use :
 For Vagrant we need to install python dependencies for provisioning tasks.
 Check if Python and pip are installed:
 
-    python -v && pip -v
+    python -V && pip -V
 
 If this returns the version of the software, you're good to go. If not, download and install Python from here <https://www.python.org/downloads/source/>
 Install the necessary requirements


### PR DESCRIPTION
The README says to check if Python and pip are installed type:

```
python -v && pip -v
```

Lowercase `-v` is `--verbose`, uppercase `-V` is `--version`. The
command should be:

```
python -V && pip -V
```