### PR TITLE
CheckNodePIDPressure is not supported in v1.10

### DIFF
--- a/roles/kubernetes/master/templates/kube-scheduler-policy.yaml.j2
+++ b/roles/kubernetes/master/templates/kube-scheduler-policy.yaml.j2
@@ -10,7 +10,6 @@
     {"name" : "GeneralPredicates"},
     {"name" : "CheckNodeMemoryPressure"},
     {"name" : "CheckNodeDiskPressure"},
-    {"name" : "CheckNodePIDPressure"},
     {"name" : "CheckNodeCondition"},
     {"name" : "PodToleratesNodeTaints"},
     {"name" : "CheckVolumeBinding"}


### PR DESCRIPTION
PR #2737 accidentally introduces `CheckNodePIDPressure ` which is was released with `v1.11` (see [CHANGELOG-1.11.md](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.11.md), PR [#60007](https://github.com/kubernetes/kubernetes/pull/60007)). Since Kubespray currently supports v1.10 this PR removes `CheckNodePIDPressure`.

Issue reported by @avoidik on slack