### PR TITLE
Enable expansion for persistent mounts

### DIFF
--- a/roles/kubernetes-apps/persistent_volumes/openstack/templates/openstack-storage-class.yml.j2
+++ b/roles/kubernetes-apps/persistent_volumes/openstack/templates/openstack-storage-class.yml.j2
@@ -12,3 +12,4 @@ parameters:
   "{{ key }}": "{{ value }}"
 {% endfor %}
 {% endfor %}
+allowVolumeExpansion: {{ expand_persistent_volumes }}

--- a/roles/kubernetes/master/defaults/main.yml
+++ b/roles/kubernetes/master/defaults/main.yml
@@ -48,6 +48,7 @@ kube_apiserver_admission_control:
   - LimitRanger
   - ServiceAccount
   - DefaultStorageClass
+  - PersistentVolumeClaimResize
   - >-
       {%- if kube_version | version_compare('v1.9', '<') -%}
       GenericAdmissionWebhook

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -188,6 +188,7 @@ persistent_volumes_enabled: false
 cephfs_provisioner_enabled: false
 ingress_nginx_enabled: false
 cert_manager_enabled: false
+expand_persistent_volumes: false
 
 ## When OpenStack is used, Cinder version can be explicitly specified if autodetection fails (Fixed in 1.9: https://github.com/kubernetes/kubernetes/issues/50461)
 # openstack_blockstorage_version: "v1/v2/auto (default)"


### PR DESCRIPTION
To support expansion of persistent mounts as described here: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#expanding-persistent-volumes-claims