### PR TITLE
fix template index out of range for pull images

### DIFF
--- a/roles/download/tasks/set_docker_image_facts.yml
+++ b/roles/download/tasks/set_docker_image_facts.yml
@@ -9,7 +9,7 @@
 
 - name: Register docker images info
   raw: >-
-    {{ docker_bin_dir }}/docker images -q | xargs {{ docker_bin_dir }}/docker inspect -f "{{ '{{' }} (index .RepoTags 0) {{ '}}' }},{{ '{{' }} (index .RepoDigests 0) {{ '}}' }}" | tr '\n' ','
+    {{ docker_bin_dir }}/docker images -q | xargs {{ docker_bin_dir }}/docker inspect -f "{{ '{{' }} if .RepoTags {{ '}}' }}{{ '{{' }} (index .RepoTags 0) {{ '}}' }}{{ '{{' }} end {{ '}}' }}{{ '{{' }} if .RepoDigests {{ '}}' }},{{ '{{' }} (index .RepoDigests 0) {{ '}}' }}{{ '{{' }} end {{ '}}' }}" | tr '\n' ','
   no_log: true
   register: docker_images
   failed_when: false


### PR DESCRIPTION
This is a bug fix about template index out of range in role/download/tasks/set_docker_image_facts.yml.
When images are need to pulled, and image's RepoDigests is '[]' , (e.g. we copy docker-tar to local, and don't need or can't pull images from outer net, then RepoDigests in the images inspect maybe '[]' ), then {{ (index .RepoDigests 0 }} will be out of range. This causes that images are pulled always in the behind, no matter whether we set pull-Always or IfNotPresent.
So, we should add a check, e.g. {{ if .RepoDigest}}...{{ end }},   {{ if .RepoTags }}...{{ end }} 