### PR TITLE
Add token_ttl as a parameter of dashboard

### DIFF
--- a/roles/kubernetes-apps/ansible/defaults/main.yml
+++ b/roles/kubernetes-apps/ansible/defaults/main.yml
@@ -45,6 +45,7 @@ netchecker_server_memory_requests: 64M
 dashboard_enabled: true
 dashboard_image_repo: gcr.io/google_containers/kubernetes-dashboard-amd64
 dashboard_image_tag: v1.8.3
+dashboard_token_ttl: 900
 
 # Limits for dashboard
 dashboard_cpu_limit: 100m

--- a/roles/kubernetes-apps/ansible/templates/dashboard.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/dashboard.yml.j2
@@ -161,6 +161,7 @@ spec:
 {% else %}
           - --auto-generate-certificates
 {% endif %}
+          - --dashboard_token_ttl={{ dashboard_token_ttl }}
           - --authentication-mode=token{% if kube_basic_auth|default(false) %},basic{% endif %}
           # Uncomment the following line to manually specify Kubernetes API server Host
           # If not specified, Dashboard will attempt to auto discover the API server and connect


### PR DESCRIPTION
Add `token_ttl timeout` as a parameter for dashboard argument. Currently  the kubespray does not expose this parameter.
It would be nice if it possible to customize this arg per env. The default 15 minutes TTL is IMHO not enough for a dev env. 