### PR TITLE
fluentd daemonset & calico-node daemonset: Tolerate any taint with any effect.

### DIFF
--- a/roles/kubernetes-apps/efk/fluentd/templates/fluentd-ds.yml.j2
+++ b/roles/kubernetes-apps/efk/fluentd/templates/fluentd-ds.yml.j2
@@ -29,6 +29,8 @@ spec:
     spec:
       priorityClassName: system-node-critical
       serviceAccountName: efk
+      tolerations:
+        - operator: Exists
       containers:
       - name: fluentd-es
         image: "{{ fluentd_image_repo }}:{{ fluentd_image_tag }}"

--- a/roles/network_plugin/calico/templates/calico-node.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-node.yml.j2
@@ -24,8 +24,7 @@ spec:
       hostNetwork: true
       serviceAccountName: calico-node
       tolerations:
-        - effect: NoSchedule
-          operator: Exists
+        - operator: Exists
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 0


### PR DESCRIPTION
FEATURE

fluentd daemonset & calico-node daemonset: Tolerate any taint with any effect.
Allows to be scheduled on Node with taint with NoExecute effect.

Rationale: when a Node is tainted using NoExecute effect, fluentd and calico-node will be expurged from the Node. But those two Pods should always be on all Nodes.
