### PR TITLE
fix the time of ca files are changed in make-ssl-etcd

### DIFF
--- a/roles/etcd/files/make-ssl-etcd.sh
+++ b/roles/etcd/files/make-ssl-etcd.sh
@@ -95,4 +95,9 @@ if [ -n "$HOSTS" ]; then
 fi
 
 # Install certs
+if [ -e "$SSLDIR/ca-key.pem" ]; then
+    # No pass existing CA
+    rm -f ca.pem ca-key.pem
+fi
+
 mv *.pem ${SSLDIR}/


### PR DESCRIPTION
Hi author,
The file time of ca.pem and ca-key.pem are always changed when running deployment every time, even if It does not produce new ca. 
Because mv *.pem $SSLDIR}/ contains ca.pem and ca-key.pem,  the time of ca.pem and ca-key.pem in /etc/ssl/etcd/ssl are always changed. This may have other effects.
When $SSLDIR/ca-key.pem exists, we should rm ca.pem and ca-key.pem before mv operation. 

Please review this bug fix and other bug fixes #2921 , #2918 , because I have no CI-auth.

Thanks!