### PR TITLE
Only subdirectories in /var/lib/kubelet should be unmounted at reset time

### DIFF
--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -61,7 +61,7 @@
     - docker
 
 - name: reset | gather mounted kubelet dirs
-  shell: mount | grep /var/lib/kubelet | awk '{print $3}' | tac
+  shell: mount | grep /var/lib/kubelet/ | awk '{print $3}' | tac
   check_mode: no
   register: mounted_dirs
   tags:


### PR DESCRIPTION
If /var/lib/kubelet has initially its own partition, it should not be unmounted.