### PR TITLE
[contrib/terraform/openstack] Add nova availability zones

### DIFF
--- a/contrib/terraform/openstack/README.md
+++ b/contrib/terraform/openstack/README.md
@@ -219,6 +219,7 @@ For your cluster, edit `inventory/$CLUSTER/cluster.tf`.
 |`number_of_gfs_nodes_no_floating_ip` | Number of gluster servers to provision. |
 | `gfs_volume_size_in_gb` | Size of the non-ephemeral volumes to be attached to store the GlusterFS bricks |
 |`supplementary_master_groups` | To add ansible groups to the masters, such as `kube-node` for tainting them as nodes, empty by default. |
+|`availability_zones` | List of availability zones we want to deploy in. `["nova"]` by default. |
 
 #### Terraform state files
 

--- a/contrib/terraform/openstack/kubespray.tf
+++ b/contrib/terraform/openstack/kubespray.tf
@@ -49,6 +49,7 @@ module "compute" {
   k8s_node_fips                                = "${module.ips.k8s_node_fips}"
   bastion_fips                                 = "${module.ips.bastion_fips}"
   supplementary_master_groups                  = "${var.supplementary_master_groups}"
+  availability_zones                           = "${var.availability_zones}"
 
   network_id = "${module.network.router_id}"
 }

--- a/contrib/terraform/openstack/modules/compute/main.tf
+++ b/contrib/terraform/openstack/modules/compute/main.tf
@@ -66,6 +66,7 @@ resource "openstack_compute_instance_v2" "bastion" {
   image_name = "${var.image}"
   flavor_id  = "${var.flavor_bastion}"
   key_pair   = "${openstack_compute_keypair_v2.k8s.name}"
+  availability_zone = "${var.availability_zones[count.index % length(var.availability_zones)]}"
 
   network {
     name = "${var.network_name}"
@@ -94,6 +95,7 @@ resource "openstack_compute_instance_v2" "k8s_master" {
   image_name = "${var.image}"
   flavor_id  = "${var.flavor_k8s_master}"
   key_pair   = "${openstack_compute_keypair_v2.k8s.name}"
+  availability_zone = "${var.availability_zones[count.index % length(var.availability_zones)]}"
 
   network {
     name = "${var.network_name}"
@@ -123,6 +125,7 @@ resource "openstack_compute_instance_v2" "k8s_master_no_etcd" {
   image_name = "${var.image}"
   flavor_id  = "${var.flavor_k8s_master}"
   key_pair   = "${openstack_compute_keypair_v2.k8s.name}"
+  availability_zone = "${var.availability_zones[count.index % length(var.availability_zones)]}"
 
   network {
     name = "${var.network_name}"
@@ -151,6 +154,7 @@ resource "openstack_compute_instance_v2" "etcd" {
   image_name = "${var.image}"
   flavor_id  = "${var.flavor_etcd}"
   key_pair   = "${openstack_compute_keypair_v2.k8s.name}"
+  availability_zone = "${var.availability_zones[count.index % length(var.availability_zones)]}"
 
   network {
     name = "${var.network_name}"
@@ -172,6 +176,7 @@ resource "openstack_compute_instance_v2" "k8s_master_no_floating_ip" {
   image_name = "${var.image}"
   flavor_id  = "${var.flavor_k8s_master}"
   key_pair   = "${openstack_compute_keypair_v2.k8s.name}"
+  availability_zone = "${var.availability_zones[count.index % length(var.availability_zones)]}"
 
   network {
     name = "${var.network_name}"
@@ -196,6 +201,7 @@ resource "openstack_compute_instance_v2" "k8s_master_no_floating_ip_no_etcd" {
   image_name = "${var.image}"
   flavor_id  = "${var.flavor_k8s_master}"
   key_pair   = "${openstack_compute_keypair_v2.k8s.name}"
+  availability_zone = "${var.availability_zones[count.index % length(var.availability_zones)]}"
 
   network {
     name = "${var.network_name}"
@@ -219,6 +225,7 @@ resource "openstack_compute_instance_v2" "k8s_node" {
   image_name = "${var.image}"
   flavor_id  = "${var.flavor_k8s_node}"
   key_pair   = "${openstack_compute_keypair_v2.k8s.name}"
+  availability_zone = "${var.availability_zones[count.index % length(var.availability_zones)]}"
 
   network {
     name = "${var.network_name}"
@@ -247,6 +254,7 @@ resource "openstack_compute_instance_v2" "k8s_node_no_floating_ip" {
   image_name = "${var.image}"
   flavor_id  = "${var.flavor_k8s_node}"
   key_pair   = "${openstack_compute_keypair_v2.k8s.name}"
+  availability_zone = "${var.availability_zones[count.index % length(var.availability_zones)]}"
 
   network {
     name = "${var.network_name}"
@@ -295,6 +303,7 @@ resource "openstack_compute_instance_v2" "glusterfs_node_no_floating_ip" {
   image_name = "${var.image_gfs}"
   flavor_id  = "${var.flavor_gfs_node}"
   key_pair   = "${openstack_compute_keypair_v2.k8s.name}"
+  availability_zone = "${var.availability_zones[count.index % length(var.availability_zones)]}"
 
   network {
     name = "${var.network_name}"

--- a/contrib/terraform/openstack/modules/compute/variables.tf
+++ b/contrib/terraform/openstack/modules/compute/variables.tf
@@ -59,3 +59,7 @@ variable "bastion_fips" {
 variable "supplementary_master_groups" {
   default = ""
 }
+
+variable "availability_zones" {
+  type = "list"
+}

--- a/contrib/terraform/openstack/sample-inventory/cluster.tf
+++ b/contrib/terraform/openstack/sample-inventory/cluster.tf
@@ -43,3 +43,5 @@ network_name = "<network>"
 external_net = "<UUID>"
 floatingip_pool = "<pool>"
 
+# availability zones
+availability_zones = ["nova"]

--- a/contrib/terraform/openstack/variables.tf
+++ b/contrib/terraform/openstack/variables.tf
@@ -116,3 +116,9 @@ variable "supplementary_master_groups" {
   description = "supplementary kubespray ansible groups for masters, such kube-node"
   default = ""
 }
+
+variable "availability_zones" {
+  description = "An array of availability zones we want to deploy in"
+  type        = "list"
+  default     = ["nova"]
+}


### PR DESCRIPTION
* Add nova availability zones

Split resources between multiple availability zones (AZ). Many deployments
run across multiple AZ to scale and create smaller failure domains.

Resources are deployed in an as evenly distributed fashion possible across
all AZ listed in the `availability_zone` variable.