### PR TITLE
move node selection from --limit to --extra-vars=node<nodename>"

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -51,11 +51,26 @@ Remove nodes
 
 You may want to remove **worker** nodes to your existing cluster. This can be done by re-running the `remove-node.yml` playbook. First, all nodes will be drained, then stop some kubernetes services and delete some certificates, and finally execute the kubectl command to delete these nodes. This can be combined with the add node function, This is generally helpful when doing something like autoscaling your clusters. Of course if a node is not working, you can remove the node and install it again.
 
-- Add worker nodes to the list under kube-node if you want to delete them (or utilize a [dynamic inventory](https://docs.ansible.com/ansible/intro_dynamic_inventory.html)).
-- Run the ansible-playbook command, substituting `remove-node.yml`:
+Add worker nodes to the list under kube-node if you want to delete them (or utilize a [dynamic inventory](https://docs.ansible.com/ansible/intro_dynamic_inventory.html)).
+
+    ansible-playbook -i inventory/mycluster/hosts.ini remove-node.yml -b -v \
+        --private-key=~/.ssh/private_key
+
+
+We support two ways to select the nodes:
+
+- Use `--extra-vars "node=<nodename>,<nodename2>"` to select the node you want to delete.
 ```
 ansible-playbook -i inventory/mycluster/hosts.ini remove-node.yml -b -v \
-  --private-key=~/.ssh/private_key
+  --private-key=~/.ssh/private_key \
+  --extra-vars "node=nodename,nodename2"
+```
+or
+- Use `--limit nodename,nodename2` to select the node
+```
+ansible-playbook -i inventory/mycluster/hosts.ini remove-node.yml -b -v \
+  --private-key=~/.ssh/private_key \
+  --limit nodename,nodename2"
 ```
 
 Connecting to Kubernetes

--- a/remove-node.yml
+++ b/remove-node.yml
@@ -5,7 +5,7 @@
     ansible_ssh_pipelining: true
   gather_facts: true
 
-- hosts: etcd:k8s-cluster:vault:calico-rr
+- hosts: "{{ node | default('etcd:k8s-cluster:vault:calico-rr') }}"
   vars_prompt:
     name: "delete_nodes_confirmation"
     prompt: "Are you sure you want to delete nodes state? Type 'yes' to delete nodes."
@@ -22,7 +22,7 @@
   roles:
     - { role: remove-node/pre-remove, tags: pre-remove }
 
-- hosts: kube-node
+- hosts: "{{ node | default('kube-node') }}"
   roles:
     - { role: kubespray-defaults }
     - { role: reset, tags: reset }

--- a/roles/remove-node/post-remove/tasks/main.yml
+++ b/roles/remove-node/post-remove/tasks/main.yml
@@ -3,7 +3,7 @@
 - name: Delete node
   command: kubectl delete node {{ item }}
   with_items:
-    - "{{ groups['kube-node'] }}"
+    - "{{ node.split(',') | default(groups['kube-node']) }}"
   delegate_to: "{{ groups['kube-master']|first }}"
   run_once: true
   ignore_errors: yes

--- a/roles/remove-node/pre-remove/tasks/main.yml
+++ b/roles/remove-node/pre-remove/tasks/main.yml
@@ -9,7 +9,7 @@
       --timeout {{ drain_timeout }}
       --delete-local-data {{ item }}
   with_items:
-    - "{{ groups['kube-node'] }}"
+    - "{{ node.split(',') | default(groups['kube-node']) }}"
   failed_when: false
   delegate_to: "{{ groups['kube-master']|first }}"
   run_once: true


### PR DESCRIPTION
Hello,

while restricting remove-node.yml with `--limit` the pre and post task will not be executed! 

```- hosts: kube-master
  roles:
    - { role: remove-node/pre-remove, tags: pre-remove }
```
We don't have any valid host in group `kube_master` and `--limit nodename`
So on execution we get:
```PLAY [kube-master] ***********************************************************************************************************
skipping: no hosts matched
```

So i propose we use `--extra-vars` for selection and the full inventory.

I changed the `hosts:` line in the node task and the selector in pre/post role task to `"{{ node }}"`

so we are able to call `ansible-playbook -i <inventory> remove-node.yml --extra-vars "node=<nodename>"`

Additionally it will not  breack reset.yml. here we can use it with `--limit` there are no task which need diffrent group/host.

thanks in advanced,
mark 