### PR TITLE
Configure Openstack subnet CIDR block

### DIFF
--- a/contrib/terraform/openstack/kubespray.tf
+++ b/contrib/terraform/openstack/kubespray.tf
@@ -3,6 +3,7 @@ module "network" {
 
   external_net    = "${var.external_net}"
   network_name    = "${var.network_name}"
+  subnet_cidr     = "${var.subnet_cidr}"
   cluster_name    = "${var.cluster_name}"
   dns_nameservers = "${var.dns_nameservers}"
 }

--- a/contrib/terraform/openstack/modules/network/main.tf
+++ b/contrib/terraform/openstack/modules/network/main.tf
@@ -12,7 +12,7 @@ resource "openstack_networking_network_v2" "k8s" {
 resource "openstack_networking_subnet_v2" "k8s" {
   name            = "${var.cluster_name}-internal-network"
   network_id      = "${openstack_networking_network_v2.k8s.id}"
-  cidr            = "10.0.0.0/24"
+  cidr            = "${var.subnet_cidr}"
   ip_version      = 4
   dns_nameservers = "${var.dns_nameservers}"
 }

--- a/contrib/terraform/openstack/modules/network/variables.tf
+++ b/contrib/terraform/openstack/modules/network/variables.tf
@@ -7,3 +7,8 @@ variable "cluster_name" {}
 variable "dns_nameservers" {
   type = "list"
 }
+
+variable "subnet_cidr" {
+  type = "string"
+  default = "10.0.0.0/24"
+}

--- a/contrib/terraform/openstack/modules/network/variables.tf
+++ b/contrib/terraform/openstack/modules/network/variables.tf
@@ -8,7 +8,4 @@ variable "dns_nameservers" {
   type = "list"
 }
 
-variable "subnet_cidr" {
-  type = "string"
-  default = "10.0.0.0/24"
-}
+variable "subnet_cidr" {}

--- a/contrib/terraform/openstack/sample-inventory/cluster.tf
+++ b/contrib/terraform/openstack/sample-inventory/cluster.tf
@@ -41,5 +41,6 @@ number_of_k8s_nodes_no_floating_ip = 4
 # networking
 network_name = "<network>"
 external_net = "<UUID>"
+subnet_cidr = "<cidr>"
 floatingip_pool = "<pool>"
 

--- a/contrib/terraform/openstack/variables.tf
+++ b/contrib/terraform/openstack/variables.tf
@@ -97,6 +97,12 @@ variable "network_name" {
   default     = "internal"
 }
 
+variable "subnet_cidr" {
+  description = "Subnet CIDR block."
+  type = "string"
+  default = "10.0.0.0/24"
+}
+
 variable "dns_nameservers" {
   description = "An array of DNS name server names used by hosts in this subnet."
   type        = "list"


### PR DESCRIPTION
**Is this a BUG REPORT or FEATURE REQUEST?** (choose one):

> FEATURE REQUEST

**Environment**:
- **Cloud provider or hardware configuration:**

> Openstack Newton

- **OS (`printf "$(uname -srm)\n$(cat /etc/os-release)\n"`):**

> Centos7

- **Version of Ansible** (`ansible --version`):

> ansible 2.5.4
>   config file = None
>   configured module search path = ['/home/vagrant/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
>   ansible python module location = /usr/lib/python3.6/site-packages/ansible
>   executable location = /usr/bin/ansible
>   python version = 3.6.5 (default, Apr 10 2018, 17:08:37) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]

**Kubespray version (commit) (`git rev-parse --short HEAD`):**
27d6294

**Network plugin used**:
Flannel

**Copy of your inventory file:**
**Command used to invoke ansible**:
**Output of ansible run**:
**Anything else do we need to know**:

We have a desire to change the default subnet CIDR for the router created in Openstack.
https://github.com/kubernetes-incubator/kubespray/issues/2896