### PR TITLE
[contrib/terraform/openstack] Change from Nova security groups to Neutron

### DIFF
--- a/contrib/terraform/openstack/README.md
+++ b/contrib/terraform/openstack/README.md
@@ -224,6 +224,7 @@ For your cluster, edit `inventory/$CLUSTER/cluster.tf`.
 | `gfs_volume_size_in_gb` | Size of the non-ephemeral volumes to be attached to store the GlusterFS bricks |
 |`supplementary_master_groups` | To add ansible groups to the masters, such as `kube-node` for tainting them as nodes, empty by default. |
 |`supplementary_node_groups` | To add ansible groups to the nodes, such as `kube-ingress` for running ingress controller pods, empty by default. |
+|`bastion_allowed_remote_ips` | List of CIDR allowed to initiate a SSH connection, `["0.0.0.0/0"]` by default |
 
 #### Terraform state files
 

--- a/contrib/terraform/openstack/kubespray.tf
+++ b/contrib/terraform/openstack/kubespray.tf
@@ -50,6 +50,7 @@ module "compute" {
   k8s_master_fips                              = "${module.ips.k8s_master_fips}"
   k8s_node_fips                                = "${module.ips.k8s_node_fips}"
   bastion_fips                                 = "${module.ips.bastion_fips}"
+  bastion_allowed_remote_ips                   = "${var.bastion_allowed_remote_ips}"
   supplementary_master_groups                  = "${var.supplementary_master_groups}"
   supplementary_node_groups                    = "${var.supplementary_node_groups}"
 

--- a/contrib/terraform/openstack/modules/compute/main.tf
+++ b/contrib/terraform/openstack/modules/compute/main.tf
@@ -3,72 +3,62 @@ resource "openstack_compute_keypair_v2" "k8s" {
   public_key = "${chomp(file(var.public_key_path))}"
 }
 
-resource "openstack_compute_secgroup_v2" "k8s_master" {
+resource "openstack_networking_secgroup_v2" "k8s_master" {
   name        = "${var.cluster_name}-k8s-master"
   description = "${var.cluster_name} - Kubernetes Master"
-
-  rule {
-    ip_protocol = "tcp"
-    from_port   = "6443"
-    to_port     = "6443"
-    cidr        = "0.0.0.0/0"
-  }
 }
 
-resource "openstack_compute_secgroup_v2" "bastion" {
+resource "openstack_networking_secgroup_rule_v2" "k8s_master" {
+  direction = "ingress"
+  ethertype = "IPv4"
+  protocol = "tcp"
+  port_range_min = "6443"
+  port_range_max = "6443"
+  remote_ip_prefix = "0.0.0.0/0"
+  security_group_id = "${openstack_networking_secgroup_v2.k8s_master.id}"
+}
+
+resource "openstack_networking_secgroup_v2" "bastion" {
   name        = "${var.cluster_name}-bastion"
   description = "${var.cluster_name} - Bastion Server"
-
-  rule {
-    ip_protocol = "tcp"
-    from_port   = "22"
-    to_port     = "22"
-    cidr        = "0.0.0.0/0"
-  }
 }
 
-resource "openstack_compute_secgroup_v2" "k8s" {
+resource "openstack_networking_secgroup_rule_v2" "bastion" {
+  count = "${length(var.bastion_allowed_remote_ips)}"
+  direction = "ingress"
+  ethertype = "IPv4"
+  protocol = "tcp"
+  port_range_min = "22"
+  port_range_max = "22"
+  remote_ip_prefix = "${var.bastion_allowed_remote_ips[count.index]}"
+  security_group_id = "${openstack_networking_secgroup_v2.bastion.id}"
+}
+
+resource "openstack_networking_secgroup_v2" "k8s" {
   name        = "${var.cluster_name}-k8s"
   description = "${var.cluster_name} - Kubernetes"
-
-  rule {
-    ip_protocol = "icmp"
-    from_port   = "-1"
-    to_port     = "-1"
-    cidr        = "0.0.0.0/0"
-  }
-
-  rule {
-    ip_protocol = "tcp"
-    from_port   = "1"
-    to_port     = "65535"
-    self        = true
-  }
-
-  rule {
-    ip_protocol = "udp"
-    from_port   = "1"
-    to_port     = "65535"
-    self        = true
-  }
-
-  rule {
-    ip_protocol = "icmp"
-    from_port   = "-1"
-    to_port     = "-1"
-    self        = true
-  }
 }
-resource "openstack_compute_secgroup_v2" "worker" {
+
+resource "openstack_networking_secgroup_rule_v2" "k8s" {
+  direction = "ingress"
+  ethertype = "IPv4"
+  remote_group_id = "${openstack_networking_secgroup_v2.k8s.id}"
+  security_group_id = "${openstack_networking_secgroup_v2.k8s.id}"
+}
+
+resource "openstack_networking_secgroup_v2" "worker" {
   name        = "${var.cluster_name}-k8s-worker"
   description = "${var.cluster_name} - Kubernetes worker nodes"
+}
 
-  rule {
-    ip_protocol = "tcp"
-    from_port   = "30000"
-    to_port     = "32767"
-    cidr        = "0.0.0.0/0"
-  }
+resource "openstack_networking_secgroup_rule_v2" "worker" {
+  direction = "ingress"
+  ethertype = "IPv4"
+  protocol = "tcp"
+  port_range_min = "30000"
+  port_range_max = "32767"
+  remote_ip_prefix = "0.0.0.0/0"
+  security_group_id = "${openstack_networking_secgroup_v2.worker.id}"
 }
 
 resource "openstack_compute_instance_v2" "bastion" {
@@ -82,8 +72,8 @@ resource "openstack_compute_instance_v2" "bastion" {
     name = "${var.network_name}"
   }
 
-  security_groups = ["${openstack_compute_secgroup_v2.k8s.name}",
-    "${openstack_compute_secgroup_v2.bastion.name}",
+  security_groups = ["${openstack_networking_secgroup_v2.k8s.name}",
+    "${openstack_networking_secgroup_v2.bastion.name}",
     "default",
   ]
 
@@ -111,9 +101,9 @@ resource "openstack_compute_instance_v2" "k8s_master" {
     name = "${var.network_name}"
   }
 
-  security_groups = ["${openstack_compute_secgroup_v2.k8s_master.name}",
-    "${openstack_compute_secgroup_v2.bastion.name}",
-    "${openstack_compute_secgroup_v2.k8s.name}",
+  security_groups = ["${openstack_networking_secgroup_v2.k8s_master.name}",
+    "${openstack_networking_secgroup_v2.bastion.name}",
+    "${openstack_networking_secgroup_v2.k8s.name}",
     "default",
   ]
 
@@ -141,9 +131,9 @@ resource "openstack_compute_instance_v2" "k8s_master_no_etcd" {
     name = "${var.network_name}"
   }
 
-  security_groups = ["${openstack_compute_secgroup_v2.k8s_master.name}",
-    "${openstack_compute_secgroup_v2.bastion.name}",
-    "${openstack_compute_secgroup_v2.k8s.name}",
+  security_groups = ["${openstack_networking_secgroup_v2.k8s_master.name}",
+    "${openstack_networking_secgroup_v2.bastion.name}",
+    "${openstack_networking_secgroup_v2.k8s.name}",
   ]
 
   metadata = {
@@ -170,7 +160,7 @@ resource "openstack_compute_instance_v2" "etcd" {
     name = "${var.network_name}"
   }
 
-  security_groups = ["${openstack_compute_secgroup_v2.k8s.name}"]
+  security_groups = ["${openstack_networking_secgroup_v2.k8s.name}"]
 
   metadata = {
     ssh_user         = "${var.ssh_user}"
@@ -192,8 +182,8 @@ resource "openstack_compute_instance_v2" "k8s_master_no_floating_ip" {
     name = "${var.network_name}"
   }
 
-  security_groups = ["${openstack_compute_secgroup_v2.k8s_master.name}",
-    "${openstack_compute_secgroup_v2.k8s.name}",
+  security_groups = ["${openstack_networking_secgroup_v2.k8s_master.name}",
+    "${openstack_networking_secgroup_v2.k8s.name}",
     "default",
   ]
 
@@ -217,8 +207,8 @@ resource "openstack_compute_instance_v2" "k8s_master_no_floating_ip_no_etcd" {
     name = "${var.network_name}"
   }
 
-  security_groups = ["${openstack_compute_secgroup_v2.k8s_master.name}",
-    "${openstack_compute_secgroup_v2.k8s.name}",
+  security_groups = ["${openstack_networking_secgroup_v2.k8s_master.name}",
+    "${openstack_networking_secgroup_v2.k8s.name}",
   ]
 
   metadata = {
@@ -241,9 +231,9 @@ resource "openstack_compute_instance_v2" "k8s_node" {
     name = "${var.network_name}"
   }
 
-  security_groups = ["${openstack_compute_secgroup_v2.k8s.name}",
-    "${openstack_compute_secgroup_v2.bastion.name}",
-    "${openstack_compute_secgroup_v2.worker.name}",
+  security_groups = ["${openstack_networking_secgroup_v2.k8s.name}",
+    "${openstack_networking_secgroup_v2.bastion.name}",
+    "${openstack_networking_secgroup_v2.worker.name}",
     "default",
   ]
 
@@ -271,8 +261,8 @@ resource "openstack_compute_instance_v2" "k8s_node_no_floating_ip" {
     name = "${var.network_name}"
   }
 
-  security_groups = ["${openstack_compute_secgroup_v2.k8s.name}",
-    "${openstack_compute_secgroup_v2.worker.name}",
+  security_groups = ["${openstack_networking_secgroup_v2.k8s.name}",
+    "${openstack_networking_secgroup_v2.worker.name}",
     "default",
   ]
 
@@ -321,7 +311,7 @@ resource "openstack_compute_instance_v2" "glusterfs_node_no_floating_ip" {
     name = "${var.network_name}"
   }
 
-  security_groups = ["${openstack_compute_secgroup_v2.k8s.name}",
+  security_groups = ["${openstack_networking_secgroup_v2.k8s.name}",
     "default",
   ]
 

--- a/contrib/terraform/openstack/modules/compute/variables.tf
+++ b/contrib/terraform/openstack/modules/compute/variables.tf
@@ -60,6 +60,10 @@ variable "bastion_fips" {
   type = "list"
 }
 
+variable "bastion_allowed_remote_ips" {
+  type = "list"
+}
+
 variable "supplementary_master_groups" {
   default = ""
 }

--- a/contrib/terraform/openstack/sample-inventory/cluster.tf
+++ b/contrib/terraform/openstack/sample-inventory/cluster.tf
@@ -43,4 +43,4 @@ network_name = "<network>"
 external_net = "<UUID>"
 subnet_cidr = "<cidr>"
 floatingip_pool = "<pool>"
-
+bastion_allowed_remote_ips = ["0.0.0.0/0"]

--- a/contrib/terraform/openstack/variables.tf
+++ b/contrib/terraform/openstack/variables.tf
@@ -133,3 +133,9 @@ variable "supplementary_node_groups" {
   description = "supplementary kubespray ansible groups for worker nodes, such as kube-ingress"
   default = ""
 }
+
+variable "bastion_allowed_remote_ips" {
+  description = "An array of CIDRs allowed to SSH to hosts"
+  type = "list"
+  default = ["0.0.0.0/0"]
+}


### PR DESCRIPTION
* Replace `openstack_compute_secgroup_v2` with `openstack_networking_secgroup_v2`

The `openstack_networking_secgroup_v2` resource allow specifications of
both ingress and egress. Nova security groups define ingress rules only.

This change will also allow for more user-friendly specified security
rules, as the different security group resources have different HCL
syntax.