### PR TITLE
generate k8s certs bug

### DIFF
--- a/roles/kubernetes/secrets/tasks/check-certs.yml
+++ b/roles/kubernetes/secrets/tasks/check-certs.yml
@@ -33,14 +33,14 @@
        '{{ kube_cert_dir }}/front-proxy-client-key.pem',
        '{{ kube_cert_dir }}/service-account-key.pem',
        {% for host in groups['kube-master'] %}
-       '{{ kube_cert_dir }}/admin-{{ host }}.pem'
+       '{{ kube_cert_dir }}/admin-{{ host }}.pem',
        '{{ kube_cert_dir }}/admin-{{ host }}-key.pem'
        {% if not loop.last %}{{','}}{% endif %}
        {% endfor %},
        {% for host in groups['k8s-cluster'] %}
-       '{{ kube_cert_dir }}/node-{{ host }}.pem'
-       '{{ kube_cert_dir }}/node-{{ host }}-key.pem'
-       '{{ kube_cert_dir }}/kube-proxy-{{ host }}.pem'
+       '{{ kube_cert_dir }}/node-{{ host }}.pem',
+       '{{ kube_cert_dir }}/node-{{ host }}-key.pem',
+       '{{ kube_cert_dir }}/kube-proxy-{{ host }}.pem',
        '{{ kube_cert_dir }}/kube-proxy-{{ host }}-key.pem'
        {% if not loop.last %}{{','}}{% endif %}
        {% endfor %}]

--- a/roles/kubernetes/secrets/tasks/check-certs.yml
+++ b/roles/kubernetes/secrets/tasks/check-certs.yml
@@ -36,7 +36,7 @@
        '{{ kube_cert_dir }}/admin-{{ host }}.pem'
        '{{ kube_cert_dir }}/admin-{{ host }}-key.pem'
        {% if not loop.last %}{{','}}{% endif %}
-       {% endfor %}]
+       {% endfor %},
        {% for host in groups['k8s-cluster'] %}
        '{{ kube_cert_dir }}/node-{{ host }}.pem'
        '{{ kube_cert_dir }}/node-{{ host }}-key.pem'


### PR DESCRIPTION
Dear author,
     Maybe there is a bug about generation k8s certificates in role/kubernetes/secrets/tasks/check_certs.yml.
     The variable gen_certs equals true always since v2.1.2, so it always creates new certs. In face, it is necessary to create new certs only when certs not exists or changed.
     It is maybe your slip. We should modify bracket ']' to comma ',', and add some comma ',' in proper position.
     There are other bugs about generation certs in master branch, not in some old versions. For example, incomplete certificate verification, .... These bugs maybe have an impact on the final result, but this is another problem. If you need it, I can help to modify it.

Thanks.