### PR TITLE
pin priority for debian and force flag for kubeadm upgrade

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -118,6 +118,15 @@
   notify: restart docker
   when: not (ansible_os_family in ["CoreOS", "Container Linux by CoreOS"] or is_atomic) and (docker_package_info.pkgs|length > 0)
 
+# This is required to ensure any apt upgrade will not break kubernetes
+- name: Set docker pin priority to apt_preferences on Debian family
+  template:
+    src: "apt_preferences.d/debian_docker.j2"
+    dest: "/etc/apt/preferences.d/docker"
+    owner: "root"
+    mode: 0644
+  when: not (ansible_os_family in ["CoreOS", "Container Linux by CoreOS", "RedHat", "Suse"] or is_atomic)
+
 - name: ensure service is started if docker packages are already present
   service:
     name: docker

--- a/roles/docker/templates/apt_preferences.d/debian_docker.j2
+++ b/roles/docker/templates/apt_preferences.d/debian_docker.j2
@@ -1,0 +1,3 @@
+Package: docker-ce
+Pin: version {{ docker_version }}.*
+Pin-Priority: 1001

--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -6,7 +6,6 @@
     - facts
 
 - include_tasks: "gen_certs_{{ cert_management }}.yml"
-  when:
   tags:
     - etcd-secrets
 

--- a/roles/kubernetes/master/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-setup.yml
@@ -89,6 +89,7 @@
     --ignore-preflight-errors=all
     --allow-experimental-upgrades
     --allow-release-candidate-upgrades
+    --force
   register: kubeadm_upgrade
   # Retry is because upload config sometimes fails
   retries: 3


### PR DESCRIPTION
Pin priority is required, without it: any upgrade with apt could break k8s due to an upgrade of docker.

Also during upgrades of kubernetes with kubeadm (test from v1.10.3 to v1.10.4 and to v1.10.5) it failed on both tests, and I had to add `--force` flag.