### PR TITLE
fluentd daemonset: do not set old nodeSelector.

### DIFF
--- a/roles/kubernetes-apps/efk/fluentd/templates/fluentd-ds.yml.j2
+++ b/roles/kubernetes-apps/efk/fluentd/templates/fluentd-ds.yml.j2
@@ -54,8 +54,6 @@ spec:
           readOnly: true
         - name: config-volume
           mountPath: "{{ fluentd_config_dir }}"
-      nodeSelector:
-        beta.kubernetes.io/fluentd-ds-ready: "true"
       terminationGracePeriodSeconds: 30
       volumes:
       - name: varlog


### PR DESCRIPTION
It seems fluentd-ds-ready label has been removed long time ago (see https://github.com/kubernetes/kubernetes/pull/43687), and no nodes in a cluster deployed by kubespray will have this label.

Fixes https://github.com/kubernetes-incubator/kubespray/pull/2763#issuecomment-399933825