### PR TITLE
No need to install rkt on CoreOS

### DIFF
--- a/roles/rkt/tasks/main.yml
+++ b/roles/rkt/tasks/main.yml
@@ -2,3 +2,4 @@
 
 - name: Install rkt
   import_tasks: install.yml
+  when: not ansible_os_family in ["CoreOS", "Container Linux by CoreOS"]


### PR DESCRIPTION
There is no need to install rkt on CoreOS it comes embedded in the distro.
So I'm simply skipping the role.