### PR TITLE
Fix `coreos_dual` -> `coredns_dual` typo

### DIFF
--- a/roles/docker/tasks/set_facts_dns.yml
+++ b/roles/docker/tasks/set_facts_dns.yml
@@ -26,7 +26,7 @@
 - name: add upstream dns servers (only when dnsmasq is not used)
   set_fact:
     docker_dns_servers: "{{ docker_dns_servers + upstream_dns_servers|default([]) }}"
-  when: dns_mode in ['kubedns', 'coredns', 'coreos_dual']
+  when: dns_mode in ['kubedns', 'coredns', 'coredns_dual']
 
 - name: add global searchdomains
   set_fact:


### PR DESCRIPTION
I noticed this typo while reading through the CoreDNS-related code. I did however *not* test this change.

See: e40368ae2bede83978523cb1d4c04866c322468e