### PR TITLE
recover master cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To deploy the cluster you can use :
     sudo pip install -r requirements.txt
 
     # Copy ``inventory/sample`` as ``inventory/mycluster``
-    cp -rfp inventory/sample inventory/mycluster
+    cp -rfp inventory/sample/* inventory/mycluster
 
     # Update Ansible inventory file with inventory builder
     declare -a IPS=(10.10.1.3 10.10.1.4 10.10.1.5)
@@ -47,6 +47,21 @@ Install the necessary requirements
 
     sudo pip install -r requirements.txt
     vagrant up
+
+### recover master cluster
+    # Install dependencies from ``requirements.txt``, if there are not dependencies in the machine that will being running recover-master-cluster ansible.
+    sudo pip install -r requirements.txt
+
+    # Copy ``inventory/sample`` as ``inventory/mycluster``, if there are not mycluster/hosts.ini, mycluster/hosts-recover-master.ini or mycluster/group_vars in the machine that will being running recover-master-cluster ansible.
+    cp -rfp inventory/sample/* inventory/mycluster
+
+    # Review and change context under ``inventory/mycluster/group_vars`` and ``inventory/mycluster/hosts-recover-master.ini``
+    cat inventory/mycluster/group_vars/all.yml
+    cat inventory/mycluster/group_vars/k8s-cluster.yml
+    cat inventory/mycluster/hosts-recover-master.ini
+
+    # Recover master with Ansible Playbook manully.
+    ansible-playbook -i inventory/mycluster/hosts-recover-master.ini recover-master.yml
 
 Documents
 ---------

--- a/inventory/sample/hosts-recover-master.ini
+++ b/inventory/sample/hosts-recover-master.ini
@@ -1,0 +1,87 @@
+# ## Operation manual
+# ## hosts-recover-master.ini is used for recover master cluster in manual or auto.
+# ## Notice:
+# ##   ip:                      getting fault and new master ip. Must be set.
+# ##   etcd_member_name:        the name of the etcd member being added to etcd cluster. Must be set.
+# ##                            if not the etcd member, it can be set to empty.
+# ##   [kube-master]:           new master cluster including new master, removing fault master. Must be set.
+# ##   [etcd]:                  the new etcd cluster including new member, removing fault member. Must be set.
+# ##   [kube-master]:           the new k8s cluster including new master and node, removing fault master and node. Must be set.
+# ##   [master-remove]:         the fault master. Must be set.
+# ##   [master-add]:            the new master. Must be set.
+# ##   [etcd-remove]:           the fault etcd. Must be set.
+# ##   [etcd-add]:              the new etcd. Must be set.
+# ##   [etcd-old]:              the old etcd cluster including the fault member being used for getting fault etcd member. Must be set.
+# ##   [kube-ingress]:          remove the fault master. Optional.
+# ##   [k8s-cluster:children] : Must be set.
+# ##
+# ## Sample:
+# ##   This sample is multi-nodes cluster that contains five nodes, the beginning status: 
+# ##     node1: master1 + etcd1 + node1
+# ##     node2: master2 + etcd2 + node2
+# ##     node3: master3 + etcd3 + node3
+# ##     node4: node4
+# ##     node5: node5
+# ##
+# ##   When node3 are fault, this module can be run to recover master and etcd cluster. The final status:
+# ##     node1: master1 + etcd1 + node1
+# ##     node2: master2 + etcd2 + node2
+# ##     node4: master4 + etcd4 + node4
+# ##     node5: node5
+# ##
+# ## You can deploy the cluster that contains five master and etcd, or other cases.
+
+# ## Configure 'ip' variable to bind kubernetes services on a
+# ## different ip than the default iface
+# ## We should set etcd_member_name for etcd cluster. The node that is not a etcd member do not need to set the value, or can set the empty string value.
+# node1 ansible_host=172.16.0.207  ip=172.16.0.207 etcd_member_name=etcd1
+# node2 ansible_host=172.16.0.208  ip=172.16.0.208 etcd_member_name=etcd2
+# node3 ansible_host=172.16.0.209  ip=172.16.0.209 etcd_member_name=etcd3
+# node4 ansible_host=172.16.0.210  ip=172.16.0.210 etcd_member_name=etcd4
+# node5 ansible_host=172.16.0.211  ip=172.16.0.211 etcd_member_name=etcd5
+
+## ## configure a bastion host if your nodes are not directly reachable
+## bastion ansible_host=x.x.x.x ansible_user=some_user
+
+# [kube-master]
+# node1
+# node2
+# node4
+
+# [etcd]
+# node1
+# node2
+# node4
+
+# [kube-node]
+# node1
+# node2
+# node4
+# node5
+
+# [master-remove]
+# node3
+
+# [master-add]
+# node4
+
+# [etcd-remove]
+# node3
+
+# [etcd-add]
+# node4
+
+# [etcd-old]
+# node1
+# node2
+# node3
+
+## [kube-ingress]
+## node1
+## node2
+## node4
+
+# [k8s-cluster:children]
+# kube-master
+# kube-node
+# kube-ingress

--- a/recover-master.yml
+++ b/recover-master.yml
@@ -1,0 +1,86 @@
+---
+- hosts: localhost
+  gather_facts: False
+  roles:
+    - { role: kubespray-defaults}
+    - { role: bastion-ssh-config, tags: ["localhost", "bastion"]}
+
+- hosts: k8s-cluster:etcd:calico-rr
+  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  gather_facts: false
+  vars:
+    # Need to disable pipelining for bootstrap-os as some systems have requiretty in sudoers set, which makes pipelining
+    # fail. bootstrap-os fixes this on these systems, so in later plays it can be enabled.
+    ansible_ssh_pipelining: false
+  roles:
+    - { role: kubespray-defaults}
+    - { role: bootstrap-os, tags: bootstrap-os}
+
+- hosts: k8s-cluster:etcd:calico-rr
+  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  vars:
+    ansible_ssh_pipelining: true
+  gather_facts: true
+  pre_tasks:
+    - name: gather facts from all instances
+      setup:
+      delegate_to: "{{item}}"
+      delegate_facts: True
+      with_items: "{{ groups['k8s-cluster'] + groups['etcd'] + groups['calico-rr']|default([]) }}"
+
+- hosts: k8s-cluster:etcd:calico-rr
+  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  roles:
+    - { role: kubespray-defaults}
+    - { role: kubernetes/preinstall, tags: preinstall }
+    - { role: download, tags: download, skip_downloads: false }
+  environment: "{{proxy_env}}"
+
+- hosts: etcd:k8s-cluster:calico-rr
+  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  roles:
+    - { role: kubespray-defaults}
+    - { role: etcd-recover, tags: etcd-recover, etcd_cluster_setup: true, etcd_events_cluster_setup: "{{ etcd_events_cluster_enabled }}" }
+
+- hosts: k8s-cluster
+  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  roles:
+    - { role: kubespray-defaults}
+    - { role: kubernetes-recover/node, tags: node }
+  environment: "{{proxy_env}}"
+
+- hosts: kube-master
+  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  roles:
+    - { role: kubespray-defaults}
+    - { role: kubernetes-recover/master, tags: master, etcd_events_cluster_setup: "{{ etcd_events_cluster_enabled }}" }
+    - { role: kubernetes/client, tags: client }
+    - { role: kubernetes-apps/cluster_roles, tags: cluster-roles }
+
+- hosts: k8s-cluster
+  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  roles:
+    - { role: kubespray-defaults}
+    - { role: kubernetes/kubeadm, tags: kubeadm, when: "kubeadm_enabled" }
+    - { role: network_plugin, tags: network }
+    #- { role: network_plugin_recover, tags: network }
+
+- hosts: kube-master[0]
+  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  roles:
+    - { role: kubespray-defaults}
+    - { role: kubernetes-apps/rotate_tokens, tags: rotate_tokens, when: "secret_changed|default(false)" }
+
+- hosts: kube-master
+  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  roles:
+    - { role: kubespray-defaults}
+    - { role: kubernetes-apps/network_plugin, tags: network }
+    - { role: kubernetes-apps/policy_controller, tags: policy-controller }
+
+- hosts: calico-rr
+  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  roles:
+    - { role: kubespray-defaults}
+    - { role: network_plugin/calico/rr, tags: network }
+

--- a/roles/etcd-recover/defaults/main.yml
+++ b/roles/etcd-recover/defaults/main.yml
@@ -1,0 +1,60 @@
+---
+# Set to false to only do certificate management
+etcd_cluster_setup: true
+etcd_events_cluster_setup: false
+
+etcd_backup_prefix: "/var/backups"
+etcd_data_dir: "/var/lib/etcd"
+etcd_events_data_dir: "/var/lib/etcd-events"
+
+etcd_config_dir: /etc/ssl/etcd
+etcd_cert_dir: "{{ etcd_config_dir }}/ssl"
+etcd_cert_group: root
+# Note: This does not set up DNS entries. It simply adds the following DNS
+# entries to the certificate
+etcd_cert_alt_names:
+  - "etcd.kube-system.svc.{{ dns_domain }}"
+  - "etcd.kube-system.svc"
+  - "etcd.kube-system"
+  - "etcd"
+
+etcd_script_dir: "{{ bin_dir }}/etcd-scripts"
+
+etcd_heartbeat_interval: "250"
+etcd_election_timeout: "5000"
+
+# etcd_snapshot_count: "10000"
+
+# Parameters for ionice
+# -c takes an integer between 0 and 3 or one of the strings none, realtime, best-effort or idle.
+# -n takes an integer between 0 (highest priority) and 7 (lowest priority)
+# etcd_ionice: "-c2 -n0"
+
+etcd_metrics: "basic"
+
+## A dictionary of extra environment variables to add to etcd.env, formatted like:
+##  etcd_extra_vars:
+##    ETCD_VAR1: "value1"
+##    ETCD_VAR2: "value2"
+etcd_extra_vars: {}
+
+# Limits
+# Limit memory only if <4GB memory on host. 0=unlimited
+etcd_memory_limit: "{% if ansible_memtotal_mb < 4096 %}512M{% else %}0{% endif %}"
+
+# Uncomment to set CPU share for etcd
+# etcd_cpu_limit: 300m
+
+etcd_blkio_weight: 1000
+
+etcd_node_cert_hosts: "{{ groups['k8s-cluster'] | union(groups.get('calico-rr', [])) | union(groups.get('vault', [])) }}"
+
+etcd_compaction_retention: "8"
+
+etcd_vault_mount_path: "/etcd"
+
+# Force clients like etcdctl to use TLS certs (different than peer security)
+etcd_secure_client: true
+
+# Enable peer client cert authentication
+etcd_peer_client_auth: true

--- a/roles/etcd-recover/files/make-ssl-etcd.sh
+++ b/roles/etcd-recover/files/make-ssl-etcd.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+# Author: Smana smainklh@gmail.com
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o pipefail
+usage()
+{
+    cat << EOF
+Create self signed certificates
+
+Usage : $(basename $0) -f <config> [-d <ssldir>]
+      -h | --help         : Show this message
+      -f | --config       : Openssl configuration file
+      -d | --ssldir       : Directory where the certificates will be installed
+
+               ex :
+               $(basename $0) -f openssl.conf -d /srv/ssl
+EOF
+}
+
+# Options parsing
+while (($#)); do
+    case "$1" in
+        -h | --help)   usage;   exit 0;;
+        -f | --config) CONFIG=${2}; shift 2;;
+        -d | --ssldir) SSLDIR="${2}"; shift 2;;
+        *)
+            usage
+            echo "ERROR : Unknown option"
+            exit 3
+        ;;
+    esac
+done
+
+if [ -z ${CONFIG} ]; then
+    echo "ERROR: the openssl configuration file is missing. option -f"
+    exit 1
+fi
+if [ -z ${SSLDIR} ]; then
+    SSLDIR="/etc/ssl/etcd"
+fi
+
+tmpdir=$(mktemp -d /tmp/etcd_cacert.XXXXXX)
+trap 'rm -rf "${tmpdir}"' EXIT
+cd "${tmpdir}"
+
+mkdir -p "${SSLDIR}"
+
+# Root CA
+if [ -e "$SSLDIR/ca-key.pem" ]; then
+    # Reuse existing CA
+    cp $SSLDIR/{ca.pem,ca-key.pem} .
+else
+    openssl genrsa -out ca-key.pem 2048 > /dev/null 2>&1
+    openssl req -x509 -new -nodes -key ca-key.pem -days 36500 -out ca.pem -subj "/CN=etcd-ca" > /dev/null 2>&1
+fi
+
+# ETCD member
+if [ -n "$MASTERS" ]; then
+    for host in $MASTERS; do
+        cn="${host%%.*}"
+        # Member key
+        openssl genrsa -out member-${host}-key.pem 2048 > /dev/null 2>&1
+        openssl req -new -key member-${host}-key.pem -out member-${host}.csr -subj "/CN=etcd-member-${cn}" -config ${CONFIG} > /dev/null 2>&1
+        openssl x509 -req -in member-${host}.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out member-${host}.pem -days 36500 -extensions ssl_client -extfile ${CONFIG} > /dev/null 2>&1
+
+        # Admin key
+        openssl genrsa -out admin-${host}-key.pem 2048 > /dev/null 2>&1
+        openssl req -new -key admin-${host}-key.pem -out admin-${host}.csr -subj "/CN=etcd-admin-${cn}" > /dev/null 2>&1
+        openssl x509 -req -in admin-${host}.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out admin-${host}.pem -days 36500 -extensions ssl_client  -extfile ${CONFIG} > /dev/null 2>&1
+    done
+fi
+
+# Node keys
+if [ -n "$HOSTS" ]; then
+    for host in $HOSTS; do
+        cn="${host%%.*}"
+        openssl genrsa -out node-${host}-key.pem 2048 > /dev/null 2>&1
+        openssl req -new -key node-${host}-key.pem -out node-${host}.csr -subj "/CN=etcd-node-${cn}" > /dev/null 2>&1
+        openssl x509 -req -in node-${host}.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out node-${host}.pem -days 36500 -extensions ssl_client  -extfile ${CONFIG} > /dev/null 2>&1
+    done
+fi
+
+# Install certs
+if [ -e "$SSLDIR/ca-key.pem" ]; then
+    # No pass existing CA
+    rm -f ca.pem ca-key.pem
+fi
+
+mv *.pem ${SSLDIR}/

--- a/roles/etcd-recover/handlers/backup.yml
+++ b/roles/etcd-recover/handlers/backup.yml
@@ -1,0 +1,54 @@
+---
+- name: Backup etcd data
+  command: /bin/true
+  notify:
+    - Refresh Time Fact
+    - Set Backup Directory
+    - Create Backup Directory
+    - Stat etcd v2 data directory
+    - Backup etcd v2 data
+    - Backup etcd v3 data
+  when: etcd_cluster_is_healthy.rc == 0
+
+- name: Refresh Time Fact
+  setup: filter=ansible_date_time
+
+- name: Set Backup Directory
+  set_fact:
+    etcd_backup_directory: "{{ etcd_backup_prefix }}/etcd-{{ ansible_date_time.date }}_{{ ansible_date_time.time }}"
+
+- name: Create Backup Directory
+  file:
+    path: "{{ etcd_backup_directory }}"
+    state: directory
+    owner: root
+    group: root
+    mode: 0600
+
+- name: Stat etcd v2 data directory
+  stat:
+    path: "{{ etcd_data_dir }}/member"
+  register: etcd_data_dir_member
+
+- name: Backup etcd v2 data
+  when: etcd_data_dir_member.stat.exists
+  command: >-
+    {{ bin_dir }}/etcdctl backup
+      --data-dir {{ etcd_data_dir }}
+      --backup-dir {{ etcd_backup_directory }}
+  environment:
+    ETCDCTL_API: 2
+  retries: 3
+  delay: "{{ retry_stagger | random + 3 }}"
+
+- name: Backup etcd v3 data
+  command: >-
+    {{ bin_dir }}/etcdctl
+      --endpoints={{ etcd_access_addresses }}
+      snapshot save {{ etcd_backup_directory }}/snapshot.db
+  environment:
+    ETCDCTL_API: 3
+    ETCDCTL_CERT: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}.pem"
+    ETCDCTL_KEY: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}-key.pem"
+  retries: 3
+  delay: "{{ retry_stagger | random + 3 }}"

--- a/roles/etcd-recover/handlers/main.yml
+++ b/roles/etcd-recover/handlers/main.yml
@@ -1,0 +1,58 @@
+---
+- name: restart etcd
+  command: /bin/true
+  notify:
+    - Backup etcd data
+    - etcd | reload systemd
+    - reload etcd
+    - wait for etcd up
+
+- name: restart etcd-events
+  command: /bin/true
+  notify:
+    - etcd | reload systemd
+    - reload etcd-events
+    - wait for etcd-events up
+
+- import_tasks: backup.yml
+
+- name: etcd | reload systemd
+  command: systemctl daemon-reload
+
+- name: reload etcd
+  service:
+    name: etcd
+    state: restarted
+  when: is_etcd_master
+
+- name: reload etcd-events
+  service:
+    name: etcd-events
+    state: restarted
+  when: is_etcd_master
+
+- name: wait for etcd up
+  uri:
+    url: "https://{% if is_etcd_master %}{{ etcd_address }}{% else %}127.0.0.1{% endif %}:2379/health"
+    validate_certs: no
+    client_cert: "{{ etcd_cert_dir }}/member-{{ inventory_hostname }}.pem"
+    client_key: "{{ etcd_cert_dir }}/member-{{ inventory_hostname }}-key.pem"
+  register: result
+  until: result.status is defined and result.status == 200
+  retries: 10
+  delay: 5
+
+- name: wait for etcd-events up
+  uri:
+    url: "https://{% if is_etcd_master %}{{ etcd_address }}{% else %}127.0.0.1{% endif %}:2381/health"
+    validate_certs: no
+    client_cert: "{{ etcd_cert_dir }}/member-{{ inventory_hostname }}.pem"
+    client_key: "{{ etcd_cert_dir }}/member-{{ inventory_hostname }}-key.pem"
+  register: result
+  until: result.status is defined and result.status == 200
+  retries: 10
+  delay: 5
+
+- name: set etcd_secret_changed
+  set_fact:
+    etcd_secret_changed: true

--- a/roles/etcd-recover/meta/main.yml
+++ b/roles/etcd-recover/meta/main.yml
@@ -1,0 +1,7 @@
+---
+dependencies:
+  - role: adduser
+    user: "{{ addusers.etcd }}"
+    when: not (ansible_os_family in ['CoreOS', 'Container Linux by CoreOS'] or is_atomic)
+
+# NOTE: Dynamic task dependency on Vault Role if cert_management == "vault"

--- a/roles/etcd-recover/tasks/check_certs.yml
+++ b/roles/etcd-recover/tasks/check_certs.yml
@@ -1,0 +1,138 @@
+---
+- name: "Check_certs | check if all certs have already been generated on first master"
+  find:
+    paths: "{{ etcd_cert_dir }}"
+    patterns: "ca-key.pem,ca.pem,admin-node*-key.pem,admin-node*.pem,member-node*-key.pem,member-node*.pem,node*-key.pem,node*.pem"
+    get_checksum: true
+  delegate_to: "{{groups['etcd'][0]}}"
+  register: etcdcert_master
+  run_once: true
+
+- name: "Check_certs | Set default value for 'sync_certs', 'gen_certs' and 'etcd_secret_changed' to false"
+  set_fact:
+    sync_certs: false
+    sync_certs_master: false
+    gen_certs: false
+    etcd_secret_changed: false
+
+- name: "Check certs | check if a cert already exists on node"
+  stat:
+    path: "{{ etcd_cert_dir }}/{{ item }}"
+  register: etcdcert_node
+  with_items:
+    - ca.pem
+    - node-{{ inventory_hostname }}-key.pem
+    - node-{{ inventory_hostname }}.pem
+
+- name: "Check certs | check if ca, member and admin certs already exist on etcd master"
+  stat:
+    path: "{{ etcd_cert_dir }}/{{ item }}"
+  register: etcdcert_node_master
+  with_items:
+    - member-{{ inventory_hostname }}-key.pem
+    - member-{{ inventory_hostname }}.pem
+    - admin-{{ inventory_hostname }}-key.pem
+    - admin-{{ inventory_hostname }}.pem
+    - ca-key.pem
+    - ca.pem
+  when: inventory_hostname in groups['etcd']
+
+- name: "Check_certs | Set 'gen_certs' to true"
+  set_fact:
+    gen_certs: true
+  when: not item in etcdcert_master.files|map(attribute='path') | list
+  run_once: true
+  with_items: >-
+       ['{{ etcd_cert_dir }}/ca.pem',
+       '{{ etcd_cert_dir }}/ca-key.pem',
+       {% set all_etcd_hosts = groups['etcd']|union(groups['k8s-cluster'])|union(groups['calico-rr']|default([]))|unique|sort %}
+       {% for host in all_etcd_hosts %}
+       '{{ etcd_cert_dir }}/node-{{ host }}-key.pem',
+       '{{ etcd_cert_dir }}/node-{{ host }}.pem'
+       {% if not loop.last %}{{','}}{% endif %}
+       {% endfor %},
+       {% set all_etcd_hosts = groups['etcd'] %}
+       {% for host in all_etcd_hosts %}
+       '{{ etcd_cert_dir }}/member-{{ host }}-key.pem',
+       '{{ etcd_cert_dir }}/member-{{ host }}.pem',
+       '{{ etcd_cert_dir }}/admin-{{ host }}-key.pem',
+       '{{ etcd_cert_dir }}/admin-{{ host }}.pem'
+       {% if not loop.last %}{{','}}{% endif %}
+       {% endfor %}]
+
+- name: "Check_certs | Set 'gen_node_certs' to true"
+  set_fact:
+    gen_node_certs: |-
+      {
+      {% set all_etcd_hosts = groups['etcd']|union(groups['k8s-cluster'])|union(groups['calico-rr']|default([]))|unique|sort -%}
+      {% set existing_certs = etcdcert_master.files|map(attribute='path')|list|sort %}
+      {% for host in all_etcd_hosts -%}
+        {% set host_cert = "%s/node-%s-key.pem"|format(etcd_cert_dir, host) %}
+        {% set host_cert2 = "%s/node-%s.pem"|format(etcd_cert_dir, host) %}
+        {% if host_cert in existing_certs and host_cert2 in existing_certs -%}
+        "{{ host }}": False,
+        {% else -%}
+        "{{ host }}": True,
+        {% endif -%}
+      {% endfor %}
+      }
+  run_once: true
+
+- name: "Check_certs | Set 'gen_master_certs' to true for master check"
+  set_fact:
+    gen_master_certs: |-
+      {
+      {% set all_etcd_hosts = groups['etcd'] -%}
+      {% set existing_certs = etcdcert_master.files|map(attribute='path')|list|sort %}
+      {% for host in all_etcd_hosts -%}
+        {% set host_cert = "%s/member-%s-key.pem"|format(etcd_cert_dir, host) %}
+        {% set host_cert_2 = "%s/member-%s.pem"|format(etcd_cert_dir, host) %}
+        {% set host_cert_3 = "%s/admin-%s-key.pem"|format(etcd_cert_dir, host) %}
+        {% set host_cert_4 = "%s/admin-%s.pem"|format(etcd_cert_dir, host) %}
+        {% if host_cert in existing_certs and host_cert_2 in existing_certs and host_cert_3 in existing_certs and host_cert_4 in existing_certs -%}
+        "{{ host }}": False,
+        {% else -%}
+        "{{ host }}": True,
+        {% endif -%}
+      {% endfor %}
+      }
+  run_once: true
+
+- name: "Check_certs | Set 'sync_certs' to true for etcd node"
+  set_fact:
+    sync_certs: true
+  when: |-
+      {%- set certs = {'sync': False} -%}
+      {% if gen_node_certs[inventory_hostname] or
+        (not etcdcert_node.results[0].stat.exists|default(False)) or
+          (not etcdcert_node.results[1].stat.exists|default(False)) or
+            (not etcdcert_node.results[2].stat.exists|default(False)) or
+              (etcdcert_node.results[0].stat.checksum|default('') != etcdcert_master.files|selectattr("path", "equalto", etcdcert_node.results[0].stat.path)|map(attribute="checksum")|first|default('')) or
+                (etcdcert_node.results[1].stat.checksum|default('') != etcdcert_master.files|selectattr("path", "equalto", etcdcert_node.results[1].stat.path)|map(attribute="checksum")|first|default('')) or
+                  (etcdcert_node.results[2].stat.checksum|default('') != etcdcert_master.files|selectattr("path", "equalto", etcdcert_node.results[2].stat.path)|map(attribute="checksum")|first|default('')) -%}
+                    {%- set _ = certs.update({'sync': True}) -%}
+      {% endif %}
+      {{ certs.sync }}
+
+- name: "Check_certs | Set 'sync_certs_master' to true  for etcd master"
+  set_fact:
+    sync_certs_master: true
+  when: |-
+      ({%- set certs = {'sync': False} -%}
+      {% if inventory_hostname in groups['etcd'] and (gen_master_certs[inventory_hostname] or
+        (not etcdcert_node_master.results[0].stat.exists|default(False)) or
+          (not etcdcert_node_master.results[1].stat.exists|default(False)) or
+            (not etcdcert_node_master.results[2].stat.exists|default(False)) or
+              (not etcdcert_node_master.results[3].stat.exists|default(False)) or
+                (not etcdcert_node_master.results[4].stat.exists|default(False)) or
+                  (not etcdcert_node_master.results[5].stat.exists|default(False)) or
+                    (etcdcert_node_master.results[0].stat.checksum|default('') != etcdcert_master.files|selectattr("path", "equalto", etcdcert_node_master.results[0].stat.path)|map(attribute="checksum")|first|default('')) or
+                      (etcdcert_node_master.results[1].stat.checksum|default('') != etcdcert_master.files|selectattr("path", "equalto", etcdcert_node_master.results[1].stat.path)|map(attribute="checksum")|first|default('')) or
+                        (etcdcert_node_master.results[2].stat.checksum|default('') != etcdcert_master.files|selectattr("path", "equalto", etcdcert_node_master.results[2].stat.path)|map(attribute="checksum")|first|default('')) or
+                          (etcdcert_node_master.results[3].stat.checksum|default('') != etcdcert_master.files|selectattr("path", "equalto", etcdcert_node_master.results[3].stat.path)|map(attribute="checksum")|first|default('')) or
+                            (etcdcert_node_master.results[4].stat.checksum|default('') != etcdcert_master.files|selectattr("path", "equalto", etcdcert_node_master.results[4].stat.path)|map(attribute="checksum")|first|default('')) or
+                              (etcdcert_node_master.results[5].stat.checksum|default('') != etcdcert_master.files|selectattr("path", "equalto", etcdcert_node_master.results[5].stat.path)|map(attribute="checksum")|first|default(''))) -%}
+                                {%- set _ = certs.update({'sync': True}) -%}
+      {% endif %}
+      {{ certs.sync }})
+

--- a/roles/etcd-recover/tasks/configure.yml
+++ b/roles/etcd-recover/tasks/configure.yml
@@ -1,0 +1,117 @@
+---
+- name: Configure | Remove fault etcd
+  include: remove_fault_etcd.yml
+  delegate_to: "{{ groups['etcd'][0] }}"
+  run_once: true
+
+- name: Configure | Check if etcd cluster is healthy
+  shell: "{{ bin_dir }}/etcdctl --endpoints={{ etcd_access_addresses }} cluster-health | grep -q 'cluster is healthy'"
+  register: etcd_cluster_is_healthy
+  ignore_errors: true
+  changed_when: false
+  check_mode: no
+  when: is_etcd_master and etcd_cluster_setup
+  tags:
+    - facts
+  environment:
+    ETCDCTL_CERT_FILE: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}.pem"
+    ETCDCTL_KEY_FILE: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}-key.pem"
+
+- name: Configure | Check if etcd-events cluster is healthy
+  shell: "{{ bin_dir }}/etcdctl --endpoints={{ etcd_events_access_addresses }} cluster-health | grep -q 'cluster is healthy'"
+  register: etcd_events_cluster_is_healthy
+  ignore_errors: true
+  changed_when: false
+  check_mode: no
+  when: is_etcd_master and etcd_events_cluster_setup
+  tags:
+    - facts
+  environment:
+    ETCDCTL_CERT_FILE: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}.pem"
+    ETCDCTL_KEY_FILE: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}-key.pem"
+
+- name: Configure | Check if member is in etcd cluster
+  shell: "{{ bin_dir }}/etcdctl --no-sync --endpoints={{ etcd_access_addresses }} member list | grep -q {{ etcd_access_address }}"
+  register: etcd_member_in_cluster
+  #ignore_errors: true
+  failed_when: false
+  changed_when: false
+  check_mode: no
+  when: is_etcd_master and etcd_cluster_setup
+  tags:
+    - facts
+  environment:
+    ETCDCTL_CERT_FILE: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}.pem"
+    ETCDCTL_KEY_FILE: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}-key.pem"
+
+- name: Configure | Check if member is in etcd-events cluster
+  shell: "{{ bin_dir }}/etcdctl --no-sync --endpoints={{ etcd_events_access_addresses }} member list | grep -q {{ etcd_access_address }}"
+  register: etcd_events_member_in_cluster
+  #ignore_errors: true
+  failed_when: false
+  changed_when: false
+  check_mode: no
+  when: is_etcd_master and etcd_events_cluster_setup
+  tags:
+    - facts
+  environment:
+    ETCDCTL_CERT_FILE: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}.pem"
+    ETCDCTL_KEY_FILE: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}-key.pem"
+
+- name: Configure | Add a new member to the etcd cluster
+  shell: "{{ bin_dir }}/etcdctl --endpoints={{ etcd_access_addresses }} member add {{ etcd_member_name_recover }} {{ etcd_peer_url }}"
+  ignore_errors: true
+  changed_when: false
+  check_mode: no
+  when: inventory_hostname in groups['etcd-add'] and is_etcd_master and etcd_cluster_setup and etcd_cluster_is_healthy.rc == 0 and etcd_member_in_cluster.rc != 0
+  environment:
+    ETCDCTL_CERT_FILE: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}.pem"
+    ETCDCTL_KEY_FILE: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}-key.pem"
+
+- name: Configure | Add a new member to the etcd-events cluster
+  shell: "{{ bin_dir }}/etcdctl --endpoints={{ etcd_events_access_addresses }} member add '{{ etcd_member_name_recover }}-events' {{ etcd_events_peer_url }}"
+  ignore_errors: true
+  changed_when: false
+  check_mode: no
+  when: inventory_hostname in groups['etcd-add'] and is_etcd_master and etcd_events_cluster_setup and etcd_events_cluster_is_healthy.rc == 0 and etcd_events_member_in_cluster.rc != 0
+  environment:
+    ETCDCTL_CERT_FILE: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}.pem"
+    ETCDCTL_KEY_FILE: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}-key.pem"
+
+- name: Configure | Copy etcd.service systemd file
+  template:
+    src: "etcd-{{ etcd_deployment_type }}.service.j2"
+    dest: /etc/systemd/system/etcd.service
+    backup: yes
+  when: is_etcd_master and etcd_cluster_setup 
+
+- name: Configure | Copy etcd-events.service systemd file
+  template:
+    src: "etcd-events-{{ etcd_deployment_type }}.service.j2"
+    dest: /etc/systemd/system/etcd-events.service
+    backup: yes
+  when: is_etcd_master and etcd_events_cluster_setup
+
+- name: Configure | reload systemd
+  command: systemctl daemon-reload
+  when: is_etcd_master 
+
+
+- include_tasks: refresh_config.yml
+  when: is_etcd_master
+
+
+- name: Configure | Ensure etcd is running
+  service:
+    name: etcd
+    state: started
+    enabled: yes
+  when: (is_etcd_master and etcd_cluster_setup and etcd_member_in_cluster.rc != 0) or etcd_secret_changed|default(false)
+
+- name: Configure | Ensure etcd-events is running
+  service:
+    name: etcd-events
+    state: started
+    enabled: yes
+  when: (is_etcd_master and etcd_events_cluster_setup and etcd_events_member_in_cluster.rc != 0) or etcd_secret_changed|default(false)
+

--- a/roles/etcd-recover/tasks/gen_certs_script.yml
+++ b/roles/etcd-recover/tasks/gen_certs_script.yml
@@ -1,0 +1,171 @@
+---
+- name: Gen_certs | change etcd cert dir mode for write
+  file:
+    path: "{{ etcd_cert_dir }}"
+    group: "{{ etcd_cert_group }}"
+    state: directory
+    owner: kube
+    mode: 0700
+    recurse: yes
+
+- name: "Gen_certs | create etcd script dir (on {{groups['etcd'][0]}})"
+  file:
+    path: "{{ etcd_script_dir }}"
+    state: directory
+    owner: root
+    mode: 0700
+  run_once: yes
+  when: inventory_hostname == groups['etcd'][0]
+  delegate_to: "{{groups['etcd'][0]}}"
+
+- name: "Gen_certs | create etcd cert dir (on {{groups['etcd'][0]}})"
+  file:
+    path: "{{ etcd_cert_dir }}"
+    group: "{{ etcd_cert_group }}"
+    state: directory
+    owner: kube
+    recurse: yes
+    mode: 0700
+  run_once: yes
+  when: inventory_hostname == groups['etcd'][0]
+  delegate_to: "{{groups['etcd'][0]}}"
+
+- name: Gen_certs | write openssl config
+  template:
+    src: "openssl.conf.j2"
+    dest: "{{ etcd_config_dir }}/openssl.conf"
+  run_once: yes
+  delegate_to: "{{groups['etcd'][0]}}"
+  when:
+    - gen_certs|default(false)
+    - inventory_hostname == groups['etcd'][0]
+
+- name: Gen_certs | copy certs generation script
+  copy:
+    src: "make-ssl-etcd.sh"
+    dest: "{{ etcd_script_dir }}/make-ssl-etcd.sh"
+    mode: 0700
+  run_once: yes
+  delegate_to: "{{groups['etcd'][0]}}"
+  when:
+    - gen_certs|default(false)
+    - inventory_hostname == groups['etcd'][0]
+
+- name: Gen_certs | run cert generation script
+  command: "bash -x {{ etcd_script_dir }}/make-ssl-etcd.sh -f {{ etcd_config_dir }}/openssl.conf -d {{ etcd_cert_dir }}"
+  environment:
+    - MASTERS: "{% for m in groups['etcd'] %}
+                  {% if gen_master_certs[m] %}
+                    {{ m }}
+                  {% endif %}
+                {% endfor %}"
+    - HOSTS: "{% for h in (groups['etcd'] + groups['k8s-cluster'] + groups['calico-rr']|default([]))|unique %}
+                {% if gen_node_certs[h] %}
+                    {{ h }}
+                {% endif %}
+              {% endfor %}"
+  run_once: yes
+  delegate_to: "{{groups['etcd'][0]}}"
+  when:
+    - gen_certs|default(false)
+    - inventory_hostname == groups['etcd'][0]
+  notify: set etcd_secret_changed
+
+- set_fact:
+    all_master_certs: "['ca-key.pem',
+                      {% for node in groups['etcd'] %}
+                      'admin-{{ node }}.pem',
+                      'admin-{{ node }}-key.pem',
+                      'member-{{ node }}.pem',
+                      'member-{{ node }}-key.pem',
+                      {% endfor %}]"
+    my_master_certs: ['ca-key.pem',
+                      'admin-{{ inventory_hostname }}.pem',
+                      'admin-{{ inventory_hostname }}-key.pem',
+                      'member-{{ inventory_hostname }}.pem',
+                      'member-{{ inventory_hostname }}-key.pem']
+    all_node_certs: "['ca.pem',
+                    {% for node in (groups['etcd'] + groups['k8s-cluster'] + groups['calico-rr']|default([]))|unique %}
+                    'node-{{ node }}.pem',
+                    'node-{{ node }}-key.pem',
+                    {% endfor %}]"
+    my_node_certs: ['ca.pem', 'node-{{ inventory_hostname }}.pem', 'node-{{ inventory_hostname }}-key.pem']
+  tags:
+    - facts
+
+- name: Gen_certs | Gather etcd master certs
+  shell: "tar cfz - -C {{ etcd_cert_dir }} -T /dev/stdin <<< {{ my_master_certs|join(' ') }} {{ all_node_certs|join(' ') }} | base64 --wrap=0"
+  args:
+    executable: /bin/bash
+  register: etcd_master_cert_data
+  no_log: true
+  check_mode: no
+  delegate_to: "{{groups['etcd'][0]}}"
+  when: inventory_hostname in groups['etcd'] and sync_certs_master|default(false) and
+        inventory_hostname != groups['etcd'][0]
+  notify: set etcd_secret_changed
+
+- name: Gen_certs | Gather etcd node certs
+  shell: "tar cfz - -C {{ etcd_cert_dir }} -T /dev/stdin <<< {{ my_node_certs|join(' ') }} | base64 --wrap=0"
+  args:
+    executable: /bin/bash
+  register: etcd_node_cert_data
+  no_log: true
+  check_mode: no
+  delegate_to: "{{groups['etcd'][0]}}"
+  when: (('calico-rr' in groups and inventory_hostname in groups['calico-rr']) or
+        inventory_hostname in groups['k8s-cluster']) and
+        sync_certs|default(false) and inventory_hostname not in groups['etcd']
+  notify: set etcd_secret_changed
+
+# NOTE(mattymo): Use temporary file to copy master certs because we have a ~200k
+# char limit when using shell command
+
+# FIXME(mattymo): Use tempfile module in ansible 2.3
+- name: Gen_certs | Prepare tempfile for unpacking certs
+  command: mktemp /tmp/certsXXXXX.tar.gz
+  register: cert_tempfile
+  when: inventory_hostname in groups['etcd'] and sync_certs_master|default(false) and
+        inventory_hostname != groups['etcd'][0]
+
+- name: Gen_certs | Write master certs to tempfile
+  copy:
+    content: "{{etcd_master_cert_data.stdout}}"
+    dest: "{{cert_tempfile.stdout}}"
+    owner: root
+    mode: "0600"
+  when: inventory_hostname in groups['etcd'] and sync_certs_master|default(false) and
+        inventory_hostname != groups['etcd'][0]
+
+- name: Gen_certs | Unpack certs on masters
+  shell: "base64 -d < {{ cert_tempfile.stdout }} | tar xz -C {{ etcd_cert_dir }}"
+  no_log: true
+  changed_when: false
+  check_mode: no
+  when: inventory_hostname in groups['etcd'] and sync_certs_master|default(false) and
+        inventory_hostname != groups['etcd'][0]
+  notify: set secret_changed
+
+- name: Gen_certs | Cleanup tempfile
+  file:
+    path: "{{cert_tempfile.stdout}}"
+    state: absent
+  when: inventory_hostname in groups['etcd'] and sync_certs_master|default(false) and
+        inventory_hostname != groups['etcd'][0]
+
+- name: Gen_certs | Copy certs on nodes
+  shell: "base64 -d <<< '{{etcd_node_cert_data.stdout|quote}}' | tar xz -C {{ etcd_cert_dir }}"
+  args:
+    executable: /bin/bash
+  changed_when: false
+  when: sync_certs|default(false) and
+        inventory_hostname not in groups['etcd']
+
+- name: Gen_certs | reset certificate permissions
+  file:
+    path: "{{ etcd_cert_dir }}"
+    group: "{{ etcd_cert_group }}"
+    state: directory
+    owner: kube
+    mode: "640"
+    recurse: yes

--- a/roles/etcd-recover/tasks/gen_certs_vault.yml
+++ b/roles/etcd-recover/tasks/gen_certs_vault.yml
@@ -1,0 +1,64 @@
+---
+- include_tasks: sync_etcd_master_certs.yml
+  when: inventory_hostname in groups.etcd
+  tags:
+    - etcd-secrets
+
+- include_tasks: sync_etcd_node_certs.yml
+  when: inventory_hostname in etcd_node_cert_hosts
+  tags:
+    - etcd-secrets
+
+# Issue master certs to Etcd nodes
+- include_tasks: ../../vault/tasks/shared/issue_cert.yml
+  vars:
+    issue_cert_common_name: "etcd:master:{{ item.rsplit('/', 1)[1].rsplit('.', 1)[0] }}"
+    issue_cert_alt_names: "{{ groups['etcd'] + ['localhost'] + (etcd_cert_alt_names)|default() }}"
+    issue_cert_copy_ca: "{{ item == etcd_master_certs_needed|first }}"
+    issue_cert_file_group: "{{ etcd_cert_group }}"
+    issue_cert_file_owner: kube
+    issue_cert_hosts: "{{ groups.etcd }}"
+    issue_cert_ip_sans: >-
+        [
+        {%- for host in groups.etcd  -%}
+        "{{ hostvars[host]['ansible_default_ipv4']['address'] }}",
+        {%- if hostvars[host]['ip'] is defined -%}
+        "{{ hostvars[host]['ip'] }}",
+        {%- endif -%}
+        {%- endfor -%}
+        "127.0.0.1","::1"
+        ]
+    issue_cert_path: "{{ item }}"
+    issue_cert_role: etcd
+    issue_cert_url: "{{ hostvars[groups.vault|first]['vault_leader_url'] }}"
+    issue_cert_mount_path: "{{ etcd_vault_mount_path }}"
+  with_items: "{{ etcd_master_certs_needed|d([]) }}"
+  when: inventory_hostname in groups.etcd
+  notify: set etcd_secret_changed
+
+# Issue node certs to everyone else
+- include_tasks: ../../vault/tasks/shared/issue_cert.yml
+  vars:
+    issue_cert_common_name: "etcd:node:{{ item.rsplit('/', 1)[1].rsplit('.', 1)[0] }}"
+    issue_cert_alt_names: "{{ etcd_node_cert_hosts }}"
+    issue_cert_copy_ca: "{{ item == etcd_node_certs_needed|first }}"
+    issue_cert_file_group: "{{ etcd_cert_group }}"
+    issue_cert_file_owner: kube
+    issue_cert_hosts: "{{ etcd_node_cert_hosts }}"
+    issue_cert_ip_sans: >-
+        [
+        {%- for host in etcd_node_cert_hosts -%}
+        "{{ hostvars[host]['ansible_default_ipv4']['address'] }}",
+        {%- if hostvars[host]['ip'] is defined -%}
+        "{{ hostvars[host]['ip'] }}",
+        {%- endif -%}
+        {%- endfor -%}
+        "127.0.0.1","::1"
+        ]
+    issue_cert_path: "{{ item }}"
+    issue_cert_role: etcd
+    issue_cert_url: "{{ hostvars[groups.vault|first]['vault_leader_url'] }}"
+    issue_cert_mount_path: "{{ etcd_vault_mount_path }}"
+  with_items: "{{ etcd_node_certs_needed|d([]) }}"
+  when: inventory_hostname in etcd_node_cert_hosts
+  notify: set etcd_secret_changed

--- a/roles/etcd-recover/tasks/install_docker.yml
+++ b/roles/etcd-recover/tasks/install_docker.yml
@@ -1,0 +1,30 @@
+---
+- name: Install | Copy etcdctl binary from docker container
+  command: sh -c "{{ docker_bin_dir }}/docker rm -f etcdctl-binarycopy;
+           {{ docker_bin_dir }}/docker create --name etcdctl-binarycopy {{ etcd_image_repo }}:{{ etcd_image_tag }} &&
+           {{ docker_bin_dir }}/docker cp etcdctl-binarycopy:/usr/local/bin/etcdctl {{ bin_dir }}/etcdctl &&
+           {{ docker_bin_dir }}/docker rm -f etcdctl-binarycopy"
+  register: etcd_task_result
+  until: etcd_task_result.rc == 0
+  retries: 4
+  delay: "{{ retry_stagger | random + 3 }}"
+  changed_when: false
+  when: etcd_cluster_setup
+
+- name: Install etcd launch script
+  template:
+    src: etcd.j2
+    dest: "{{ bin_dir }}/etcd"
+    owner: 'root'
+    mode: 0750
+    backup: yes
+  when: etcd_cluster_setup
+
+- name: Install etcd-events launch script
+  template:
+    src: etcd-events.j2
+    dest: "{{ bin_dir }}/etcd-events"
+    owner: 'root'
+    mode: 0750
+    backup: yes
+  when: etcd_events_cluster_setup

--- a/roles/etcd-recover/tasks/install_host.yml
+++ b/roles/etcd-recover/tasks/install_host.yml
@@ -1,0 +1,13 @@
+---
+- name: Install | Copy etcdctl and etcd binary from docker container
+  command: sh -c "{{ docker_bin_dir }}/docker rm -f etcdctl-binarycopy;
+           {{ docker_bin_dir }}/docker create --name etcdctl-binarycopy {{ etcd_image_repo }}:{{ etcd_image_tag }} &&
+           {{ docker_bin_dir }}/docker cp etcdctl-binarycopy:/usr/local/bin/etcdctl {{ bin_dir }}/etcdctl &&
+           {{ docker_bin_dir }}/docker cp etcdctl-binarycopy:/usr/local/bin/etcd {{ bin_dir }}/etcd &&
+           {{ docker_bin_dir }}/docker rm -f etcdctl-binarycopy"
+  register: etcd_task_result
+  until: etcd_task_result.rc == 0
+  retries: 4
+  delay: "{{ retry_stagger | random + 3 }}"
+  changed_when: false
+  when: etcd_cluster_setup

--- a/roles/etcd-recover/tasks/install_rkt.yml
+++ b/roles/etcd-recover/tasks/install_rkt.yml
@@ -1,0 +1,30 @@
+---
+- name: Trust etcd container
+  command: >-
+    /usr/bin/rkt trust
+    --skip-fingerprint-review
+    --root
+    https://quay.io/aci-signing-key
+  register: etcd_rkt_trust_result
+  until: etcd_rkt_trust_result.rc == 0
+  retries: 4
+  delay: "{{ retry_stagger | random + 3 }}"
+  changed_when: false
+  environment: "{{proxy_env}}"
+  when: etcd_cluster_setup
+
+- name: Install | Copy etcdctl binary from rkt container
+  command: >-
+    /usr/bin/rkt run
+    --volume=bin-dir,kind=host,source={{ bin_dir}},readOnly=false
+    --mount=volume=bin-dir,target=/host/bin
+    {{ etcd_image_repo }}:{{ etcd_image_tag }}
+    --name=etcdctl-binarycopy
+    --exec=/bin/cp -- /usr/local/bin/etcdctl /host/bin/etcdctl
+  register: etcd_task_result
+  until: etcd_task_result.rc == 0
+  retries: 4
+  delay: "{{ retry_stagger | random + 3 }}"
+  changed_when: false
+  environment: "{{proxy_env}}"
+  when: etcd_cluster_setup

--- a/roles/etcd-recover/tasks/join_etcd-events_member.yml
+++ b/roles/etcd-recover/tasks/join_etcd-events_member.yml
@@ -1,0 +1,36 @@
+---
+- name: Join Member | Add member to etcd-events cluster
+  shell: "{{ bin_dir }}/etcdctl --endpoints={{ etcd_events_access_addresses }} member add {{ etcd_member_name_recover }} {{ etcd_events_peer_url }}"
+  register: member_add_result
+  until: member_add_result.rc == 0
+  retries: 4
+  delay: "{{ retry_stagger | random + 3 }}"
+  when: target_node == inventory_hostname
+  environment:
+    ETCDCTL_CERT_FILE: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}.pem"
+    ETCDCTL_KEY_FILE: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}-key.pem"
+
+- include_tasks: refresh_config.yml
+  vars:
+    etcd_events_peer_addresses_recover: >-
+      {% for host in groups['etcd'] -%}
+        {%- if hostvars[host]['etcd_events_member_in_cluster'].rc == 0 -%}
+          {{ "etcd"+loop.index|string }}=https://{{ hostvars[host].access_ip | default(hostvars[host].ip | default(hostvars[host].ansible_default_ipv4['address'])) }}:2382,
+        {%- endif -%}
+        {%- if loop.last -%}
+          {{ etcd_member_name_recover }}={{ etcd_events_peer_url }}
+        {%- endif -%}
+      {%- endfor -%}
+  when: target_node == inventory_hostname
+
+- name: Join Member | Ensure member is in etcd-events cluster
+  shell: "{{ bin_dir }}/etcdctl --no-sync --endpoints={{ etcd_events_access_addresses }} member list | grep -q {{ etcd_events_access_addresses }}"
+  register: etcd_events_member_in_cluster
+  changed_when: false
+  check_mode: no
+  tags:
+    - facts
+  when: target_node == inventory_hostname
+  environment:
+    ETCDCTL_CERT_FILE: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}.pem"
+    ETCDCTL_KEY_FILE: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}-key.pem"

--- a/roles/etcd-recover/tasks/join_etcd_member.yml
+++ b/roles/etcd-recover/tasks/join_etcd_member.yml
@@ -1,0 +1,36 @@
+---
+- name: Join Member | Add member to etcd cluster
+  shell: "{{ bin_dir }}/etcdctl --endpoints={{ etcd_access_addresses }} member add {{ etcd_member_name_recover }} {{ etcd_peer_url }}"
+  register: member_add_result
+  until: member_add_result.rc == 0
+  retries: 4
+  delay: "{{ retry_stagger | random + 3 }}"
+  when: target_node == inventory_hostname
+  environment:
+    ETCDCTL_CERT_FILE: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}.pem"
+    ETCDCTL_KEY_FILE: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}-key.pem"
+
+- include_tasks: refresh_config.yml
+  vars:
+    etcd_peer_addresses_recover: >-
+      {% for host in groups['etcd'] -%}
+        {%- if hostvars[host]['etcd_member_in_cluster'].rc == 0 -%}
+          {{ "etcd"+loop.index|string }}=https://{{ hostvars[host].access_ip | default(hostvars[host].ip | default(hostvars[host].ansible_default_ipv4['address'])) }}:2380,
+        {%- endif -%}
+        {%- if loop.last -%}
+          {{ etcd_member_name_recover }}={{ etcd_peer_url }}
+        {%- endif -%}
+      {%- endfor -%}
+  when: target_node == inventory_hostname
+
+- name: Join Member | Ensure member is in etcd cluster
+  shell: "{{ bin_dir }}/etcdctl --no-sync --endpoints={{ etcd_access_addresses }} member list | grep -q {{ etcd_access_address }}"
+  register: etcd_member_in_cluster
+  changed_when: false
+  check_mode: no
+  tags:
+    - facts
+  when: target_node == inventory_hostname
+  environment:
+    ETCDCTL_CERT_FILE: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}.pem"
+    ETCDCTL_KEY_FILE: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}-key.pem"

--- a/roles/etcd-recover/tasks/main.yml
+++ b/roles/etcd-recover/tasks/main.yml
@@ -1,0 +1,34 @@
+---
+- include_tasks: check_certs.yml
+  when: cert_management == "script"
+  tags:
+    - etcd-secrets
+    - facts
+
+- include_tasks: "gen_certs_{{ cert_management }}.yml"
+  tags:
+    - etcd-secrets
+
+- include_tasks: upd_ca_trust.yml
+  tags:
+    - etcd-secrets
+
+- name: "Gen_certs | Get etcd certificate serials"
+  shell: "openssl x509 -in {{ etcd_cert_dir }}/node-{{ inventory_hostname }}.pem -noout -serial | cut -d= -f2"
+  register: "etcd_client_cert_serial_result"
+  changed_when: false
+  when: inventory_hostname in groups['etcd']|union(groups['k8s-cluster'])|union(groups['calico-rr']|default([]))|unique|sort
+
+- name: Set etcd_client_cert_serial
+  set_fact:
+    etcd_client_cert_serial: "{{ etcd_client_cert_serial_result.stdout }}"
+  when: inventory_hostname in groups['etcd']|union(groups['k8s-cluster'])|union(groups['calico-rr']|default([]))|unique|sort
+
+- include_tasks: "install_{{ etcd_deployment_type }}.yml"
+  when: is_etcd_master
+  tags:
+    - upgrade
+
+- include_tasks: configure.yml
+  when: is_etcd_master
+

--- a/roles/etcd-recover/tasks/refresh_config.yml
+++ b/roles/etcd-recover/tasks/refresh_config.yml
@@ -1,0 +1,14 @@
+---
+- name: Refresh config | Create etcd config file
+  template:
+    src: etcd.env.j2
+    dest: /etc/etcd.env
+  notify: restart etcd
+  when: is_etcd_master and etcd_cluster_setup 
+
+- name: Refresh config | Create etcd-events config file
+  template:
+    src: etcd-events.env.j2
+    dest: /etc/etcd-events.env
+  notify: restart etcd
+  when: is_etcd_master and etcd_events_cluster_setup 

--- a/roles/etcd-recover/tasks/remove_fault_etcd.yml
+++ b/roles/etcd-recover/tasks/remove_fault_etcd.yml
@@ -1,0 +1,105 @@
+---
+- name: Configure | Check if etcd cluster is healthy
+  shell: "{{ bin_dir }}/etcdctl --endpoints={{ etcd_access_addresses_old }} cluster-health | grep -q 'cluster is healthy'"
+  register: etcd_cluster_is_healthy_rm
+  ignore_errors: true
+  changed_when: false
+  check_mode: no
+  when: is_etcd_master and etcd_cluster_setup
+  tags:
+    - facts
+  environment:
+    ETCDCTL_CERT_FILE: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}.pem"
+    ETCDCTL_KEY_FILE: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}-key.pem"
+
+- name: Configure | Check if etcd-events cluster is healthy
+  shell: "{{ bin_dir }}/etcdctl --endpoints={{ etcd_events_access_addresses_old }} cluster-health | grep -q 'cluster is healthy'"
+  register: etcd_events_cluster_is_healthy_rm
+  ignore_errors: true
+  changed_when: false
+  check_mode: no
+  when: is_etcd_master and etcd_events_cluster_setup
+  tags:
+    - facts
+  environment:
+    ETCDCTL_CERT_FILE: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}.pem"
+    ETCDCTL_KEY_FILE: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}-key.pem"
+
+
+- name: Configure | Check if member is in etcd cluster
+  shell: "{{ bin_dir }}/etcdctl --no-sync --endpoints={{ etcd_access_addresses_old }} member list | grep {{ hostvars[groups['etcd-remove'][0]].ip }}"
+  register: etcd_member_in_cluster_rm
+  failed_when: false
+  changed_when: false
+  check_mode: no
+  when: is_etcd_master and etcd_cluster_setup and etcd_cluster_is_healthy_rm.rc == 0
+  tags:
+    - facts
+  environment:
+    ETCDCTL_CERT_FILE: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}.pem"
+    ETCDCTL_KEY_FILE: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}-key.pem"
+
+- name: Configure | Check if member is in etcd-events cluster
+  shell: "{{ bin_dir }}/etcdctl --no-sync --endpoints={{ etcd_events_access_addresses_old }} member list | grep {{ hostvars[groups['etcd-remove'][0]].ip }}"
+  register: etcd_events_member_in_cluster_rm
+  failed_when: false
+  changed_when: false
+  check_mode: no
+  when: is_etcd_master and etcd_events_cluster_setup and etcd_events_cluster_is_healthy_rm.rc == 0
+  #with_items: "{{ groups['etcd-remove'] }}"
+  tags:
+    - facts
+  environment:
+    ETCDCTL_CERT_FILE: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}.pem"
+    ETCDCTL_KEY_FILE: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}-key.pem"
+
+- name: Configure | Get etcd id being removed
+  shell: "{{ bin_dir }}/etcdctl --no-sync --endpoints={{ etcd_access_addresses_old }} member list | grep {{ hostvars[groups['etcd-remove'][0]]['ip'] }} | awk 'BEGIN{FS=\":\"}{printf substr($1,0,16)}'"
+  register: etcd_remove_id
+  ignore_errors: true
+  changed_when: false
+  check_mode: no
+  when: is_etcd_master and etcd_cluster_setup and etcd_cluster_is_healthy_rm.rc == 0 and etcd_member_in_cluster_rm.rc == 0
+  tags:
+    - facts
+  environment:
+    ETCDCTL_CERT_FILE: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}.pem"
+    ETCDCTL_KEY_FILE: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}-key.pem"
+
+- name: Configure | Get etcd-events id being removed
+  shell: "{{ bin_dir }}/etcdctl --no-sync --endpoints={{ etcd_events_access_addresses_old }} member list | grep {{ hostvars[groups['etcd-remove'][0]]['ip'] }} | awk 'BEGIN{FS=\":\"}{printf substr($1,0,16)}'"
+  register: etcd_events_remove_id
+  ignore_errors: true
+  changed_when: false
+  check_mode: no
+  when: is_etcd_master and etcd_events_cluster_setup and etcd_events_cluster_is_healthy_rm.rc == 0 and etcd_member_in_cluster_rm.rc == 0
+  tags:
+    - facts
+  environment:
+    ETCDCTL_CERT_FILE: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}.pem"
+    ETCDCTL_KEY_FILE: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}-key.pem"
+  
+- name: Configure | Remove member from etcd cluster
+  shell: "{{ bin_dir }}/etcdctl --peers={{ etcd_access_addresses_old }} member remove {{ etcd_remove_id.stdout }}"
+  ignore_errors: true
+  changed_when: false
+  check_mode: no
+  when: is_etcd_master and etcd_cluster_setup and etcd_cluster_is_healthy_rm.rc == 0 and etcd_member_in_cluster_rm.rc == 0 and etcd_remove_id.stdout != ""
+  tags:
+    - facts
+  environment:
+    ETCDCTL_CERT_FILE: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}.pem"
+    ETCDCTL_KEY_FILE: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}-key.pem"
+
+- name: Configure | Remove member from etcd-events cluster
+  shell: "{{ bin_dir }}/etcdctl --peers={{ etcd_events_access_addresses_old }} member remove {{ etcd_events_remove_id.stdout }}"
+  ignore_errors: true
+  changed_when: false
+  check_mode: no
+  when: is_etcd_master and etcd_events_cluster_setup and etcd_events_cluster_is_healthy_rm.rc == 0 and etcd_events_member_in_cluster_rm.rc == 0 and etcd_events_remove_id.stdout != "" 
+  tags:
+    - facts
+  environment:
+    ETCDCTL_CERT_FILE: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}.pem"
+    ETCDCTL_KEY_FILE: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}-key.pem"
+

--- a/roles/etcd-recover/tasks/remove_fault_master.yml
+++ b/roles/etcd-recover/tasks/remove_fault_master.yml
@@ -1,0 +1,26 @@
+- name: Clean | get fault k8s master minion info from etcd
+  shell: "{{ bin_dir }}/etcdctl --endpoints={{ etcd_access_addresses }} get /registry/minions/{{ item }} --prefix --keys-only"
+  register: result
+  ignore_errors: true
+  changed_when: false
+  check_mode: no
+  with_items: "{{ groups['master-remove'] }}"
+  environment:
+    ETCDCTL_CERT_FILE: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}.pem"
+    ETCDCTL_KEY_FILE: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}-key.pem"
+    ETCDCTL_API: 3
+
+- name: Clean | delete fault k8s master minion info from etcd, other info can be deleted by k8s
+  shell: "{{ bin_dir }}/etcdctl --endpoints={{ etcd_access_addresses }} del /registry/minions/{{ item }}"
+  when: result.stdout != ""
+  ignore_errors: true
+  changed_when: false
+  check_mode: no
+  with_items: "{{ groups['master-remove'] }}"
+  environment:
+    ETCDCTL_CERT_FILE: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}.pem"
+    ETCDCTL_KEY_FILE: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}-key.pem"
+    ETCDCTL_API: 3
+
+- name: debug
+  debug: msg="{{ result.stdout }}"

--- a/roles/etcd-recover/tasks/reset_etcd.yml
+++ b/roles/etcd-recover/tasks/reset_etcd.yml
@@ -1,0 +1,11 @@
+---
+- name: reset | delete some files and directories
+  file:
+    path: "{{ item }}"
+    state: absent
+  with_items:
+    - "{{ etcd_data_dir }}"
+    - "{{ etcd_events_data_dir }}"
+  ignore_errors: yes
+  tags:
+    - files

--- a/roles/etcd-recover/tasks/sync_etcd_master_certs.yml
+++ b/roles/etcd-recover/tasks/sync_etcd_master_certs.yml
@@ -1,0 +1,37 @@
+---
+
+- name: sync_etcd_master_certs | Create list of master certs needing creation
+  set_fact:
+    etcd_master_cert_list: >-
+        {{ etcd_master_cert_list|default([]) +  [
+        "admin-" + inventory_hostname + ".pem",
+        "member-" + inventory_hostname + ".pem"
+        ] }}
+
+- include_tasks: ../../vault/tasks/shared/sync_file.yml
+  vars:
+    sync_file: "{{ item }}"
+    sync_file_dir: "{{ etcd_cert_dir }}"
+    sync_file_hosts: [ "{{ inventory_hostname }}" ]
+    sync_file_is_cert: true
+  with_items: "{{ etcd_master_cert_list|d([]) }}"
+
+- name: sync_etcd_certs | Set facts for etcd sync_file results
+  set_fact:
+    etcd_master_certs_needed: "{{ etcd_master_certs_needed|default([]) + [item.path] }}"
+  with_items: "{{ sync_file_results|d([]) }}"
+  when: item.no_srcs|bool
+
+- name: sync_etcd_certs | Unset sync_file_results after etcd certs sync
+  set_fact:
+    sync_file_results: []
+
+- include_tasks: ../../vault/tasks/shared/sync_file.yml
+  vars:
+    sync_file: ca.pem
+    sync_file_dir: "{{ etcd_cert_dir }}"
+    sync_file_hosts: [ "{{ inventory_hostname }}" ]
+
+- name: sync_etcd_certs | Unset sync_file_results after ca.pem sync
+  set_fact:
+    sync_file_results: []

--- a/roles/etcd-recover/tasks/sync_etcd_node_certs.yml
+++ b/roles/etcd-recover/tasks/sync_etcd_node_certs.yml
@@ -1,0 +1,33 @@
+---
+
+- name: sync_etcd_node_certs | Create list of node certs needing creation
+  set_fact:
+    etcd_node_cert_list: "{{ etcd_node_cert_list|default([]) +  ['node-' + inventory_hostname + '.pem'] }}"
+
+- include_tasks: ../../vault/tasks/shared/sync_file.yml
+  vars:
+    sync_file: "{{ item }}"
+    sync_file_dir: "{{ etcd_cert_dir }}"
+    sync_file_hosts: [ "{{ inventory_hostname }}" ]
+    sync_file_is_cert: true
+  with_items: "{{ etcd_node_cert_list|d([]) }}"
+
+- name: sync_etcd_node_certs | Set facts for etcd sync_file results
+  set_fact:
+    etcd_node_certs_needed: "{{ etcd_node_certs_needed|default([]) + [item.path] }}"
+  with_items: "{{ sync_file_results|d([]) }}"
+  when: item.no_srcs|bool
+
+- name: sync_etcd_node_certs | Unset sync_file_results after etcd node certs
+  set_fact:
+    sync_file_results: []
+
+- include_tasks: ../../vault/tasks/shared/sync_file.yml
+  vars:
+    sync_file: ca.pem
+    sync_file_dir: "{{ etcd_cert_dir }}"
+    sync_file_hosts: "{{ groups['etcd'] }}"
+
+- name: sync_etcd_node_certs | Unset sync_file_results after ca.pem
+  set_fact:
+    sync_file_results: []

--- a/roles/etcd-recover/tasks/upd_ca_trust.yml
+++ b/roles/etcd-recover/tasks/upd_ca_trust.yml
@@ -1,0 +1,30 @@
+---
+- name: Gen_certs | target ca-certificate store file
+  set_fact:
+    ca_cert_path: |-
+      {% if ansible_os_family == "Debian" -%}
+      /usr/local/share/ca-certificates/etcd-ca.crt
+      {%- elif ansible_os_family == "RedHat" -%}
+      /etc/pki/ca-trust/source/anchors/etcd-ca.crt
+      {%- elif ansible_os_family in ["CoreOS", "Container Linux by CoreOS"] -%}
+      /etc/ssl/certs/etcd-ca.pem
+      {%- elif ansible_os_family == "Suse" -%}
+      /etc/pki/trust/anchors/etcd-ca.pem
+      {%- endif %}
+  tags:
+    - facts
+
+- name: Gen_certs | add CA to trusted CA dir
+  copy:
+    src: "{{ etcd_cert_dir }}/ca.pem"
+    dest: "{{ ca_cert_path }}"
+    remote_src: true
+  register: etcd_ca_cert
+
+- name: Gen_certs | update ca-certificates (Debian/Ubuntu/SUSE/Container Linux by CoreOS)
+  command: update-ca-certificates
+  when: etcd_ca_cert.changed and ansible_os_family in ["Debian", "CoreOS", "Container Linux by CoreOS", "Suse"]
+
+- name: Gen_certs | update ca-certificates (RedHat)
+  command: update-ca-trust extract
+  when: etcd_ca_cert.changed and ansible_os_family == "RedHat"

--- a/roles/etcd-recover/templates/etcd-docker.service.j2
+++ b/roles/etcd-recover/templates/etcd-docker.service.j2
@@ -1,0 +1,18 @@
+[Unit]
+Description=etcd docker wrapper
+Wants=docker.socket
+After=docker.service
+
+[Service]
+User=root
+PermissionsStartOnly=true
+EnvironmentFile=-/etc/etcd.env
+ExecStart={{ bin_dir }}/etcd
+ExecStartPre=-{{ docker_bin_dir }}/docker rm -f {{ etcd_member_name_recover | default("etcd") }}
+ExecStop={{ docker_bin_dir }}/docker stop {{ etcd_member_name_recover | default("etcd") }}
+Restart=always
+RestartSec=15s
+TimeoutStartSec=30s
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/etcd-recover/templates/etcd-events-docker.service.j2
+++ b/roles/etcd-recover/templates/etcd-events-docker.service.j2
@@ -1,0 +1,18 @@
+[Unit]
+Description=etcd docker wrapper
+Wants=docker.socket
+After=docker.service
+
+[Service]
+User=root
+PermissionsStartOnly=true
+EnvironmentFile=-/etc/etcd-events.env
+ExecStart={{ bin_dir }}/etcd-events
+ExecStartPre=-{{ docker_bin_dir }}/docker rm -f {{ etcd_member_name_recover }}-events
+ExecStop={{ docker_bin_dir }}/docker stop {{ etcd_member_name_recover }}-events
+Restart=always
+RestartSec=15s
+TimeoutStartSec=30s
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/etcd-recover/templates/etcd-events-host.service.j2
+++ b/roles/etcd-recover/templates/etcd-events-host.service.j2
@@ -1,0 +1,16 @@
+[Unit]
+Description=etcd
+After=network.target
+
+[Service]
+Type=notify
+User=root
+EnvironmentFile=/etc/etcd-events.env
+ExecStart={{ bin_dir }}/etcd
+NotifyAccess=all
+Restart=always
+RestartSec=10s
+LimitNOFILE=40000
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/etcd-recover/templates/etcd-events-rkt.service.j2
+++ b/roles/etcd-recover/templates/etcd-events-rkt.service.j2
@@ -1,0 +1,31 @@
+[Unit]
+Description=etcd events rkt wrapper
+Documentation=https://github.com/coreos/etcd
+Wants=network.target
+
+[Service]
+Restart=on-failure
+RestartSec=10s
+TimeoutStartSec=0
+LimitNOFILE=40000
+
+ExecStart=/usr/bin/rkt run \
+--uuid-file-save=/var/run/etcd-events.uuid \
+--volume hosts,kind=host,source=/etc/hosts,readOnly=true \
+--mount volume=hosts,target=/etc/hosts \
+--volume=etc-ssl-certs,kind=host,source=/etc/ssl/certs,readOnly=true \
+--mount=volume=etc-ssl-certs,target=/etc/ssl/certs \
+--volume=etcd-cert-dir,kind=host,source={{ etcd_cert_dir }},readOnly=true \
+--mount=volume=etcd-cert-dir,target={{ etcd_cert_dir }} \
+--volume=etcd-data-dir,kind=host,source={{ etcd_events_data_dir }},readOnly=false \
+--mount=volume=etcd-data-dir,target={{ etcd_events_data_dir }} \
+--set-env-file=/etc/etcd-events.env \
+--stage1-from-dir=stage1-fly.aci \
+{{ etcd_image_repo }}:{{ etcd_image_tag }} \
+--name={{ etcd_member_name_recover | default("etcd-events") }}
+
+ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/run/etcd-events.uuid
+ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/etcd-events.uuid
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/etcd-recover/templates/etcd-events.env.j2
+++ b/roles/etcd-recover/templates/etcd-events.env.j2
@@ -1,0 +1,29 @@
+ETCD_DATA_DIR={{ etcd_events_data_dir }}
+ETCD_ADVERTISE_CLIENT_URLS={{ etcd_events_client_url }}
+ETCD_INITIAL_ADVERTISE_PEER_URLS={{ etcd_events_peer_url }}
+ETCD_INITIAL_CLUSTER_STATE={% if etcd_events_cluster_is_healthy.rc != 0 | bool %}new{% else %}existing{% endif %}
+
+ETCD_METRICS={{ etcd_metrics }}
+ETCD_LISTEN_CLIENT_URLS=https://{{ etcd_address }}:2381,https://127.0.0.1:2381
+ETCD_ELECTION_TIMEOUT={{ etcd_election_timeout }}
+ETCD_HEARTBEAT_INTERVAL={{ etcd_heartbeat_interval }}
+ETCD_INITIAL_CLUSTER_TOKEN=k8s_events_etcd
+ETCD_LISTEN_PEER_URLS=https://{{ etcd_address }}:2382
+ETCD_NAME={{ etcd_member_name_recover }}-events
+ETCD_PROXY=off
+ETCD_INITIAL_CLUSTER={{ etcd_events_peer_addresses_recover }}
+ETCD_AUTO_COMPACTION_RETENTION={{ etcd_compaction_retention }}
+{% if etcd_snapshot_count is defined %}
+ETCD_SNAPSHOT_COUNT={{ etcd_snapshot_count }}
+{% endif %}
+
+# TLS settings
+ETCD_TRUSTED_CA_FILE={{ etcd_cert_dir }}/ca.pem
+ETCD_CERT_FILE={{ etcd_cert_dir }}/member-{{ inventory_hostname }}.pem
+ETCD_KEY_FILE={{ etcd_cert_dir }}/member-{{ inventory_hostname }}-key.pem
+ETCD_CLIENT_CERT_AUTH={{ etcd_secure_client | lower}}
+
+ETCD_PEER_TRUSTED_CA_FILE={{ etcd_cert_dir }}/ca.pem
+ETCD_PEER_CERT_FILE={{ etcd_cert_dir }}/member-{{ inventory_hostname }}.pem
+ETCD_PEER_KEY_FILE={{ etcd_cert_dir }}/member-{{ inventory_hostname }}-key.pem
+ETCD_PEER_CLIENT_CERT_AUTH={{ etcd_peer_client_auth }}

--- a/roles/etcd-recover/templates/etcd-events.j2
+++ b/roles/etcd-recover/templates/etcd-events.j2
@@ -1,0 +1,21 @@
+#!/bin/bash
+{{ docker_bin_dir }}/docker run \
+  --restart=on-failure:5 \
+  --env-file=/etc/etcd-events.env \
+  --net=host \
+  -v /etc/ssl/certs:/etc/ssl/certs:ro \
+  -v {{ etcd_cert_dir }}:{{ etcd_cert_dir }}:ro \
+  -v {{ etcd_events_data_dir }}:{{ etcd_events_data_dir }}:rw \
+  {% if etcd_memory_limit is defined %}
+  --memory={{ etcd_memory_limit|regex_replace('Mi', 'M') }} \
+  {% endif %}
+  {% if etcd_cpu_limit is defined %}
+  --cpu-shares={{ etcd_cpu_limit|regex_replace('m', '') }} \
+  {% endif %}
+  {% if etcd_blkio_weight is defined %}
+  --blkio-weight={{ etcd_blkio_weight }} \
+  {% endif %}
+  --name={{ etcd_member_name_recover }}-events \
+  {{ etcd_image_repo }}:{{ etcd_image_tag }} \
+  /usr/local/bin/etcd \
+  "$@"

--- a/roles/etcd-recover/templates/etcd-host.service.j2
+++ b/roles/etcd-recover/templates/etcd-host.service.j2
@@ -1,0 +1,16 @@
+[Unit]
+Description=etcd
+After=network.target
+
+[Service]
+Type=notify
+User=root
+EnvironmentFile=/etc/etcd.env
+ExecStart={{ bin_dir }}/etcd
+NotifyAccess=all
+Restart=always
+RestartSec=10s
+LimitNOFILE=40000
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/etcd-recover/templates/etcd-rkt.service.j2
+++ b/roles/etcd-recover/templates/etcd-rkt.service.j2
@@ -1,0 +1,31 @@
+[Unit]
+Description=etcd rkt wrapper
+Documentation=https://github.com/coreos/etcd
+Wants=network.target
+
+[Service]
+Restart=on-failure
+RestartSec=10s
+TimeoutStartSec=0
+LimitNOFILE=40000
+
+ExecStart=/usr/bin/rkt run \
+--uuid-file-save=/var/run/etcd.uuid \
+--volume hosts,kind=host,source=/etc/hosts,readOnly=true \
+--mount volume=hosts,target=/etc/hosts \
+--volume=etc-ssl-certs,kind=host,source=/etc/ssl/certs,readOnly=true \
+--mount=volume=etc-ssl-certs,target=/etc/ssl/certs \
+--volume=etcd-cert-dir,kind=host,source={{ etcd_cert_dir }},readOnly=true \
+--mount=volume=etcd-cert-dir,target={{ etcd_cert_dir }} \
+--volume=etcd-data-dir,kind=host,source={{ etcd_data_dir }},readOnly=false \
+--mount=volume=etcd-data-dir,target={{ etcd_data_dir }} \
+--set-env-file=/etc/etcd.env \
+--stage1-from-dir=stage1-fly.aci \
+{{ etcd_image_repo }}:{{ etcd_image_tag }} \
+--name={{ etcd_member_name_recover | default("etcd") }}
+
+ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/run/etcd.uuid
+ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/etcd.uuid
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/etcd-recover/templates/etcd.env.j2
+++ b/roles/etcd-recover/templates/etcd.env.j2
@@ -1,0 +1,33 @@
+ETCD_DATA_DIR={{ etcd_data_dir }}
+ETCD_ADVERTISE_CLIENT_URLS={{ etcd_client_url }}
+ETCD_INITIAL_ADVERTISE_PEER_URLS={{ etcd_peer_url }}
+ETCD_INITIAL_CLUSTER_STATE={% if etcd_cluster_is_healthy.rc != 0 | bool %}new{% else %}existing{% endif %}
+
+ETCD_METRICS={{ etcd_metrics }}
+ETCD_LISTEN_CLIENT_URLS=https://{{ etcd_address }}:2379,https://127.0.0.1:2379
+ETCD_ELECTION_TIMEOUT={{ etcd_election_timeout }}
+ETCD_HEARTBEAT_INTERVAL={{ etcd_heartbeat_interval }}
+ETCD_INITIAL_CLUSTER_TOKEN=k8s_etcd
+ETCD_LISTEN_PEER_URLS=https://{{ etcd_address }}:2380
+ETCD_NAME={{ etcd_member_name_recover }}
+ETCD_PROXY=off
+ETCD_INITIAL_CLUSTER={{ etcd_peer_addresses_recover }}
+ETCD_AUTO_COMPACTION_RETENTION={{ etcd_compaction_retention }}
+{% if etcd_snapshot_count is defined %}
+ETCD_SNAPSHOT_COUNT={{ etcd_snapshot_count }}
+{% endif %}
+
+# TLS settings
+ETCD_TRUSTED_CA_FILE={{ etcd_cert_dir }}/ca.pem
+ETCD_CERT_FILE={{ etcd_cert_dir }}/member-{{ inventory_hostname }}.pem
+ETCD_KEY_FILE={{ etcd_cert_dir }}/member-{{ inventory_hostname }}-key.pem
+ETCD_CLIENT_CERT_AUTH={{ etcd_secure_client | lower}}
+
+ETCD_PEER_TRUSTED_CA_FILE={{ etcd_cert_dir }}/ca.pem
+ETCD_PEER_CERT_FILE={{ etcd_cert_dir }}/member-{{ inventory_hostname }}.pem
+ETCD_PEER_KEY_FILE={{ etcd_cert_dir }}/member-{{ inventory_hostname }}-key.pem
+ETCD_PEER_CLIENT_CERT_AUTH={{ etcd_peer_client_auth }}
+
+{% for key, value in etcd_extra_vars.items() %}
+{{ key }}={{ value }}
+{% endfor %}

--- a/roles/etcd-recover/templates/etcd.j2
+++ b/roles/etcd-recover/templates/etcd.j2
@@ -1,0 +1,24 @@
+#!/bin/bash
+{{ docker_bin_dir }}/docker run \
+  --restart=on-failure:5 \
+  --env-file=/etc/etcd.env \
+  --net=host \
+  -v /etc/ssl/certs:/etc/ssl/certs:ro \
+  -v {{ etcd_cert_dir }}:{{ etcd_cert_dir }}:ro \
+  -v {{ etcd_data_dir }}:{{ etcd_data_dir }}:rw \
+{% if etcd_memory_limit is defined %}
+  --memory={{ etcd_memory_limit|regex_replace('Mi', 'M') }} \
+{% endif %}
+{% if etcd_cpu_limit is defined %}
+  --cpu-shares={{ etcd_cpu_limit|regex_replace('m', '') }} \
+{% endif %}
+{% if etcd_blkio_weight is defined %}
+  --blkio-weight={{ etcd_blkio_weight }} \
+{% endif %}
+  --name={{ etcd_member_name_recover | default("etcd") }} \
+  {{ etcd_image_repo }}:{{ etcd_image_tag }} \
+{% if etcd_ionice is defined %}
+  /bin/ionice {{ etcd_ionice }} \
+{% endif %}
+  /usr/local/bin/etcd \
+  "$@"

--- a/roles/etcd-recover/templates/openssl.conf.j2
+++ b/roles/etcd-recover/templates/openssl.conf.j2
@@ -1,0 +1,42 @@
+{% set counter = {'dns': 2,'ip': 1,} %}{% macro increment(dct, key, inc=1)%}{% if dct.update({key: dct[key] + inc}) %} {% endif %}{% endmacro %}[req]
+req_extensions = v3_req
+distinguished_name = req_distinguished_name
+
+[req_distinguished_name]
+
+[ v3_req ]
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+subjectAltName = @alt_names
+
+[ ssl_client ]
+extendedKeyUsage = clientAuth, serverAuth
+basicConstraints = CA:FALSE
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid,issuer
+subjectAltName = @alt_names
+
+[ v3_ca ]
+basicConstraints = CA:TRUE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+subjectAltName = @alt_names
+authorityKeyIdentifier=keyid:always,issuer
+
+[alt_names]
+DNS.1 = localhost
+{% for host in groups['etcd'] %}
+DNS.{{ counter["dns"] }} = {{ host }}{{ increment(counter, 'dns') }}
+{% endfor %}
+{% if apiserver_loadbalancer_domain_name is defined %}
+DNS.{{ counter["dns"] }} = {{ apiserver_loadbalancer_domain_name }}{{ increment(counter, 'dns') }}
+{% endif %}
+{% for etcd_alt_name in etcd_cert_alt_names %}
+DNS.{{ counter["dns"] }} = {{ etcd_alt_name }}{{ increment(counter, 'dns') }}
+{% endfor %}
+{% for host in groups['etcd'] %}
+{% if hostvars[host]['access_ip'] is defined  %}
+IP.{{ counter["ip"] }} = {{ hostvars[host]['access_ip'] }}{{ increment(counter, 'ip') }}
+{% endif %}
+IP.{{ counter["ip"] }} = {{ hostvars[host]['ip'] | default(hostvars[host]['ansible_default_ipv4']['address']) }}{{ increment(counter, 'ip') }}
+{% endfor %}
+IP.{{ counter["ip"] }} = 127.0.0.1

--- a/roles/kubernetes-recover/client/defaults/main.yml
+++ b/roles/kubernetes-recover/client/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+kubeconfig_localhost: false
+kubectl_localhost: false
+artifacts_dir: "{{ inventory_dir }}/artifacts"
+
+kube_config_dir: "/etc/kubernetes"
+kube_apiserver_port: "6443"

--- a/roles/kubernetes-recover/client/tasks/main.yml
+++ b/roles/kubernetes-recover/client/tasks/main.yml
@@ -1,0 +1,75 @@
+---
+- name: Set external kube-apiserver endpoint
+  set_fact:
+    external_apiserver_endpoint: >-
+      {%- if loadbalancer_apiserver is defined and loadbalancer_apiserver.port is defined -%}
+      https://{{ apiserver_loadbalancer_domain_name }}:{{ loadbalancer_apiserver.port|default(kube_apiserver_port) }}
+      {%- else -%}
+      https://{{ kube_apiserver_access_address }}:{{ kube_apiserver_port }}
+      {%- endif -%}
+  tags:
+    - facts
+
+- name: Gather certs for admin kubeconfig
+  slurp:
+    src: "{{ item }}"
+  register: admin_certs
+  with_items:
+    - "{{ kube_cert_dir }}/ca.pem"
+    - "{{ kube_cert_dir }}/admin-{{ inventory_hostname }}.pem"
+    - "{{ kube_cert_dir }}/admin-{{ inventory_hostname }}-key.pem"
+  when: not kubeadm_enabled|d(false)|bool
+
+- name: Write admin kubeconfig
+  template:
+    src: admin.conf.j2
+    dest: "{{ kube_config_dir }}/admin.conf"
+    owner: root
+    group: "{{ kube_cert_group }}"
+    mode: 0640
+  when: not kubeadm_enabled|d(false)|bool
+
+- name: Create kube config dir
+  file:
+    path: "/root/.kube"
+    mode: "0700"
+    state: directory
+
+- name: Copy admin kubeconfig to root user home
+  copy:
+    src: "{{ kube_config_dir }}/admin.conf"
+    dest: "/root/.kube/config"
+    remote_src: yes
+    mode: "0600"
+    backup: yes
+
+- name: Copy admin kubeconfig to ansible host
+  fetch:
+    src: "{{ kube_config_dir }}/admin.conf"
+    dest: "{{ artifacts_dir }}/admin.conf"
+    flat: yes
+    validate_checksum: no
+  run_once: yes
+  when: kubeconfig_localhost|default(false)
+
+- name: Copy kubectl binary to ansible host
+  fetch:
+    src: "{{ bin_dir }}/kubectl"
+    dest: "{{ artifacts_dir }}/kubectl"
+    flat: yes
+    validate_checksum: no
+  become: no
+  run_once: yes
+  when: kubectl_localhost|default(false)
+
+- name: create helper script kubectl.sh on ansible host
+  copy:
+    content: |
+      #!/bin/bash
+      kubectl --kubeconfig=admin.conf $@
+    dest: "{{ artifacts_dir }}/kubectl.sh"
+    mode: 0755
+  become: no
+  run_once: yes
+  delegate_to: localhost
+  when: kubectl_localhost|default(false) and kubeconfig_localhost|default(false)

--- a/roles/kubernetes-recover/client/templates/admin.conf.j2
+++ b/roles/kubernetes-recover/client/templates/admin.conf.j2
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Config
+current-context: admin-{{ cluster_name }}
+preferences: {}
+clusters:
+- cluster:
+    certificate-authority-data: {{ admin_certs.results[0]['content'] }}
+    server: {{ external_apiserver_endpoint }}
+  name: {{ cluster_name }}
+contexts:
+- context:
+    cluster: {{ cluster_name }}
+    user: admin-{{ cluster_name }}
+  name: admin-{{ cluster_name }}
+users:
+- name: admin-{{ cluster_name }}
+  user:
+    client-certificate-data: {{ admin_certs.results[1]['content'] }}
+    client-key-data: {{ admin_certs.results[2]['content'] }}

--- a/roles/kubernetes-recover/kubeadm/handlers/main.yml
+++ b/roles/kubernetes-recover/kubeadm/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: restart kubelet
+  service:
+    name: kubelet
+    state: restarted

--- a/roles/kubernetes-recover/kubeadm/tasks/main.yml
+++ b/roles/kubernetes-recover/kubeadm/tasks/main.yml
@@ -1,0 +1,71 @@
+---
+- name: Set kubeadm_discovery_address
+  set_fact:
+    kubeadm_discovery_address: >-
+      {%- if "127.0.0.1" or "localhost" in kube_apiserver_endpoint -%}
+      {{ first_kube_master }}:{{ kube_apiserver_port }}
+      {%- else -%}
+      {{ kube_apiserver_endpoint }}
+      {%- endif %}
+  when: not is_kube_master
+  tags:
+    - facts
+
+- name: Check if kubelet.conf exists
+  stat:
+    path: "{{ kube_config_dir }}/kubelet.conf"
+  register: kubelet_conf
+
+- name: Calculate kubeadm CA cert hash
+  shell: openssl x509 -pubkey -in {{ kube_config_dir }}/ssl/ca.crt | openssl rsa -pubin -outform der 2>/dev/null | openssl dgst -sha256 -hex | sed 's/^.* //'
+  register: kubeadm_ca_hash
+  delegate_to: "{{ groups['kube-master'][0] }}"
+  run_once: true
+
+- name: Create kubeadm token for joining nodes with 24h expiration (default)
+  command: "{{ bin_dir }}/kubeadm token create"
+  run_once: true
+  register: temp_token
+  delegate_to: "{{ groups['kube-master'][0] }}"
+
+- name: Create kubeadm client config
+  template:
+    src: kubeadm-client.conf.j2
+    dest: "{{ kube_config_dir }}/kubeadm-client.conf"
+    backup: yes
+  when: not is_kube_master
+  vars:
+    kubeadm_token: "{{ temp_token.stdout }}"
+  register: kubeadm_client_conf
+
+- name: Join to cluster if needed
+  command: >-
+    {{ bin_dir }}/kubeadm join
+    --config {{ kube_config_dir}}/kubeadm-client.conf
+    --ignore-preflight-errors=all
+  register: kubeadm_join
+  when: not is_kube_master and (kubeadm_client_conf.changed or not kubelet_conf.stat.exists)
+
+- name: Wait for kubelet bootstrap to create config
+  wait_for:
+    path: "{{ kube_config_dir }}/kubelet.conf"
+    delay: 1
+    timeout: 60
+
+- name: Update server field in kubelet kubeconfig
+  lineinfile:
+    dest: "{{ kube_config_dir }}/kubelet.conf"
+    regexp: 'server:'
+    line: '    server: {{ kube_apiserver_endpoint }}'
+    backup: yes
+  when: not is_kube_master and kubeadm_discovery_address != kube_apiserver_endpoint
+  notify: restart kubelet
+
+# FIXME(mattymo): Reconcile kubelet kubeconfig filename for both deploy modes
+- name: Symlink kubelet kubeconfig for calico/canal
+  file:
+    src: "{{ kube_config_dir }}//kubelet.conf"
+    dest: "{{ kube_config_dir }}/node-kubeconfig.yaml"
+    state: link
+    force: yes
+  when: kube_network_plugin in ['calico','canal']

--- a/roles/kubernetes-recover/kubeadm/templates/kubeadm-client.conf.j2
+++ b/roles/kubernetes-recover/kubeadm/templates/kubeadm-client.conf.j2
@@ -1,0 +1,8 @@
+apiVersion: kubeadm.k8s.io/v1alpha1
+kind: NodeConfiguration
+caCertPath: {{ kube_config_dir }}/ssl/ca.crt
+token: {{ kubeadm_token }}
+discoveryTokenAPIServers:
+- {{ kubeadm_discovery_address | replace("https://", "")}}
+DiscoveryTokenCACertHashes:
+- sha256:{{ kubeadm_ca_hash.stdout }}

--- a/roles/kubernetes-recover/master/defaults/main.yml
+++ b/roles/kubernetes-recover/master/defaults/main.yml
@@ -1,0 +1,105 @@
+---
+# An experimental dev/test only dynamic volumes provisioner,
+# for PetSets. Works for kube>=v1.3 only.
+kube_hostpath_dynamic_provisioner: "false"
+
+# change to 0.0.0.0 to enable insecure access from anywhere (not recommended)
+kube_apiserver_insecure_bind_address: 127.0.0.1
+
+# By default the external API listens on all interfaces, this can be changed to
+# listen on a specific address/interface.
+kube_apiserver_bind_address: 0.0.0.0
+
+# A port range to reserve for services with NodePort visibility.
+# Inclusive at both ends of the range.
+kube_apiserver_node_port_range: "30000-32767"
+
+# ETCD cert dir for connecting apiserver to etcd
+etcd_config_dir: /etc/ssl/etcd
+etcd_cert_dir: "{{ etcd_config_dir }}/ssl"
+
+# ETCD backend for k8s data
+kube_apiserver_storage_backend: etcd3
+
+# By default, force back to etcd2. Set to true to force etcd3 (experimental!)
+force_etcd3: false
+
+# Limits for kube components
+kube_controller_memory_limit: 512M
+kube_controller_cpu_limit: 250m
+kube_controller_memory_requests: 100M
+kube_controller_cpu_requests: 100m
+kube_controller_node_monitor_grace_period: 40s
+kube_controller_node_monitor_period: 5s
+kube_controller_pod_eviction_timeout: 5m0s
+kube_scheduler_memory_limit: 512M
+kube_scheduler_cpu_limit: 250m
+kube_scheduler_memory_requests: 170M
+kube_scheduler_cpu_requests: 80m
+kube_apiserver_memory_limit: 2000M
+kube_apiserver_cpu_limit: 800m
+kube_apiserver_memory_requests: 256M
+kube_apiserver_cpu_requests: 100m
+
+# Admission control plug-ins
+kube_apiserver_admission_control:
+  - Initializers
+  - NamespaceLifecycle
+  - LimitRanger
+  - ServiceAccount
+  - DefaultStorageClass
+  - >-
+      {%- if kube_version | version_compare('v1.9', '<') -%}
+      GenericAdmissionWebhook
+      {%- else -%}
+      MutatingAdmissionWebhook,ValidatingAdmissionWebhook
+      {%- endif -%}
+  - ResourceQuota
+
+# extra runtime config
+kube_api_runtime_config:
+  - admissionregistration.k8s.io/v1alpha1
+
+## Enable/Disable Kube API Server Authentication Methods
+kube_basic_auth: false
+kube_token_auth: false
+kube_oidc_auth: false
+
+## Variables for OpenID Connect Configuration https://kubernetes.io/docs/admin/authentication/
+## To use OpenID you have to deploy additional an OpenID Provider (e.g Dex, Keycloak, ...)
+
+# kube_oidc_url: https:// ...
+# kube_oidc_client_id: kubernetes
+## Optional settings for OIDC
+# kube_oidc_ca_file: {{ kube_cert_dir }}/ca.pem
+# kube_oidc_username_claim: sub
+# kube_oidc_username_prefix: oidc:
+# kube_oidc_groups_claim: groups
+# kube_oidc_groups_prefix: oidc:
+
+## Variables for custom flags
+apiserver_custom_flags: []
+
+# List of the preferred NodeAddressTypes to use for kubelet connections.
+kubelet_preferred_address_types: 'InternalDNS,InternalIP,Hostname,ExternalDNS,ExternalIP'
+
+controller_mgr_custom_flags: []
+
+scheduler_custom_flags: []
+
+## Extra args for k8s components passing by kubeadm
+kube_kubeadm_apiserver_extra_args: {}
+kube_kubeadm_controller_extra_args: {}
+kube_kubeadm_scheduler_extra_args: {}
+
+## Variable for influencing kube-scheduler behaviour
+volume_cross_zone_attachment: false
+
+## Encrypting Secret Data at Rest
+kube_encrypt_secret_data: false
+kube_encrypt_token: "{{ lookup('password', inventory_dir + '/credentials/kube_encrypt_token.creds length=32 chars=ascii_letters,digits') }}"
+# Must be either: aescbc, secretbox or aesgcm
+kube_encryption_algorithm: "aescbc"
+
+# You may want to use ca.pem depending on your situation
+kube_front_proxy_ca: "front-proxy-ca.pem"

--- a/roles/kubernetes-recover/master/handlers/main.yml
+++ b/roles/kubernetes-recover/master/handlers/main.yml
@@ -1,0 +1,103 @@
+---
+- name: Master | restart kubelet
+  command: /bin/true
+  notify:
+    - Master | reload systemd
+    - Master | reload kubelet
+    - Master | wait for master static pods
+
+- name: Master | wait for master static pods
+  command: /bin/true
+  notify:
+    - Master | wait for the apiserver to be running
+    - Master | wait for kube-scheduler
+    - Master | wait for kube-controller-manager
+
+- name: Master | Restart apiserver
+  command: /bin/true
+  notify:
+    - Master | Remove apiserver container
+    - Master | wait for the apiserver to be running
+
+- name: Master | Restart kube-scheduler
+  command: /bin/true
+  notify:
+    - Master | Remove scheduler container
+    - Master | wait for kube-scheduler
+
+- name: Master | Restart kube-controller-manager
+  command: /bin/true
+  notify:
+    - Master | Remove controller manager container
+    - Master | wait for kube-controller-manager
+
+- name: Master | reload systemd
+  command: systemctl daemon-reload
+
+- name: Master | reload kubelet
+  service:
+    name: kubelet
+    state: restarted
+
+- name: Master | Remove apiserver container
+  shell: "docker ps -af name=k8s_kube-apiserver* -q | xargs --no-run-if-empty docker rm -f"
+  register: remove_apiserver_container
+  retries: 4
+  until: remove_apiserver_container.rc == 0
+  delay: 5
+
+- name: Master | Remove scheduler container
+  shell: "docker ps -af name=k8s_kube-scheduler* -q | xargs --no-run-if-empty docker rm -f"
+  register: remove_scheduler_container
+  retries: 4
+  until: remove_scheduler_container.rc == 0
+  delay: 5
+
+- name: Master | Remove controller manager container
+  shell: "docker ps -af name=k8s_kube-controller-manager* -q | xargs --no-run-if-empty docker rm -f"
+  register: remove_cm_container
+  retries: 4
+  until: remove_cm_container.rc == 0
+  delay: 5
+
+- name: Master | wait for kube-scheduler
+  uri:
+    url: http://localhost:10251/healthz
+  register: scheduler_result
+  until: scheduler_result.status == 200
+  retries: 60
+  delay: 5
+
+- name: Master | wait for kube-controller-manager
+  uri:
+    url: http://localhost:10252/healthz
+  register: controller_manager_result
+  until: controller_manager_result.status == 200
+  retries: 15
+  delay: 5
+
+- name: Master | wait for the apiserver to be running
+  uri:
+    url: "{{ kube_apiserver_endpoint }}/healthz"
+    validate_certs: no
+    client_cert: "{{ kube_apiserver_client_cert }}"
+    client_key: "{{ kube_apiserver_client_key }}"
+  register: result
+  until: result.status == 200
+  retries: 30
+  delay: 10
+
+- name: Master | set secret_changed
+  command: /bin/true
+  notify:
+    - Master | set secret_changed to true
+    - Master | clear kubeconfig for root user
+
+- name: Master | set secret_changed to true
+  set_fact:
+    secret_changed: true
+
+- name: Master | clear kubeconfig for root user
+  file:
+    path: /root/.kube/config
+    state: absent

--- a/roles/kubernetes-recover/master/tasks/encrypt-at-rest.yml
+++ b/roles/kubernetes-recover/master/tasks/encrypt-at-rest.yml
@@ -1,0 +1,10 @@
+---
+- name: Write secrets for encrypting secret data at rest
+  template:
+    src: secrets_encryption.yaml.j2
+    dest: "{{ kube_config_dir }}/ssl/secrets_encryption.yaml"
+    owner: root
+    group: "{{ kube_cert_group }}"
+    mode: 0640
+  tags:
+    - kube-apiserver

--- a/roles/kubernetes-recover/master/tasks/kubeadm-cleanup-old-certs.yml
+++ b/roles/kubernetes-recover/master/tasks/kubeadm-cleanup-old-certs.yml
@@ -1,0 +1,3 @@
+---
+- name: kubeadm | Purge old certs
+  command: "rm -f {{kube_cert_dir }}/*.pem"

--- a/roles/kubernetes-recover/master/tasks/kubeadm-migrate-certs.yml
+++ b/roles/kubernetes-recover/master/tasks/kubeadm-migrate-certs.yml
@@ -1,0 +1,18 @@
+---
+- name: Copy old certs to the kubeadm expected path
+  copy:
+    src: "{{ kube_cert_dir }}/{{ item.src }}"
+    dest: "{{ kube_cert_dir }}/{{ item.dest }}"
+    remote_src: yes
+  with_items:
+    - {src: apiserver.pem, dest: apiserver.crt}
+    - {src: apiserver-key.pem, dest: apiserver.key}
+    - {src: ca.pem, dest: ca.crt}
+    - {src: ca-key.pem, dest: ca.key}
+    - {src: front-proxy-ca.pem, dest: front-proxy-ca.crt}
+    - {src: front-proxy-ca-key.pem, dest: front-proxy-ca.key}
+    - {src: front-proxy-client.pem, dest: front-proxy-client.crt}
+    - {src: front-proxy-client-key.pem, dest: front-proxy-client.key}
+    - {src: service-account-key.pem, dest: sa.pub}
+    - {src: service-account-key.pem, dest: sa.key}
+  register: kubeadm_copy_old_certs

--- a/roles/kubernetes-recover/master/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes-recover/master/tasks/kubeadm-setup.yml
@@ -1,0 +1,172 @@
+---
+- name: kubeadm | Check if old apiserver cert exists on host
+  stat:
+    path: "{{ kube_cert_dir }}/apiserver.pem"
+  register: old_apiserver_cert
+  delegate_to: "{{groups['kube-master']|first}}"
+  run_once: true
+
+- name: kubeadm | Check service account key
+  stat:
+    path: "{{ kube_cert_dir }}/sa.key"
+  register: sa_key_before
+  delegate_to: "{{groups['kube-master']|first}}"
+  run_once: true
+
+- name: kubeadm | Check if kubeadm has already run
+  stat:
+    path: "{{ kube_cert_dir }}/ca.key"
+  register: kubeadm_ca
+
+- name: kubeadm | Delete old admin.conf
+  file:
+    path: "{{ kube_config_dir }}/admin.conf"
+    state: absent
+  when: not kubeadm_ca.stat.exists
+
+- name: kubeadm | Delete old static pods
+  file:
+    path: "{{ kube_config_dir }}/manifests/{{item}}.manifest"
+    state: absent
+  with_items: ["kube-apiserver", "kube-controller-manager", "kube-scheduler", "kube-proxy"]
+  when: old_apiserver_cert.stat.exists
+
+- name: kubeadm | Forcefully delete old static pods
+  shell: "docker ps -f name=k8s_{{item}} -q | xargs --no-run-if-empty docker rm -f"
+  with_items: ["kube-apiserver", "kube-controller-manager", "kube-scheduler"]
+  when: old_apiserver_cert.stat.exists
+
+- name: kubeadm | aggregate all SANs
+  set_fact:
+    apiserver_sans: >-
+      kubernetes
+      kubernetes.default
+      kubernetes.default.svc
+      kubernetes.default.svc.{{ dns_domain }}
+      {{ kube_apiserver_ip }}
+      localhost
+      127.0.0.1
+      {{ ' '.join(groups['kube-master']) }}
+      {%- if loadbalancer_apiserver is defined %}
+      {{ apiserver_loadbalancer_domain_name }}
+      {%- endif %}
+      {%- for host in groups['kube-master'] -%}
+      {%- if hostvars[host]['access_ip'] is defined %}{{ hostvars[host]['access_ip'] }}{% endif %}
+      {{ hostvars[host]['ip'] | default(hostvars[host]['ansible_default_ipv4']['address']) }}
+      {%- endfor %}
+      {%- if supplementary_addresses_in_ssl_keys is defined %}
+      {%- for addr in supplementary_addresses_in_ssl_keys %}
+      {{ addr }}
+      {%- endfor %}
+      {%- endif %}
+  tags: facts
+
+- name: kubeadm | Copy etcd cert dir under k8s cert dir
+  command: "cp -TR {{ etcd_cert_dir }} {{ kube_config_dir }}/ssl/etcd"
+  changed_when: false
+
+- name: kubeadm | Create kubeadm config
+  template:
+    src: kubeadm-config.yaml.j2
+    dest: "{{ kube_config_dir }}/kubeadm-config.yaml"
+  register: kubeadm_config
+
+- name: kubeadm | Initialize first master
+  command: timeout -k 240s 240s {{ bin_dir }}/kubeadm init --config={{ kube_config_dir }}/kubeadm-config.yaml --ignore-preflight-errors=all
+  register: kubeadm_init
+  # Retry is because upload config sometimes fails
+  retries: 3
+  when: inventory_hostname == groups['kube-master']|first and not kubeadm_ca.stat.exists
+  failed_when: kubeadm_init.rc != 0 and "field is immutable" not in kubeadm_init.stderr
+  notify: Master | restart kubelet
+
+- name: kubeadm | Upgrade first master
+  command: >-
+    timeout -k 240s 240s
+    {{ bin_dir }}/kubeadm
+    upgrade apply -y {{ kube_version }}
+    --config={{ kube_config_dir }}/kubeadm-config.yaml
+    --ignore-preflight-errors=all
+    --allow-experimental-upgrades
+    --allow-release-candidate-upgrades
+  register: kubeadm_upgrade
+  # Retry is because upload config sometimes fails
+  retries: 3
+  when: inventory_hostname == groups['kube-master']|first and (kubeadm_config.changed and kubeadm_ca.stat.exists)
+  failed_when: kubeadm_upgrade.rc != 0 and "field is immutable" not in kubeadm_upgrade.stderr
+  notify: Master | restart kubelet
+
+# FIXME(mattymo): remove when https://github.com/kubernetes/kubeadm/issues/433 is fixed
+- name: kubeadm | Enable kube-proxy
+  command: "{{ bin_dir }}/kubeadm alpha phase addon kube-proxy --config={{ kube_config_dir }}/kubeadm-config.yaml"
+  when: inventory_hostname == groups['kube-master']|first
+  changed_when: false
+
+- name: slurp kubeadm certs
+  slurp:
+    src: "{{ item }}"
+  with_items:
+    - "{{ kube_cert_dir }}/apiserver.crt"
+    - "{{ kube_cert_dir }}/apiserver.key"
+    - "{{ kube_cert_dir }}/apiserver-kubelet-client.crt"
+    - "{{ kube_cert_dir }}/apiserver-kubelet-client.key"
+    - "{{ kube_cert_dir }}/ca.crt"
+    - "{{ kube_cert_dir }}/ca.key"
+    - "{{ kube_cert_dir }}/front-proxy-ca.crt"
+    - "{{ kube_cert_dir }}/front-proxy-ca.key"
+    - "{{ kube_cert_dir }}/front-proxy-client.crt"
+    - "{{ kube_cert_dir }}/front-proxy-client.key"
+    - "{{ kube_cert_dir }}/sa.key"
+    - "{{ kube_cert_dir }}/sa.pub"
+  register: kubeadm_certs
+  delegate_to: "{{ groups['kube-master']|first }}"
+  run_once: true
+
+- name: kubeadm | write out kubeadm certs
+  copy:
+    dest: "{{ item.item }}"
+    content: "{{ item.content | b64decode }}"
+    owner: root
+    group: root
+    mode: 0600
+  no_log: true
+  register: copy_kubeadm_certs
+  with_items: "{{ kubeadm_certs.results }}"
+  when: inventory_hostname != groups['kube-master']|first
+
+- name: kubeadm | Init other uninitialized masters
+  command: timeout -k 240s 240s {{ bin_dir }}/kubeadm init --config={{ kube_config_dir }}/kubeadm-config.yaml --ignore-preflight-errors=all
+  register: kubeadm_init
+  when: inventory_hostname != groups['kube-master']|first and not kubeadm_ca.stat.exists
+  failed_when: kubeadm_init.rc != 0 and "field is immutable" not in kubeadm_init.stderr
+  notify: Master | restart kubelet
+
+- name: kubeadm | Upgrade other masters
+  command: >-
+    timeout -k 240s 240s
+    {{ bin_dir }}/kubeadm
+    upgrade apply -y {{ kube_version }}
+    --config={{ kube_config_dir }}/kubeadm-config.yaml
+    --ignore-preflight-errors=all
+    --allow-experimental-upgrades
+    --allow-release-candidate-upgrades
+  register: kubeadm_upgrade
+  when: inventory_hostname != groups['kube-master']|first and (kubeadm_config.changed and kubeadm_ca.stat.exists)
+  failed_when: kubeadm_upgrade.rc != 0 and "field is immutable" not in kubeadm_upgrade.stderr
+  notify: Master | restart kubelet
+
+- name: kubeadm | Check service account key again
+  stat:
+    path: "{{ kube_cert_dir }}/sa.key"
+  register: sa_key_after
+  delegate_to: "{{groups['kube-master']|first}}"
+  run_once: true
+
+- name: kubeadm | Set secret_changed if service account key was updated
+  command: /bin/true
+  notify: Master | set secret_changed
+  when: sa_key_before.stat.checksum|default("") != sa_key_after.stat.checksum
+
+- name: kubeadm | cleanup old certs if necessary
+  import_tasks: kubeadm-cleanup-old-certs.yml
+  when: old_apiserver_cert.stat.exists

--- a/roles/kubernetes-recover/master/tasks/main.yml
+++ b/roles/kubernetes-recover/master/tasks/main.yml
@@ -1,0 +1,81 @@
+---
+- import_tasks: pre-upgrade.yml
+  tags:
+    - k8s-pre-upgrade
+
+# upstream bug: https://github.com/kubernetes/kubeadm/issues/441
+- name: Disable kube_basic_auth until kubeadm/441 is fixed
+  set_fact:
+    kube_basic_auth: false
+  when: kubeadm_enabled|bool|default(false)
+
+- import_tasks: users-file.yml
+  when: kube_basic_auth|default(true)
+
+- import_tasks: encrypt-at-rest.yml
+  when: kube_encrypt_secret_data
+
+- name: Compare host kubectl with hyperkube container
+  command: "{{ docker_bin_dir }}/docker run --rm -v {{ bin_dir }}:/systembindir {{ hyperkube_image_repo }}:{{ hyperkube_image_tag }} /usr/bin/cmp /hyperkube /systembindir/kubectl"
+  register: kubectl_task_compare_result
+  until: kubectl_task_compare_result.rc in [0,1,2]
+  retries: 4
+  delay: "{{ retry_stagger | random + 3 }}"
+  changed_when: false
+  failed_when: "kubectl_task_compare_result.rc not in [0,1,2]"
+  tags:
+    - hyperkube
+    - kubectl
+    - upgrade
+
+- name: Copy kubectl from hyperkube container
+  command: "{{ docker_bin_dir }}/docker run --rm -v {{ bin_dir }}:/systembindir {{ hyperkube_image_repo }}:{{ hyperkube_image_tag }} /bin/cp /hyperkube /systembindir/kubectl"
+  when: kubectl_task_compare_result.rc != 0
+  register: kubectl_task_result
+  until: kubectl_task_result.rc == 0
+  retries: 4
+  delay: "{{ retry_stagger | random + 3 }}"
+  changed_when: false
+  tags:
+    - hyperkube
+    - kubectl
+    - upgrade
+
+- name: Install kubectl bash completion
+  shell: "{{ bin_dir }}/kubectl completion bash >/etc/bash_completion.d/kubectl.sh"
+  when: kubectl_task_compare_result.rc != 0 and ansible_os_family in ["Debian","RedHat"]
+  tags:
+    - kubectl
+
+- name: Set kubectl bash completion file
+  file:
+    path: /etc/bash_completion.d/kubectl.sh
+    owner: root
+    group: root
+    mode: 0755
+  when: ansible_os_family in ["Debian","RedHat"]
+  tags:
+    - kubectl
+    - upgrade
+
+- name: Include kubeadm setup if enabled
+  import_tasks: kubeadm-setup.yml
+  when: kubeadm_enabled|bool|default(false)
+
+- name: Include static pod setup if not using kubeadm
+  import_tasks: static-pod-setup.yml
+  when: not kubeadm_enabled|bool|default(false)
+
+- name: Master | label new master
+  shell: kubectl label node {{ groups['master-add'][0] }} node-role.kubernetes.io/master=true --overwrite
+  delegate_to: "{{ groups['kube-master'][0] }}"
+  run_once: true
+
+- name: Master | Remove fault master
+  shell: kubectl delete node {{ item }}
+  delegate_to: "{{ groups['kube-master'][0] }}"
+  run_once: true
+  #ignore_errors: true
+  failed_when: false
+  with_items: "{{ groups['master-remove'] }}"
+

--- a/roles/kubernetes-recover/master/tasks/pre-upgrade.yml
+++ b/roles/kubernetes-recover/master/tasks/pre-upgrade.yml
@@ -1,0 +1,36 @@
+---
+- name: "Pre-upgrade | etcd3 upgrade | see if old config exists"
+  command: "{{ bin_dir }}/etcdctl --peers={{ etcd_access_addresses }} ls /registry/minions"
+  environment:
+    ETCDCTL_API: 2
+    ETCDCTL_CERT_FILE: "{{ etcd_cert_dir }}/node-{{ inventory_hostname }}.pem"
+    ETCDCTL_KEY_FILE: "{{ etcd_cert_dir }}/node-{{ inventory_hostname }}-key.pem"
+  register: old_data_exists
+  delegate_to: "{{groups['etcd'][0]}}"
+  changed_when: false
+  when: kube_apiserver_storage_backend == "etcd3"
+  failed_when: false
+
+- name: "Pre-upgrade | etcd3 upgrade | use etcd2 unless forced to etcd3"
+  set_fact:
+    kube_apiserver_storage_backend: "etcd2"
+  when: old_data_exists.rc == 0 and not force_etcd3|bool
+
+#- name: "Pre-upgrade | Delete master manifests"
+#  file:
+#    path: "/etc/kubernetes/manifests/{{item}}.manifest"
+#    state: absent
+#  with_items:
+#    - ["kube-apiserver", "kube-controller-manager", "kube-scheduler"]
+#  register: kube_apiserver_manifest_replaced
+#  when: (secret_changed|default(false) or etcd_secret_changed|default(false))
+
+#- name: "Pre-upgrade | Delete master containers forcefully"
+#  shell: "docker ps -af name=k8s_{{item}}* -q | xargs --no-run-if-empty docker rm -f"
+#  with_items:
+#    - ["kube-apiserver", "kube-controller-manager", "kube-scheduler"]
+#  when: kube_apiserver_manifest_replaced.changed
+#  register: remove_master_container
+#  retries: 4
+#  until: remove_master_container.rc == 0
+#  delay: 5

--- a/roles/kubernetes-recover/master/tasks/static-pod-setup.yml
+++ b/roles/kubernetes-recover/master/tasks/static-pod-setup.yml
@@ -1,0 +1,50 @@
+---
+- name: Write kube-apiserver manifest
+  template:
+    src: manifests/kube-apiserver.manifest.j2
+    dest: "{{ kube_manifest_dir }}/kube-apiserver.manifest"
+  notify: Master | Restart apiserver
+  tags:
+    - kube-apiserver
+
+- meta: flush_handlers
+
+- name: Write kube-scheduler policy file
+  template:
+    src: kube-scheduler-policy.yaml.j2
+    dest: "{{ kube_config_dir }}/kube-scheduler-policy.yaml"
+  notify: Master | Restart kube-scheduler
+  tags:
+    - kube-scheduler
+
+- name: Write kube-scheduler kubeconfig
+  template:
+    src: kube-scheduler-kubeconfig.yaml.j2
+    dest: "{{ kube_config_dir }}/kube-scheduler-kubeconfig.yaml"
+  tags:
+    - kube-scheduler
+
+- name: Write kube-scheduler manifest
+  template:
+    src: manifests/kube-scheduler.manifest.j2
+    dest: "{{ kube_manifest_dir }}/kube-scheduler.manifest"
+  notify: Master | Restart kube-scheduler
+  tags:
+    - kube-scheduler
+
+- name: Write kube-controller-manager kubeconfig
+  template:
+    src: kube-controller-manager-kubeconfig.yaml.j2
+    dest: "{{ kube_config_dir }}/kube-controller-manager-kubeconfig.yaml"
+  tags:
+    - kube-controller-manager
+
+- name: Write kube-controller-manager manifest
+  template:
+    src: manifests/kube-controller-manager.manifest.j2
+    dest: "{{ kube_manifest_dir }}/kube-controller-manager.manifest"
+  notify: Master | Restart kube-controller-manager
+  tags:
+    - kube-controller-manager
+
+- meta: flush_handlers

--- a/roles/kubernetes-recover/master/tasks/users-file.yml
+++ b/roles/kubernetes-recover/master/tasks/users-file.yml
@@ -1,0 +1,15 @@
+---
+- name: Make sure the users directory exits
+  file:
+    path: "{{ kube_users_dir }}"
+    state: directory
+    mode: o-rwx
+    group: "{{ kube_cert_group }}"
+
+- name: Populate users for basic auth in API
+  template:
+    src: known_users.csv.j2
+    dest: "{{ kube_users_dir }}/known_users.csv"
+    mode: 0640
+    backup: yes
+  notify: Master | set secret_changed

--- a/roles/kubernetes-recover/master/templates/known_users.csv.j2
+++ b/roles/kubernetes-recover/master/templates/known_users.csv.j2
@@ -1,0 +1,4 @@
+{% for user in kube_users %}
+{{kube_users[user].pass}},{{user}},{{kube_users[user].role}}{% if kube_users[user].groups is defined %},{% set groups_csv = kube_users[user].groups|join(',') -%}"{{groups_csv}}"{% endif %}
+
+{% endfor %}

--- a/roles/kubernetes-recover/master/templates/kube-controller-manager-kubeconfig.yaml.j2
+++ b/roles/kubernetes-recover/master/templates/kube-controller-manager-kubeconfig.yaml.j2
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Config
+clusters:
+- name: local
+  cluster:
+    certificate-authority: {{ kube_cert_dir }}/ca.pem
+    server: {{ kube_apiserver_endpoint }}
+users:
+- name: kube-controller-manager
+  user:
+    client-certificate: {{ kube_cert_dir }}/kube-controller-manager.pem
+    client-key: {{ kube_cert_dir }}/kube-controller-manager-key.pem
+contexts:
+- context:
+    cluster: local
+    user: kube-controller-manager
+  name: kube-controller-manager-{{ cluster_name }}
+current-context: kube-controller-manager-{{ cluster_name }}

--- a/roles/kubernetes-recover/master/templates/kube-scheduler-kubeconfig.yaml.j2
+++ b/roles/kubernetes-recover/master/templates/kube-scheduler-kubeconfig.yaml.j2
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Config
+clusters:
+- name: local
+  cluster:
+    certificate-authority: {{ kube_cert_dir }}/ca.pem
+    server: {{ kube_apiserver_endpoint }}
+users:
+- name: kube-scheduler
+  user:
+    client-certificate: {{ kube_cert_dir }}/kube-scheduler.pem
+    client-key: {{ kube_cert_dir }}/kube-scheduler-key.pem
+contexts:
+- context:
+    cluster: local
+    user: kube-scheduler
+  name: kube-scheduler-{{ cluster_name }}
+current-context: kube-scheduler-{{ cluster_name }}

--- a/roles/kubernetes-recover/master/templates/kube-scheduler-policy.yaml.j2
+++ b/roles/kubernetes-recover/master/templates/kube-scheduler-policy.yaml.j2
@@ -1,0 +1,18 @@
+{
+"kind" : "Policy",
+"apiVersion" : "v1",
+"predicates" : [
+    {"name" : "PodFitsHostPorts"},
+    {"name" : "PodFitsResources"},
+    {"name" : "NoDiskConflict"},
+    {"name" : "MatchNodeSelector"},
+    {"name" : "HostName"}
+    ],
+"priorities" : [
+    {"name" : "LeastRequestedPriority", "weight" : 1},
+    {"name" : "BalancedResourceAllocation", "weight" : 1},
+    {"name" : "ServiceSpreadingPriority", "weight" : 1},
+    {"name" : "EqualPriority", "weight" : 1}
+    ],
+"hardPodAffinitySymmetricWeight" : 10
+}

--- a/roles/kubernetes-recover/master/templates/kubeadm-config.yaml.j2
+++ b/roles/kubernetes-recover/master/templates/kubeadm-config.yaml.j2
@@ -1,0 +1,98 @@
+apiVersion: kubeadm.k8s.io/v1alpha1
+kind: MasterConfiguration
+api:
+  advertiseAddress: {{ ip | default(ansible_default_ipv4.address) }}
+  bindPort: {{ kube_apiserver_port }}
+etcd:
+  endpoints:
+{% for endpoint in etcd_access_addresses.split(',') %}
+  - {{ endpoint }}
+{% endfor %}
+  caFile: {{ kube_config_dir }}/ssl/etcd/ca.pem
+  certFile: {{ kube_config_dir }}/ssl/etcd/node-{{ inventory_hostname }}.pem
+  keyFile: {{ kube_config_dir }}/ssl/etcd/node-{{ inventory_hostname }}-key.pem
+networking:
+  dnsDomain: {{ dns_domain }}
+  serviceSubnet: {{ kube_service_addresses }}
+  podSubnet: {{ kube_pods_subnet }}
+kubernetesVersion: {{ kube_version }}
+{% if cloud_provider is defined and cloud_provider != "gce" %}
+cloudProvider: {{ cloud_provider }}
+{% endif %}
+{% if kube_proxy_mode == 'ipvs' and kube_version | version_compare('v1.10', '<') %}
+kubeProxy:
+  config:
+    featureGates: SupportIPVSProxyMode=true
+    mode: ipvs
+{% endif %}
+authorizationModes:
+{% for mode in authorization_modes %}
+- {{ mode }}
+{% endfor %}
+selfHosted: false
+apiServerExtraArgs:
+  bind-address: {{ kube_apiserver_bind_address }}
+  insecure-bind-address: {{ kube_apiserver_insecure_bind_address }}
+  insecure-port: "{{ kube_apiserver_insecure_port }}"
+  admission-control: {{ kube_apiserver_admission_control | join(',') }}
+  apiserver-count: "{{ kube_apiserver_count }}"
+{% if kube_version | version_compare('v1.9', '>=') %}
+  endpoint-reconciler-type: lease
+{% endif %}
+{% if etcd_events_cluster_setup  %}
+  etcd-servers-overrides: "/events#{{ etcd_events_access_addresses }}"
+{% endif %}
+  service-node-port-range: {{ kube_apiserver_node_port_range }}
+  kubelet-preferred-address-types: "{{ kubelet_preferred_address_types }}"
+{% if kube_basic_auth|default(true) %}
+  basic-auth-file: {{ kube_users_dir }}/known_users.csv
+{% endif %}
+{% if kube_oidc_auth|default(false) and kube_oidc_url is defined and kube_oidc_client_id is defined %}
+  oidc-issuer-url: {{ kube_oidc_url }}
+  oidc-client-id: {{ kube_oidc_client_id }}
+{%   if kube_oidc_ca_file is defined %}
+  oidc-ca-file: {{ kube_oidc_ca_file }}
+{%   endif %}
+{%   if kube_oidc_username_claim is defined %}
+  oidc-username-claim: {{ kube_oidc_username_claim }}
+{%   endif %}
+{%   if kube_oidc_groups_claim is defined %}
+  oidc-groups-claim: {{ kube_oidc_groups_claim }}
+{%   endif %}
+{% endif %}
+{% if kube_encrypt_secret_data %}
+  experimental-encryption-provider-config: {{ kube_config_dir }}/ssl/secrets_encryption.yaml
+{% endif %}
+  storage-backend: {{ kube_apiserver_storage_backend }}
+{% if kube_api_runtime_config is defined %}
+  runtime-config: {{ kube_api_runtime_config | join(',') }}
+{% endif %}
+  allow-privileged: "true"
+{% for key in kube_kubeadm_apiserver_extra_args %}
+  {{ key }}: "{{ kube_kubeadm_apiserver_extra_args[key] }}"
+{% endfor %}
+controllerManagerExtraArgs:
+  node-monitor-grace-period: {{ kube_controller_node_monitor_grace_period }}
+  node-monitor-period: {{ kube_controller_node_monitor_period }}
+  pod-eviction-timeout: {{ kube_controller_pod_eviction_timeout }}
+{% if kube_feature_gates %}
+  feature-gates: {{ kube_feature_gates|join(',') }}
+{% endif %}
+{% for key in kube_kubeadm_controller_extra_args %}
+  {{ key }}: "{{ kube_kubeadm_controller_extra_args[key] }}"
+{% endfor %}
+{% if kube_kubeadm_scheduler_extra_args|length > 0 %}
+schedulerExtraArgs:
+{% for key in kube_kubeadm_scheduler_extra_args %}
+  {{ key }}: "{{ kube_kubeadm_scheduler_extra_args[key] }}"
+{% endfor %}
+{% endif %}
+apiServerCertSANs:
+{% for san in  apiserver_sans.split(' ') | unique %}
+  - {{ san }}
+{% endfor %}
+certificatesDir: {{ kube_config_dir }}/ssl
+unifiedControlPlaneImage: "{{ hyperkube_image_repo }}:{{ hyperkube_image_tag }}"
+{% if kube_override_hostname|default('') %}
+nodeName: {{ kube_override_hostname }}
+{% endif %}

--- a/roles/kubernetes-recover/master/templates/kubectl-kubeconfig.yaml.j2
+++ b/roles/kubernetes-recover/master/templates/kubectl-kubeconfig.yaml.j2
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Config
+current-context: kubectl-to-{{ cluster_name }}
+preferences: {}
+clusters:
+- cluster:
+    certificate-authority-data: {{ kube_node_cert|b64encode }}
+    server: {{ kube_apiserver_endpoint }}
+  name: {{ cluster_name }}
+contexts:
+- context:
+    cluster: {{ cluster_name }}
+    user: kubectl
+  name: kubectl-to-{{ cluster_name }}
+users:
+- name: kubectl
+  user:
+    token: {{ kubectl_token }}

--- a/roles/kubernetes-recover/master/templates/manifests/kube-apiserver.manifest.j2
+++ b/roles/kubernetes-recover/master/templates/manifests/kube-apiserver.manifest.j2
@@ -1,0 +1,198 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kube-apiserver
+  namespace: kube-system
+  labels:
+    k8s-app: kube-apiserver
+    kubespray: v2
+  annotations:
+    kubespray.etcd-cert/serial: "{{ etcd_client_cert_serial }}"
+    kubespray.apiserver-cert/serial: "{{ apiserver_cert_serial }}"
+spec:
+  hostNetwork: true
+{% if kube_version | version_compare('v1.6', '>=')  %}
+  dnsPolicy: ClusterFirst
+{% endif %}
+  containers:
+  - name: kube-apiserver
+    image: {{ hyperkube_image_repo }}:{{ hyperkube_image_tag }}
+    imagePullPolicy: {{ k8s_image_pull_policy }}
+    resources:
+      limits:
+        cpu: {{ kube_apiserver_cpu_limit }}
+        memory: {{ kube_apiserver_memory_limit }}
+      requests:
+        cpu: {{ kube_apiserver_cpu_requests }}
+        memory: {{ kube_apiserver_memory_requests }}
+    command:
+    - /hyperkube
+    - apiserver
+    - --advertise-address={{ ip | default(ansible_default_ipv4.address) }}
+    - --etcd-servers={{ etcd_access_addresses }}
+{%   if etcd_events_cluster_setup  %}
+    - --etcd-servers-overrides=/events#{{ etcd_events_access_addresses }}
+{% endif %}
+{%   if kube_version | version_compare('v1.9', '<')  %}
+    - --etcd-quorum-read=true
+{% endif %}
+    - --etcd-cafile={{ etcd_cert_dir }}/ca.pem
+    - --etcd-certfile={{ etcd_cert_dir }}/node-{{ inventory_hostname }}.pem
+    - --etcd-keyfile={{ etcd_cert_dir }}/node-{{ inventory_hostname }}-key.pem
+    - --insecure-bind-address={{ kube_apiserver_insecure_bind_address }}
+    - --bind-address={{ kube_apiserver_bind_address }}
+    - --apiserver-count={{ kube_apiserver_count }}
+{% if kube_version | version_compare('v1.9', '>=') %}
+    - --endpoint-reconciler-type=lease
+{% endif %}
+    - --admission-control={{ kube_apiserver_admission_control | join(',') }}
+    - --service-cluster-ip-range={{ kube_service_addresses }}
+    - --service-node-port-range={{ kube_apiserver_node_port_range }}
+    - --client-ca-file={{ kube_cert_dir }}/ca.pem
+    - --profiling=false
+    - --repair-malformed-updates=false
+    - --kubelet-client-certificate={{ kube_cert_dir }}/node-{{ inventory_hostname }}.pem
+    - --kubelet-client-key={{ kube_cert_dir }}/node-{{ inventory_hostname }}-key.pem
+    - --service-account-lookup=true
+    - --kubelet-preferred-address-types={{ kubelet_preferred_address_types }}
+{% if kube_basic_auth|default(true) %}
+    - --basic-auth-file={{ kube_users_dir }}/known_users.csv
+{% endif %}
+    - --tls-cert-file={{ kube_cert_dir }}/apiserver.pem
+    - --tls-private-key-file={{ kube_cert_dir }}/apiserver-key.pem
+{% if kube_token_auth|default(true) %}
+    - --token-auth-file={{ kube_token_dir }}/known_tokens.csv
+{% endif %}
+    - --service-account-key-file={{ kube_cert_dir }}/service-account-key.pem
+{% if kube_oidc_auth|default(false) and kube_oidc_url is defined and kube_oidc_client_id is defined %}
+    - --oidc-issuer-url={{ kube_oidc_url }}
+    - --oidc-client-id={{ kube_oidc_client_id }}
+{%   if kube_oidc_ca_file is defined %}
+    - --oidc-ca-file={{ kube_oidc_ca_file }}
+{%   endif %}
+{%   if kube_oidc_username_claim is defined %}
+    - --oidc-username-claim={{ kube_oidc_username_claim }}
+{%   endif %}
+{%   if kube_oidc_username_prefix is defined %}
+    - "--oidc-username-prefix={{ kube_oidc_username_prefix }}"
+{%   endif %}
+{%   if kube_oidc_groups_claim is defined %}
+    - --oidc-groups-claim={{ kube_oidc_groups_claim }}
+{%   endif %}
+{%   if kube_oidc_groups_prefix is defined %}
+    - "--oidc-groups-prefix={{ kube_oidc_groups_prefix }}"
+{%   endif %}
+{% endif %}
+    - --secure-port={{ kube_apiserver_port }}
+    - --insecure-port={{ kube_apiserver_insecure_port }}
+    - --storage-backend={{ kube_apiserver_storage_backend }}
+{% if kube_api_runtime_config is defined %}
+{%   for conf in kube_api_runtime_config %}
+    - --runtime-config={{ conf }}
+{%   endfor %}
+{% endif %}
+{% if enable_network_policy %}
+{%   if kube_version | version_compare('v1.8', '<')  %}
+    - --runtime-config=extensions/v1beta1/networkpolicies=true
+{%   endif %}
+{% endif %}
+    - --v={{ kube_log_level }}
+    - --allow-privileged=true
+{% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere"] %}
+    - --cloud-provider={{ cloud_provider }}
+    - --cloud-config={{ kube_config_dir }}/cloud_config
+{% elif cloud_provider is defined and cloud_provider == "aws" %}
+    - --cloud-provider={{ cloud_provider }}
+{% endif %}
+{% if kube_api_anonymous_auth is defined and kube_version | version_compare('v1.5', '>=')  %}
+    - --anonymous-auth={{ kube_api_anonymous_auth }}
+{% endif %}
+{% if authorization_modes %}
+    - --authorization-mode={{ authorization_modes|join(',') }}
+{% endif %}
+{% if kube_encrypt_secret_data %}
+    - --experimental-encryption-provider-config={{ kube_config_dir }}/ssl/secrets_encryption.yaml
+{% endif %}
+{% if kube_feature_gates %}
+    - --feature-gates={{ kube_feature_gates|join(',') }}
+{% endif %}
+{% if kube_version | version_compare('v1.9', '>=') %}
+    - --requestheader-client-ca-file={{ kube_cert_dir }}/{{ kube_front_proxy_ca }}
+{# FIXME(mattymo): Vault certs do not work with front-proxy-client #}
+{% if cert_management == "vault" %}
+    - --requestheader-allowed-names=
+{% else %}
+    - --requestheader-allowed-names=front-proxy-client
+{% endif %}
+    - --requestheader-extra-headers-prefix=X-Remote-Extra-
+    - --requestheader-group-headers=X-Remote-Group
+    - --requestheader-username-headers=X-Remote-User
+    - --enable-aggregator-routing={{ kube_api_aggregator_routing }}
+    - --proxy-client-cert-file={{ kube_cert_dir }}/front-proxy-client.pem
+    - --proxy-client-key-file={{ kube_cert_dir }}/front-proxy-client-key.pem
+{% else %}
+    - --proxy-client-cert-file={{ kube_cert_dir }}/apiserver.pem
+    - --proxy-client-key-file={{ kube_cert_dir }}/apiserver-key.pem
+{% endif %}
+{% if apiserver_custom_flags is string %}
+    - {{ apiserver_custom_flags }}
+{% else %}
+{% for flag in apiserver_custom_flags %}
+    - {{ flag }}
+{% endfor %}
+{% endif %}
+    livenessProbe:
+      httpGet:
+        host: 127.0.0.1
+        path: /healthz
+{% if kube_apiserver_insecure_port|int == 0 %}
+        port: {{ kube_apiserver_port }}
+        scheme: HTTPS
+{% else %}
+        port: {{ kube_apiserver_insecure_port }}
+{% endif %}
+      failureThreshold: 8
+      initialDelaySeconds: 15
+      periodSeconds: 10
+      successThreshold: 1
+      timeoutSeconds: 15
+    volumeMounts:
+    - mountPath: {{ kube_config_dir }}
+      name: kubernetes-config
+      readOnly: true
+    - mountPath: /etc/ssl
+      name: ssl-certs-host
+      readOnly: true
+{% for dir in ssl_ca_dirs %}
+    - mountPath: {{ dir }}
+      name: {{ dir | regex_replace('^/(.*)$', '\\1' ) | regex_replace('/', '-') }}
+      readOnly: true
+{% endfor %}
+    - mountPath: {{ etcd_cert_dir }}
+      name: etcd-certs
+      readOnly: true
+{% if cloud_provider is defined and cloud_provider == 'aws' and ansible_os_family == 'RedHat' %}
+    - mountPath: /etc/ssl/certs/ca-bundle.crt
+      name: rhel-ca-bundle
+      readOnly: true
+{% endif %}
+  volumes:
+  - hostPath:
+      path: {{ kube_config_dir }}
+    name: kubernetes-config
+  - name: ssl-certs-host
+    hostPath:
+      path: /etc/ssl
+{% for dir in ssl_ca_dirs %}
+  - name: {{ dir | regex_replace('^/(.*)$', '\\1' ) | regex_replace('/', '-') }}
+    hostPath:
+      path: {{ dir }}
+{% endfor %}
+  - hostPath:
+      path: {{ etcd_cert_dir }}
+    name: etcd-certs
+{% if cloud_provider is defined and cloud_provider == 'aws' and ansible_os_family == 'RedHat' %}
+  - hostPath:
+      path: /etc/ssl/certs/ca-bundle.crt
+    name: rhel-ca-bundle
+{% endif %}

--- a/roles/kubernetes-recover/master/templates/manifests/kube-controller-manager.manifest.j2
+++ b/roles/kubernetes-recover/master/templates/manifests/kube-controller-manager.manifest.j2
@@ -1,0 +1,117 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kube-controller-manager
+  namespace: kube-system
+  labels:
+    k8s-app: kube-controller-manager
+  annotations:
+    kubespray.etcd-cert/serial: "{{ etcd_client_cert_serial }}"
+    kubespray.controller-manager-cert/serial: "{{ controller_manager_cert_serial }}"
+spec:
+  hostNetwork: true
+{% if kube_version | version_compare('v1.6', '>=') %}
+  dnsPolicy: ClusterFirst
+{% endif %}
+  containers:
+  - name: kube-controller-manager
+    image: {{ hyperkube_image_repo }}:{{ hyperkube_image_tag }}
+    imagePullPolicy: {{ k8s_image_pull_policy }}
+    resources:
+      limits:
+        cpu: {{ kube_controller_cpu_limit }}
+        memory: {{ kube_controller_memory_limit }}
+      requests:
+        cpu: {{ kube_controller_cpu_requests }}
+        memory: {{ kube_controller_memory_requests }}
+    command:
+    - /hyperkube
+    - controller-manager
+    - --kubeconfig={{ kube_config_dir }}/kube-controller-manager-kubeconfig.yaml
+    - --leader-elect=true
+    - --service-account-private-key-file={{ kube_cert_dir }}/service-account-key.pem
+    - --root-ca-file={{ kube_cert_dir }}/ca.pem
+    - --cluster-signing-cert-file={{ kube_cert_dir }}/ca.pem
+    - --cluster-signing-key-file={{ kube_cert_dir }}/ca-key.pem
+    - --enable-hostpath-provisioner={{ kube_hostpath_dynamic_provisioner }}
+    - --node-monitor-grace-period={{ kube_controller_node_monitor_grace_period }}
+    - --node-monitor-period={{ kube_controller_node_monitor_period }}
+    - --pod-eviction-timeout={{ kube_controller_pod_eviction_timeout }}
+    - --profiling=false
+    - --terminated-pod-gc-threshold=12500
+    - --v={{ kube_log_level }}
+{% if rbac_enabled %}
+    - --use-service-account-credentials=true
+{% endif %}
+{% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere"] %}
+    - --cloud-provider={{cloud_provider}}
+    - --cloud-config={{ kube_config_dir }}/cloud_config
+{% elif cloud_provider is defined and cloud_provider in ["aws", "external"] %}
+    - --cloud-provider={{cloud_provider}}
+{% endif %}
+{% if kube_network_plugin is defined and kube_network_plugin == 'cloud' %}
+    - --configure-cloud-routes=true
+{% endif %}
+{% if kube_network_plugin is defined and kube_network_plugin in ["cloud", "flannel", "canal", "cilium"] %}
+    - --allocate-node-cidrs=true
+    - --cluster-cidr={{ kube_pods_subnet }}
+    - --service-cluster-ip-range={{ kube_service_addresses }}
+    - --node-cidr-mask-size={{ kube_network_node_prefix }}
+{% endif %}
+{% if kube_feature_gates %}
+    - --feature-gates={{ kube_feature_gates|join(',') }}
+{% endif %}
+{% if controller_mgr_custom_flags is string %}
+    - {{ controller_mgr_custom_flags }}
+{% else %}
+{%   for flag in controller_mgr_custom_flags %}
+    - {{ flag }}
+{%   endfor %}
+{% endif %}
+    livenessProbe:
+      httpGet:
+        host: 127.0.0.1
+        path: /healthz
+        port: 10252
+      initialDelaySeconds: 30
+      timeoutSeconds: 10
+    volumeMounts:
+    - mountPath: /etc/ssl
+      name: ssl-certs-host
+      readOnly: true
+{% for dir in ssl_ca_dirs %}
+    - mountPath: {{ dir }}
+      name: {{ dir | regex_replace('^/(.*)$', '\\1' ) | regex_replace('/', '-') }}
+      readOnly: true
+{% endfor %}
+    - mountPath: "{{kube_config_dir}}/ssl"
+      name: etc-kube-ssl
+      readOnly: true
+    - mountPath: "{{ kube_config_dir }}/kube-controller-manager-kubeconfig.yaml"
+      name: kubeconfig
+      readOnly: true
+{% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere" ] %}
+    - mountPath: "{{ kube_config_dir }}/cloud_config"
+      name: cloudconfig
+      readOnly: true
+{% endif %}
+  volumes:
+  - name: ssl-certs-host
+    hostPath:
+      path: /etc/ssl
+{% for dir in ssl_ca_dirs %}
+  - name: {{ dir | regex_replace('^/(.*)$', '\\1' ) | regex_replace('/', '-') }}
+    hostPath:
+      path: {{ dir }}
+{% endfor %}
+  - name: etc-kube-ssl
+    hostPath:
+      path: "{{ kube_config_dir }}/ssl"
+  - name: kubeconfig
+    hostPath:
+      path: "{{ kube_config_dir }}/kube-controller-manager-kubeconfig.yaml"
+{% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere"] %}
+  - hostPath:
+      path: "{{ kube_config_dir }}/cloud_config"
+    name: cloudconfig
+{% endif %}

--- a/roles/kubernetes-recover/master/templates/manifests/kube-scheduler.manifest.j2
+++ b/roles/kubernetes-recover/master/templates/manifests/kube-scheduler.manifest.j2
@@ -1,0 +1,93 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kube-scheduler
+  namespace: kube-system
+  labels:
+    k8s-app: kube-scheduler
+  annotations:
+    kubespray.scheduler-cert/serial: "{{ scheduler_cert_serial }}"
+spec:
+  hostNetwork: true
+{% if kube_version | version_compare('v1.6', '>=') %}
+  dnsPolicy: ClusterFirst
+{% endif %}
+  containers:
+  - name: kube-scheduler
+    image: {{ hyperkube_image_repo }}:{{ hyperkube_image_tag }}
+    imagePullPolicy: {{ k8s_image_pull_policy }}
+    resources:
+      limits:
+        cpu: {{ kube_scheduler_cpu_limit }}
+        memory: {{ kube_scheduler_memory_limit }}
+      requests:
+        cpu: {{ kube_scheduler_cpu_requests }}
+        memory: {{ kube_scheduler_memory_requests }}
+    command:
+    - /hyperkube
+    - scheduler
+    - --leader-elect=true
+    - --kubeconfig={{ kube_config_dir }}/kube-scheduler-kubeconfig.yaml
+{% if volume_cross_zone_attachment %}
+    - --use-legacy-policy-config
+    - --policy-config-file={{ kube_config_dir }}/kube-scheduler-policy.yaml
+{% endif %}
+    - --profiling=false
+    - --v={{ kube_log_level }}
+{% if kube_feature_gates %}
+    - --feature-gates={{ kube_feature_gates|join(',') }}
+{% endif %}
+{% if scheduler_custom_flags is string %}
+    - {{ scheduler_custom_flags }}
+{% else %}
+{%   for flag in scheduler_custom_flags %}
+    - {{ flag }}
+{%   endfor %}
+{% endif %}
+    livenessProbe:
+      httpGet:
+        host: 127.0.0.1
+        path: /healthz
+        port: 10251
+      initialDelaySeconds: 30
+      timeoutSeconds: 10
+    volumeMounts:
+    - mountPath: /etc/ssl
+      name: ssl-certs-host
+      readOnly: true
+{% for dir in ssl_ca_dirs %}
+    - mountPath: {{ dir }}
+      name: {{ dir | regex_replace('^/(.*)$', '\\1' ) | regex_replace('/', '-') }}
+      readOnly: true
+{% endfor %}
+    - mountPath: "{{ kube_config_dir }}/ssl"
+      name: etc-kube-ssl
+      readOnly: true
+    - mountPath: "{{ kube_config_dir }}/kube-scheduler-kubeconfig.yaml"
+      name: kubeconfig
+      readOnly: true
+{% if volume_cross_zone_attachment %}
+    - mountPath: "{{ kube_config_dir }}/kube-scheduler-policy.yaml"
+      name: kube-scheduler-policy
+      readOnly: true
+{% endif %}
+  volumes:
+  - name: ssl-certs-host
+    hostPath:
+      path: /etc/ssl
+{% for dir in ssl_ca_dirs %}
+  - name: {{ dir | regex_replace('^/(.*)$', '\\1' ) | regex_replace('/', '-') }}
+    hostPath:
+      path: {{ dir }}
+{% endfor %}
+  - name: etc-kube-ssl
+    hostPath:
+      path: "{{ kube_config_dir }}/ssl"
+  - name: kubeconfig
+    hostPath:
+      path: "{{ kube_config_dir }}/kube-scheduler-kubeconfig.yaml"
+{% if volume_cross_zone_attachment %}
+  - name: kube-scheduler-policy
+    hostPath:
+      path: "{{ kube_config_dir }}/kube-scheduler-policy.yaml"
+{% endif %}

--- a/roles/kubernetes-recover/master/templates/secrets_encryption.yaml.j2
+++ b/roles/kubernetes-recover/master/templates/secrets_encryption.yaml.j2
@@ -1,0 +1,11 @@
+kind: EncryptionConfig
+apiVersion: v1
+resources:
+  - resources:
+    - secrets
+    providers:
+    - {{ kube_encryption_algorithm }}:
+        keys:
+        - name: key
+          secret: {{ kube_encrypt_token | b64encode }}
+    - identity: {}

--- a/roles/kubernetes-recover/node/defaults/main.yml
+++ b/roles/kubernetes-recover/node/defaults/main.yml
@@ -1,0 +1,144 @@
+---
+# Valid options: docker (default), rkt, or host
+kubelet_deployment_type: host
+
+# change to 0.0.0.0 to enable insecure access from anywhere (not recommended)
+kube_apiserver_insecure_bind_address: 127.0.0.1
+
+# advertised host IP for kubelet. This affects network plugin config. Take caution
+kubelet_address: "{{ ip | default(ansible_default_ipv4['address']) }}"
+
+# bind address for kubelet. Set to 0.0.0.0 to listen on all interfaces
+kubelet_bind_address: "{{ ip | default('0.0.0.0') }}"
+
+# resolv.conf to base dns config
+kube_resolv_conf: "/etc/resolv.conf"
+
+# Can be ipvs, iptables
+kube_proxy_mode: iptables
+
+# If using the pure iptables proxy, SNAT everything. Note that it breaks any
+# policy engine.
+kube_proxy_masquerade_all: false
+
+# These options reflect limitations of running kubelet in a container.
+# Modify at your own risk
+kubelet_enable_cri: true
+kubelet_cgroups_per_qos: true
+# Set to empty to avoid cgroup creation
+kubelet_enforce_node_allocatable: "\"\""
+
+# Set false to enable sharing a pid namespace between containers in a pod.
+# Note that PID namespace sharing requires docker >= 1.13.1.
+kubelet_disable_shared_pid: true
+
+### fail with swap on (default true)
+kubelet_fail_swap_on: true
+
+# Reserve this space for kube resources
+kube_memory_reserved: 256M
+kube_cpu_reserved: 100m
+# Reservation for master hosts
+kube_master_memory_reserved: 512M
+kube_master_cpu_reserved: 200m
+
+kubelet_status_update_frequency: 10s
+
+# Limits for kube components and nginx load balancer app
+kube_proxy_memory_limit: 2000M
+kube_proxy_cpu_limit: 500m
+kube_proxy_memory_requests: 64M
+kube_proxy_cpu_requests: 150m
+nginx_memory_limit: 512M
+nginx_cpu_limit: 300m
+nginx_memory_requests: 32M
+nginx_cpu_requests: 25m
+
+# kube_api_runtime_config:
+#   - extensions/v1beta1/daemonsets=true
+#   - extensions/v1beta1/deployments=true
+
+nginx_image_repo: nginx
+nginx_image_tag: 1.13
+
+etcd_config_dir: /etc/ssl/etcd
+
+kubelet_flexvolumes_plugins_dir: /var/lib/kubelet/volume-plugins
+
+# A port range to reserve for services with NodePort visibility.
+# Inclusive at both ends of the range.
+kube_apiserver_node_port_range: "30000-32767"
+
+kubelet_load_modules: false
+
+# Configure the amount of pods able to run on single node
+# default is equal to application default
+kubelet_max_pods: 110
+
+## Support custom flags to be passed to kubelet
+kubelet_custom_flags: []
+
+# This setting is used for rkt based kubelet for deploying hyperkube
+# from a docker based registry ( controls --insecure and docker:// )
+## Empty vaule for quay.io containers
+## docker for docker registry containers
+kube_hyperkube_image_repo: ""
+
+# If non-empty, will use this string as identification instead of the actual hostname
+kube_override_hostname: >-
+  {%- if cloud_provider is defined and cloud_provider in [ 'aws' ] -%}
+  {%- else -%}
+  {{ inventory_hostname }}
+  {%- endif -%}
+
+# cAdvisor port
+kube_cadvisor_port: 0
+
+# The read-only port for the Kubelet to serve on with no authentication/authorization.
+kube_read_only_port: 0
+
+# sysctl_file_path to add sysctl conf to
+sysctl_file_path: "/etc/sysctl.d/99-sysctl.conf"
+
+# For the openstack integration kubelet will need credentials to access
+# openstack apis like nova and cinder. Per default this values will be
+# read from the environment.
+openstack_auth_url: "{{ lookup('env','OS_AUTH_URL')  }}"
+openstack_username: "{{ lookup('env','OS_USERNAME')  }}"
+openstack_password: "{{ lookup('env','OS_PASSWORD')  }}"
+openstack_region: "{{ lookup('env','OS_REGION_NAME')  }}"
+openstack_tenant_id: "{{ lookup('env','OS_TENANT_ID')| default(lookup('env','OS_PROJECT_ID')|default(lookup('env','OS_PROJECT_NAME'),true)) }}"
+openstack_tenant_name: "{{ lookup('env','OS_TENANT_NAME') }}"
+openstack_domain_name: "{{ lookup('env','OS_USER_DOMAIN_NAME') }}"
+openstack_domain_id: "{{ lookup('env','OS_USER_DOMAIN_ID') }}"
+
+# For the vsphere integration, kubelet will need credentials to access
+# vsphere apis
+# Documentation regarding these values can be found
+# https://github.com/kubernetes/kubernetes/blob/master/pkg/cloudprovider/providers/vsphere/vsphere.go#L105
+vsphere_vcenter_ip: "{{ lookup('env', 'VSPHERE_VCENTER') }}"
+vsphere_vcenter_port: "{{ lookup('env', 'VSPHERE_VCENTER_PORT') }}"
+vsphere_user: "{{ lookup('env', 'VSPHERE_USER') }}"
+vsphere_password: "{{ lookup('env', 'VSPHERE_PASSWORD') }}"
+vsphere_datacenter: "{{ lookup('env', 'VSPHERE_DATACENTER') }}"
+vsphere_datastore: "{{ lookup('env', 'VSPHERE_DATASTORE') }}"
+vsphere_working_dir: "{{ lookup('env', 'VSPHERE_WORKING_DIR') }}"
+vsphere_insecure: "{{ lookup('env', 'VSPHERE_INSECURE') }}"
+vsphere_resource_pool: "{{ lookup('env', 'VSPHERE_RESOURCE_POOL') }}"
+
+vsphere_scsi_controller_type: pvscsi
+# vsphere_public_network is name of the network the VMs are joined to
+vsphere_public_network: "{{ lookup('env', 'VSPHERE_PUBLIC_NETWORK')|default('') }}"
+
+## When azure is used, you need to also set the following variables.
+## see docs/azure.md for details on how to get these values
+# azure_tenant_id:
+# azure_subscription_id:
+# azure_aad_client_id:
+# azure_aad_client_secret:
+# azure_resource_group:
+# azure_location:
+# azure_subnet_name:
+# azure_security_group_name:
+# azure_vnet_name:
+# azure_route_table_name:

--- a/roles/kubernetes-recover/node/handlers/main.yml
+++ b/roles/kubernetes-recover/node/handlers/main.yml
@@ -1,0 +1,14 @@
+---
+- name: restart kubelet
+  command: /bin/true
+  notify:
+    - Kubelet | reload systemd
+    - Kubelet | reload kubelet
+
+- name: Kubelet | reload systemd
+  command: systemctl daemon-reload
+
+- name: Kubelet | reload kubelet
+  service:
+    name: kubelet
+    state: restarted

--- a/roles/kubernetes-recover/node/meta/main.yml
+++ b/roles/kubernetes-recover/node/meta/main.yml
@@ -1,0 +1,6 @@
+---
+dependencies:
+  - role: kubernetes-recover/secrets
+    when: not kubeadm_enabled
+    tags:
+      - k8s-secrets

--- a/roles/kubernetes-recover/node/tasks/azure-credential-check.yml
+++ b/roles/kubernetes-recover/node/tasks/azure-credential-check.yml
@@ -1,0 +1,55 @@
+---
+- name: check azure_tenant_id value
+  fail:
+    msg: "azure_tenant_id is missing"
+  when: azure_tenant_id is not defined or azure_tenant_id == ""
+
+- name: check openstack_username value
+  fail:
+    msg: "azure_subscription_id is missing"
+  when: azure_subscription_id is not defined or azure_subscription_id == ""
+
+- name: check azure_aad_client_id value
+  fail:
+    msg: "azure_aad_client_id is missing"
+  when: azure_aad_client_id is not defined or azure_aad_client_id == ""
+
+- name: check azure_aad_client_secret value
+  fail:
+    msg: "azure_aad_client_secret is missing"
+  when: azure_aad_client_secret is not defined or azure_aad_client_secret == ""
+
+- name: check azure_resource_group value
+  fail:
+    msg: "azure_resource_group is missing"
+  when: azure_resource_group is not defined or azure_resource_group == ""
+
+- name: check azure_location value
+  fail:
+    msg: "azure_location is missing"
+  when: azure_location is not defined or azure_location == ""
+
+- name: check azure_subnet_name value
+  fail:
+    msg: "azure_subnet_name is missing"
+  when: azure_subnet_name is not defined or azure_subnet_name == ""
+
+- name: check azure_security_group_name value
+  fail:
+    msg: "azure_security_group_name is missing"
+  when: azure_security_group_name is not defined or azure_security_group_name == ""
+
+- name: check azure_vnet_name value
+  fail:
+    msg: "azure_vnet_name is missing"
+  when: azure_vnet_name is not defined or azure_vnet_name == ""
+
+- name: check azure_vnet_resource_group value
+  fail:
+    msg: "azure_vnet_resource_group is missing"
+  when: azure_vnet_resource_group is not defined or azure_vnet_resource_group == ""
+
+- name: check azure_route_table_name value
+  fail:
+    msg: "azure_route_table_name is missing"
+  when: azure_route_table_name is not defined or azure_route_table_name == ""

--- a/roles/kubernetes-recover/node/tasks/facts.yml
+++ b/roles/kubernetes-recover/node/tasks/facts.yml
@@ -1,0 +1,11 @@
+---
+- name: look up docker cgroup driver
+  shell: "docker info | grep 'Cgroup Driver' | awk -F': ' '{ print $2; }'"
+  register: docker_cgroup_driver_result
+  changed_when: false
+
+- set_fact:
+    standalone_kubelet: >-
+      {%- if inventory_hostname in groups['kube-master'] and inventory_hostname not in groups['kube-node'] -%}true{%- else -%}false{%- endif -%}
+    kubelet_cgroup_driver_detected: "{{ docker_cgroup_driver_result.stdout }}"
+

--- a/roles/kubernetes-recover/node/tasks/install.yml
+++ b/roles/kubernetes-recover/node/tasks/install.yml
@@ -1,0 +1,47 @@
+---
+- name: install | Set SSL CA directories
+  set_fact:
+    ssl_ca_dirs: "[
+      {% if ansible_os_family in ['CoreOS', 'Container Linux by CoreOS'] -%}
+      '/usr/share/ca-certificates',
+      {% elif ansible_os_family == 'RedHat' -%}
+      '/etc/pki/tls',
+      '/etc/pki/ca-trust',
+      {% elif ansible_os_family == 'Debian' -%}
+      '/usr/share/ca-certificates',
+      {% endif -%}
+    ]"
+  tags:
+    - facts
+
+- name: Set kubelet deployment to host if kubeadm is enabled
+  set_fact:
+    kubelet_deployment_type: host
+  when: kubeadm_enabled
+  tags:
+    - kubeadm
+
+- name: install | Copy kubeadm binary from download dir
+  command: rsync -piu "{{ local_release_dir }}/kubeadm" "{{ bin_dir }}/kubeadm"
+  changed_when: false
+  when: kubeadm_enabled
+  tags:
+    - kubeadm
+
+- name: install | Set kubeadm binary permissions
+  file:
+    path: "{{ bin_dir }}/kubeadm"
+    mode: "0755"
+    state: file
+  when: kubeadm_enabled
+  tags:
+    - kubeadm
+
+- include_tasks: "install_{{ kubelet_deployment_type }}.yml"
+
+- name: install | Write kubelet systemd init file
+  template:
+    src: "kubelet.{{ kubelet_deployment_type }}.service.j2"
+    dest: "/etc/systemd/system/kubelet.service"
+    backup: "yes"
+  #notify: restart kubelet

--- a/roles/kubernetes-recover/node/tasks/install_docker.yml
+++ b/roles/kubernetes-recover/node/tasks/install_docker.yml
@@ -1,0 +1,9 @@
+---
+- name: install | Install kubelet launch script
+  template:
+    src: kubelet-container.j2
+    dest: "{{ bin_dir }}/kubelet"
+    owner: kube
+    mode: 0755
+    backup: yes
+  #notify: restart kubelet

--- a/roles/kubernetes-recover/node/tasks/install_host.yml
+++ b/roles/kubernetes-recover/node/tasks/install_host.yml
@@ -1,0 +1,30 @@
+---
+- name: install | Compare host kubelet with hyperkube container
+  command: "{{ docker_bin_dir }}/docker run --rm -v {{ bin_dir }}:/systembindir {{ hyperkube_image_repo }}:{{ hyperkube_image_tag }} /usr/bin/cmp /hyperkube /systembindir/kubelet"
+  register: kubelet_task_compare_result
+  until: kubelet_task_compare_result.rc in [0,1,2]
+  retries: 4
+  delay: "{{ retry_stagger | random + 3 }}"
+  changed_when: false
+  failed_when: "kubelet_task_compare_result.rc not in [0,1,2]"
+  tags:
+    - hyperkube
+    - upgrade
+
+- name: install | Copy kubelet from hyperkube container
+  command: "{{ docker_bin_dir }}/docker run --rm -v {{ bin_dir }}:/systembindir {{ hyperkube_image_repo }}:{{ hyperkube_image_tag }} /bin/cp -f /hyperkube /systembindir/kubelet"
+  when: kubelet_task_compare_result.rc != 0
+  register: kubelet_task_result
+  until: kubelet_task_result.rc == 0
+  retries: 4
+  delay: "{{ retry_stagger | random + 3 }}"
+  tags:
+    - hyperkube
+    - upgrade
+  notify: restart kubelet
+
+- name: install | Copy socat wrapper for Container Linux
+  command: "{{ docker_bin_dir }}/docker run --rm -v {{ bin_dir }}:/opt/bin {{ install_socat_image_repo }}:{{ install_socat_image_tag }}"
+  args:
+    creates: "{{ bin_dir }}/socat"
+  when: ansible_os_family in ['CoreOS', 'Container Linux by CoreOS']

--- a/roles/kubernetes-recover/node/tasks/install_rkt.yml
+++ b/roles/kubernetes-recover/node/tasks/install_rkt.yml
@@ -1,0 +1,32 @@
+---
+- name: Trust kubelet container
+  command: >-
+    /usr/bin/rkt trust
+    --skip-fingerprint-review
+    --root
+    {{ item }}
+  register: kubelet_rkt_trust_result
+  until: kubelet_rkt_trust_result.rc == 0
+  with_items:
+    - "https://quay.io/aci-signing-key"
+    - "https://coreos.com/dist/pubkeys/aci-pubkeys.gpg"
+  retries: 4
+  delay: "{{ retry_stagger | random + 3 }}"
+  changed_when: false
+
+- name: create kubelet working directory
+  file:
+    state: directory
+    path: /var/lib/kubelet
+
+- name: Create kubelet service systemd directory
+  file:
+    path: /etc/systemd/system/kubelet.service.d
+    state: directory
+
+- name: Write kubelet proxy drop-in
+  template:
+    src: http-proxy.conf.j2
+    dest: /etc/systemd/system/kubelet.service.d/http-proxy.conf
+  when: http_proxy is defined or https_proxy is defined
+  notify: restart kubelet

--- a/roles/kubernetes-recover/node/tasks/main.yml
+++ b/roles/kubernetes-recover/node/tasks/main.yml
@@ -1,0 +1,188 @@
+---
+- import_tasks: facts.yml
+  when: inventory_hostname in groups['master-add']
+  tags:
+    - facts
+
+- name: Ensure /var/lib/cni exists
+  file:
+    path: /var/lib/cni
+    state: directory
+    mode: 0755
+
+- import_tasks: install.yml
+  #when: inventory_hostname in groups['master-add']
+  tags:
+    - kubelet
+
+- name: Remove nginx proxy from new master avoid port conflict
+  file:
+    path: "{{ kube_manifest_dir }}/nginx-proxy.yml"
+    state: absent
+  ignore_errors: yes
+  when: is_kube_master == true
+  tags:
+    - files
+  
+- name: Write kubelet config file (non-kubeadm)
+  template:
+    src: kubelet.standard.env.j2
+    dest: "{{ kube_config_dir }}/kubelet.env"
+    backup: yes
+  when: not kubeadm_enabled and inventory_hostname in groups['master-add']
+  #notify: restart kubelet
+  tags:
+    - kubelet
+
+- name: Write kubelet config file (kubeadm)
+  template:
+    src: kubelet.kubeadm.env.j2
+    dest: "{{ kube_config_dir }}/kubelet.env"
+    backup: yes
+  when: kubeadm_enabled and inventory_hostname in groups['master-add']
+  #notify: restart kubelet
+  tags:
+    - kubelet
+    - kubeadm
+
+- name: write the kubecfg (auth) file for kubelet
+  template:
+    src: "{{ item }}-kubeconfig.yaml.j2"
+    dest: "{{ kube_config_dir }}/{{ item }}-kubeconfig.yaml"
+    backup: yes
+  with_items:
+    - node
+    - kube-proxy
+  when: not kubeadm_enabled and inventory_hostname in groups['master-add']
+  #notify: restart kubelet
+  tags:
+    - kubelet
+
+- name: Ensure nodePort range is reserved
+  sysctl:
+    name: net.ipv4.ip_local_reserved_ports
+    value: "{{ kube_apiserver_node_port_range }}"
+    sysctl_set: yes
+    sysctl_file: "{{ sysctl_file_path }}"
+    state: present
+    reload: yes
+  when: kube_apiserver_node_port_range is defined and inventory_hostname in groups['master-add']
+  tags:
+    - kube-proxy
+
+- name: Verify if br_netfilter module exists
+  shell: "modinfo br_netfilter"
+  register: modinfo_br_netfilter
+  failed_when: modinfo_br_netfilter.rc not in [0, 1]
+  changed_when: false
+
+- name: Enable br_netfilter module
+  modprobe:
+    name: br_netfilter
+    state: present
+  when: modinfo_br_netfilter.rc == 0 and inventory_hostname in groups['master-add']
+
+- name: Persist br_netfilter module
+  copy:
+    dest: /etc/modules-load.d/kubespray-br_netfilter.conf
+    content: br_netfilter
+  when: modinfo_br_netfilter.rc == 0 and inventory_hostname in groups['master-add']
+
+# kube-proxy needs net.bridge.bridge-nf-call-iptables enabled when found if br_netfilter is not a module
+- name: Check if bridge-nf-call-iptables key exists
+  command: "sysctl net.bridge.bridge-nf-call-iptables"
+  failed_when: false
+  changed_when: false
+  register: sysctl_bridge_nf_call_iptables
+
+- name: Enable bridge-nf-call tables
+  sysctl:
+    name: "{{ item }}"
+    state: present
+    sysctl_file: "{{ sysctl_file_path }}"
+    value: 1
+    reload: yes
+  when: sysctl_bridge_nf_call_iptables.rc == 0 and inventory_hostname in groups['master-add']
+  with_items:
+    - net.bridge.bridge-nf-call-iptables
+    - net.bridge.bridge-nf-call-arptables
+    - net.bridge.bridge-nf-call-ip6tables
+
+- name: Modprode Kernel Module for IPVS
+  modprobe:
+    name: "{{ item }}"
+    state: present
+  when: kube_proxy_mode == 'ipvs' and inventory_hostname in groups['master-add']
+  with_items:
+    - ip_vs
+    - ip_vs_rr
+    - ip_vs_wrr
+    - ip_vs_sh
+    - nf_conntrack_ipv4
+  tags:
+    - kube-proxy
+
+- name: Persist ip_vs modules
+  copy:
+    dest: /etc/modules-load.d/kube_proxy-ipvs.conf
+    content: |
+      ip_vs
+      ip_vs_rr
+      ip_vs_wrr
+      ip_vs_sh
+      nf_conntrack_ipv4
+  when: kube_proxy_mode == 'ipvs' and inventory_hostname in groups['master-add']
+  tags:
+    - kube-proxy
+
+- name: Write proxy manifest
+  template:
+    src: manifests/kube-proxy.manifest.j2
+    dest: "{{ kube_manifest_dir }}/kube-proxy.manifest"
+  when: not kubeadm_enabled and inventory_hostname in groups['master-add']
+  tags:
+    - kube-proxy
+
+- name: Purge proxy manifest for kubeadm
+  file:
+    path: "{{ kube_manifest_dir }}/kube-proxy.manifest"
+    state: absent
+  when: kubeadm_enabled and inventory_hostname in groups['master-add']
+  tags:
+    - kube-proxy
+
+- include_tasks: "{{ cloud_provider }}-credential-check.yml"
+  when:
+    - cloud_provider is defined
+    - cloud_provider in [ 'openstack', 'azure', 'vsphere' ]
+    - inventory_hostname in groups['master-add']
+  tags:
+    - cloud-provider
+    - facts
+
+- name: Write cloud-config
+  template:
+    src: "{{ cloud_provider }}-cloud-config.j2"
+    dest: "{{ kube_config_dir }}/cloud_config"
+    group: "{{ kube_cert_group }}"
+    mode: 0640
+  when:
+    - cloud_provider is defined
+    - cloud_provider in [ 'openstack', 'azure', 'vsphere' ]
+    - inventory_hostname in groups['master-add']
+  notify: restart kubelet
+  tags:
+    - cloud-provider
+
+# reload-systemd
+- meta: flush_handlers
+  #when: inventory_hostname in groups['master-add']
+
+- name: Enable kubelet
+  service:
+    name: kubelet
+    enabled: yes
+    state: started
+  #when: inventory_hostname in groups['master-add']
+  tags:
+    - kubelet

--- a/roles/kubernetes-recover/node/tasks/nginx-proxy.yml
+++ b/roles/kubernetes-recover/node/tasks/nginx-proxy.yml
@@ -1,0 +1,20 @@
+---
+- name: nginx-proxy | Write static pod
+  template:
+    src: manifests/nginx-proxy.manifest.j2
+    dest: "{{kube_manifest_dir}}/nginx-proxy.yml"
+
+- name: nginx-proxy | Make nginx directory
+  file:
+    path: /etc/nginx
+    state: directory
+    mode: 0700
+    owner: root
+
+- name: nginx-proxy | Write nginx-proxy configuration
+  template:
+    src: nginx.conf.j2
+    dest: "/etc/nginx/nginx.conf"
+    owner: root
+    mode: 0755
+    backup: yes

--- a/roles/kubernetes-recover/node/tasks/openstack-credential-check.yml
+++ b/roles/kubernetes-recover/node/tasks/openstack-credential-check.yml
@@ -1,0 +1,25 @@
+---
+- name: check openstack_auth_url value
+  fail:
+    msg: "openstack_auth_url is missing"
+  when: openstack_auth_url is not defined or openstack_auth_url == ""
+
+- name: check openstack_username value
+  fail:
+    msg: "openstack_username is missing"
+  when: openstack_username is not defined or openstack_username == ""
+
+- name: check openstack_password value
+  fail:
+    msg: "openstack_password is missing"
+  when: openstack_password is not defined or openstack_password == ""
+
+- name: check openstack_region value
+  fail:
+    msg: "openstack_region is missing"
+  when: openstack_region is not defined or openstack_region == ""
+
+- name: check openstack_tenant_id value
+  fail:
+    msg: "openstack_tenant_id is missing"
+  when: openstack_tenant_id is not defined or openstack_tenant_id == ""

--- a/roles/kubernetes-recover/node/tasks/pre_upgrade.yml
+++ b/roles/kubernetes-recover/node/tasks/pre_upgrade.yml
@@ -1,0 +1,29 @@
+---
+- name: "Pre-upgrade | check if kubelet container exists"
+  shell: docker ps -af name=kubelet | grep kubelet
+  failed_when: false
+  changed_when: false
+  register: kubelet_container_check
+
+- name: "Pre-upgrade | copy /var/lib/cni from kubelet"
+  command: docker cp kubelet:/var/lib/cni /var/lib/cni
+  args:
+    creates: "/var/lib/cni"
+  failed_when: false
+  when: kubelet_container_check.rc == 0
+
+- name: "Pre-upgrade | ensure kubelet container service is stopped if using host deployment"
+  service:
+    name: kubelet
+    state: stopped
+  when: kubelet_deployment_type == 'host' and kubelet_container_check.rc == 0
+
+- name: "Pre-upgrade | ensure kubelet container is removed if using host deployment"
+  command: docker rm -fv kubelet
+  failed_when: false
+  changed_when: false
+  register: remove_kubelet_container
+  retries: 4
+  until: remove_kubelet_container.rc == 0
+  delay: 5
+  when: kubelet_deployment_type == 'host' and kubelet_container_check.rc == 0

--- a/roles/kubernetes-recover/node/tasks/vsphere-credential-check.yml
+++ b/roles/kubernetes-recover/node/tasks/vsphere-credential-check.yml
@@ -1,0 +1,22 @@
+---
+- name: check vsphere environment variables
+  fail:
+    msg: "{{ item.name }} is missing"
+  when: item.value is not defined or item.value == ''
+  with_items:
+    - name: vsphere_vcenter_ip
+      value: "{{ vsphere_vcenter_ip }}"
+    - name: vsphere_vcenter_port
+      value: "{{ vsphere_vcenter_port }}"
+    - name: vsphere_user
+      value: "{{ vsphere_user }}"
+    - name: vsphere_password
+      value: "{{ vsphere_password }}"
+    - name: vsphere_datacenter
+      value: "{{ vsphere_datacenter }}"
+    - name: vsphere_datastore
+      value: "{{ vsphere_datastore }}"
+    - name: vsphere_working_dir
+      value: "{{ vsphere_working_dir }}"
+    - name: vsphere_insecure
+      value: "{{ vsphere_insecure }}"

--- a/roles/kubernetes-recover/node/templates/azure-cloud-config.j2
+++ b/roles/kubernetes-recover/node/templates/azure-cloud-config.j2
@@ -1,0 +1,13 @@
+{
+  "tenantId": "{{ azure_tenant_id }}",
+  "subscriptionId": "{{ azure_subscription_id }}",
+  "aadClientId": "{{ azure_aad_client_id }}",
+  "aadClientSecret": "{{ azure_aad_client_secret }}",
+  "resourceGroup": "{{ azure_resource_group }}",
+  "location": "{{ azure_location }}",
+  "subnetName": "{{ azure_subnet_name }}",
+  "securityGroupName": "{{ azure_security_group_name }}",
+  "vnetName": "{{ azure_vnet_name }}",
+  "vnetResourceGroup": "{{ azure_vnet_resource_group }}",
+  "routeTableName": "{{ azure_route_table_name }}"
+}

--- a/roles/kubernetes-recover/node/templates/http-proxy.conf.j2
+++ b/roles/kubernetes-recover/node/templates/http-proxy.conf.j2
@@ -1,0 +1,2 @@
+[Service]
+Environment={% if http_proxy %}"HTTP_PROXY={{ http_proxy }}"{% endif %} {% if https_proxy %}"HTTPS_PROXY={{ https_proxy }}"{% endif %} {% if no_proxy %}"NO_PROXY={{ no_proxy }}"{% endif %}

--- a/roles/kubernetes-recover/node/templates/kube-proxy-kubeconfig.yaml.j2
+++ b/roles/kubernetes-recover/node/templates/kube-proxy-kubeconfig.yaml.j2
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Config
+clusters:
+- name: local
+  cluster:
+    certificate-authority: {{ kube_cert_dir }}/ca.pem
+    server: {{ kube_apiserver_endpoint }}
+users:
+- name: kube-proxy
+  user:
+    client-certificate: {{ kube_cert_dir }}/kube-proxy-{{ inventory_hostname }}.pem
+    client-key: {{ kube_cert_dir }}/kube-proxy-{{ inventory_hostname }}-key.pem
+contexts:
+- context:
+    cluster: local
+    user: kube-proxy
+  name: kube-proxy-{{ cluster_name }}
+current-context: kube-proxy-{{ cluster_name }}

--- a/roles/kubernetes-recover/node/templates/kubelet-container.j2
+++ b/roles/kubernetes-recover/node/templates/kubelet-container.j2
@@ -1,0 +1,40 @@
+#!/bin/bash
+{{ docker_bin_dir }}/docker run \
+  --net=host \
+  --pid=host \
+  --privileged \
+  --name=kubelet \
+  --restart=on-failure:5 \
+  --memory={{ kube_memory_reserved|regex_replace('Mi', 'M') }} \
+  --cpu-shares={{ kube_cpu_reserved|regex_replace('m', '')  }} \
+  -v /dev:/dev:rw \
+  -v /etc/cni:/etc/cni:ro \
+  -v /opt/cni:/opt/cni:ro \
+  -v /etc/ssl:/etc/ssl:ro \
+  -v /etc/resolv.conf:/etc/resolv.conf \
+  {% for dir in ssl_ca_dirs -%}
+  -v {{ dir }}:{{ dir }}:ro \
+  {% endfor -%}
+  {% if kubelet_load_modules -%}
+  -v /lib/modules:/lib/modules:ro \
+  {% endif -%}
+  -v /sys:/sys:ro \
+  -v {{ docker_daemon_graph }}:{{ docker_daemon_graph }}:rw \
+  -v /var/log:/var/log:rw \
+  -v /var/lib/kubelet:/var/lib/kubelet:shared \
+  -v /var/lib/cni:/var/lib/cni:shared \
+  -v /var/run:/var/run:rw \
+  {# we can run into issues with double mounting /var/lib/kubelet #}
+  {# surely there's a better way to do this #}
+  {% if '/var/lib/kubelet' not in kubelet_flexvolumes_plugins_dir %}
+  -v {{ kubelet_flexvolumes_plugins_dir }}:{{ kubelet_flexvolumes_plugins_dir }}:rw \
+  {% endif -%}
+  {% if local_volume_provisioner_enabled -%}
+  -v {{ local_volume_provisioner_base_dir }}:{{ local_volume_provisioner_base_dir }}:rw \
+  -v {{ local_volume_provisioner_mount_dir }}:{{ local_volume_provisioner_mount_dir }}:rw \
+  {% endif %}
+  -v {{kube_config_dir}}:{{kube_config_dir}}:ro \
+  -v /etc/os-release:/etc/os-release:ro \
+  {{ hyperkube_image_repo }}:{{ hyperkube_image_tag}} \
+  ./hyperkube kubelet \
+  "$@"

--- a/roles/kubernetes-recover/node/templates/kubelet.docker.service.j2
+++ b/roles/kubernetes-recover/node/templates/kubelet.docker.service.j2
@@ -1,0 +1,31 @@
+[Unit]
+Description=Kubernetes Kubelet Server
+Documentation=https://github.com/GoogleCloudPlatform/kubernetes
+After=docker.service
+Wants=docker.socket
+
+[Service]
+User=root
+EnvironmentFile={{kube_config_dir}}/kubelet.env
+ExecStart={{ bin_dir }}/kubelet \
+		$KUBE_LOGTOSTDERR \
+		$KUBE_LOG_LEVEL \
+		$KUBELET_API_SERVER \
+		$KUBELET_ADDRESS \
+		$KUBELET_PORT \
+		$KUBELET_HOSTNAME \
+		$KUBE_ALLOW_PRIV \
+		$KUBELET_ARGS \
+		$DOCKER_SOCKET \
+		$KUBELET_NETWORK_PLUGIN \
+		$KUBELET_VOLUME_PLUGIN \
+		$KUBELET_CLOUDPROVIDER
+Restart=always
+RestartSec=10s
+ExecStartPre=-{{ docker_bin_dir }}/docker rm -f kubelet
+ExecStartPre=-/bin/mkdir -p {{ kubelet_flexvolumes_plugins_dir }}
+ExecReload={{ docker_bin_dir }}/docker restart kubelet
+
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/kubernetes-recover/node/templates/kubelet.host.service.j2
+++ b/roles/kubernetes-recover/node/templates/kubelet.host.service.j2
@@ -1,0 +1,28 @@
+[Unit]
+Description=Kubernetes Kubelet Server
+Documentation=https://github.com/GoogleCloudPlatform/kubernetes
+After=docker.service
+Wants=docker.socket
+
+[Service]
+User=root
+EnvironmentFile=-{{kube_config_dir}}/kubelet.env
+ExecStartPre=-/bin/mkdir -p {{ kubelet_flexvolumes_plugins_dir }}
+ExecStart={{ bin_dir }}/kubelet \
+		$KUBE_LOGTOSTDERR \
+		$KUBE_LOG_LEVEL \
+		$KUBELET_API_SERVER \
+		$KUBELET_ADDRESS \
+		$KUBELET_PORT \
+		$KUBELET_HOSTNAME \
+		$KUBE_ALLOW_PRIV \
+		$KUBELET_ARGS \
+		$DOCKER_SOCKET \
+		$KUBELET_NETWORK_PLUGIN \
+		$KUBELET_VOLUME_PLUGIN \
+		$KUBELET_CLOUDPROVIDER
+Restart=always
+RestartSec=10s
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/kubernetes-recover/node/templates/kubelet.kubeadm.env.j2
+++ b/roles/kubernetes-recover/node/templates/kubelet.kubeadm.env.j2
@@ -1,0 +1,105 @@
+### Upstream source https://github.com/kubernetes/release/blob/master/debian/xenial/kubeadm/channel/stable/etc/systemd/system/kubelet.service.d/
+### All upstream values should be present in this file
+
+# logging to stderr means we get it in the systemd journal
+KUBE_LOGTOSTDERR="--logtostderr=true"
+KUBE_LOG_LEVEL="--v={{ kube_log_level }}"
+# The address for the info server to serve on (set to 0.0.0.0 or "" for all interfaces)
+KUBELET_ADDRESS="--address={{ kubelet_bind_address }} --node-ip={{ kubelet_address }}"
+# The port for the info server to serve on
+# KUBELET_PORT="--port=10250"
+{% if kube_override_hostname|default('') %}
+# You may leave this blank to use the actual hostname
+KUBELET_HOSTNAME="--hostname-override={{ kube_override_hostname }}"
+{% endif %}
+{# Base kubelet args #}
+{% set kubelet_args_base -%}
+{# start kubeadm specific settings #}
+--bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
+--kubeconfig={{ kube_config_dir }}/kubelet.conf \
+{% if kube_version | version_compare('v1.8', '<') %}
+--require-kubeconfig \
+{% endif %}
+{% if kubelet_authentication_token_webhook %}
+--authentication-token-webhook \
+{% endif %}
+{% if kubelet_authorization_mode_webhook %}
+--authorization-mode=Webhook \
+{% endif %}
+--client-ca-file={{ kube_cert_dir }}/ca.crt \
+--pod-manifest-path={{ kube_manifest_dir }} \
+--cadvisor-port={{ kube_cadvisor_port }} \
+{# end kubeadm specific settings #}
+--pod-infra-container-image={{ pod_infra_image_repo }}:{{ pod_infra_image_tag }} \
+--node-status-update-frequency={{ kubelet_status_update_frequency }} \
+--cgroup-driver={{ kubelet_cgroup_driver|default(kubelet_cgroup_driver_detected) }} \
+--max-pods={{ kubelet_max_pods }} \
+--docker-disable-shared-pid={{ kubelet_disable_shared_pid }} \
+--anonymous-auth=false \
+--read-only-port={{ kube_read_only_port }} \
+{% if kube_version | version_compare('v1.8', '<') %}
+--experimental-fail-swap-on={{ kubelet_fail_swap_on|default(true)}} \
+{% else %}
+--fail-swap-on={{ kubelet_fail_swap_on|default(true)}} \
+{% endif %}
+{% endset %}
+
+{# Node reserved CPU/memory #}
+{% if is_kube_master|bool %}
+{% set kube_reserved %}--kube-reserved cpu={{ kube_master_cpu_reserved }},memory={{ kube_master_memory_reserved|regex_replace('Mi', 'M') }}{% endset %}
+{% else %}
+{% set kube_reserved %}--kube-reserved cpu={{ kube_cpu_reserved }},memory={{ kube_memory_reserved|regex_replace('Mi', 'M') }}{% endset %}
+{% endif %}
+
+{# DNS settings for kubelet #}
+{% if dns_mode in ['kubedns', 'coredns'] %}
+{% set kubelet_args_cluster_dns %}--cluster-dns={{ skydns_server }}{% endset %}
+{% elif dns_mode == 'coredns_dual' %}
+{% set kubelet_args_cluster_dns %}--cluster-dns={{ skydns_server }},{{ skydns_server_secondary }}{% endset %}
+{% elif dns_mode == 'dnsmasq_kubedns' %}
+{% set kubelet_args_cluster_dns %}--cluster-dns={{ dnsmasq_dns_server }}{% endset %}
+{% elif dns_mode == 'manual' %}
+{% set kubelet_args_cluster_dns %}--cluster-dns={{ manual_dns_server }}{% endset %}
+{% else %}
+{% set kubelet_args_cluster_dns %}{% endset %}
+{% endif %}
+{% set kubelet_args_dns %}{{ kubelet_args_cluster_dns }} --cluster-domain={{ dns_domain }} --resolv-conf={{ kube_resolv_conf }}{% endset %}
+
+{# Kubelet node labels #}
+{% set role_node_labels = [] %}
+{% if inventory_hostname in groups['kube-master'] %}
+{%   set dummy = role_node_labels.append('node-role.kubernetes.io/master=true') %}
+{%   if not standalone_kubelet|bool %}
+{%     set dummy = role_node_labels.append('node-role.kubernetes.io/node=true') %}
+{%   endif %}
+{% else %}
+{%   set dummy = role_node_labels.append('node-role.kubernetes.io/node=true') %}
+{% endif %}
+{% if inventory_hostname in groups['kube-ingress']|default([]) %}
+{%   set dummy = role_node_labels.append('node-role.kubernetes.io/ingress=true') %}
+{% endif %}
+{% set inventory_node_labels = [] %}
+{% if node_labels is defined %}
+{%   for labelname, labelvalue in node_labels.iteritems() %}
+{%     set dummy = inventory_node_labels.append('%s=%s'|format(labelname, labelvalue)) %}
+{%   endfor %}
+{% endif %}
+{% set all_node_labels = role_node_labels + inventory_node_labels %}
+
+KUBELET_ARGS="{{ kubelet_args_base }} {{ kubelet_args_dns }} {{ kube_reserved }} --node-labels={{ all_node_labels | join(',') }} {% if kubelet_custom_flags is string %} {{kubelet_custom_flags}} {% else %}{% for flag in kubelet_custom_flags %} {{flag}} {% endfor %}{% endif %}"
+{% if kube_network_plugin is defined and kube_network_plugin in ["calico", "canal", "flannel", "weave", "contiv", "cilium"] %}
+KUBELET_NETWORK_PLUGIN="--network-plugin=cni --cni-conf-dir=/etc/cni/net.d --cni-bin-dir=/opt/cni/bin"
+{% elif kube_network_plugin is defined and kube_network_plugin == "cloud" %}
+KUBELET_NETWORK_PLUGIN="--hairpin-mode=promiscuous-bridge --network-plugin=kubenet"
+{% endif %}
+# Should this cluster be allowed to run privileged docker containers
+KUBE_ALLOW_PRIV="--allow-privileged=true"
+{% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere"] %}
+KUBELET_CLOUDPROVIDER="--cloud-provider={{ cloud_provider }} --cloud-config={{ kube_config_dir }}/cloud_config"
+{% elif cloud_provider is defined and cloud_provider == "aws" %}
+KUBELET_CLOUDPROVIDER="--cloud-provider={{ cloud_provider }}"
+{% else %}
+KUBELET_CLOUDPROVIDER=""
+{% endif %}
+
+PATH={{ bin_dir }}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

--- a/roles/kubernetes-recover/node/templates/kubelet.rkt.service.j2
+++ b/roles/kubernetes-recover/node/templates/kubelet.rkt.service.j2
@@ -1,0 +1,112 @@
+[Unit]
+Description=Kubernetes Kubelet Server
+Documentation=https://github.com/GoogleCloudPlatform/kubernetes
+Wants=network.target
+
+[Service]
+User=root
+Restart=on-failure
+RestartSec=10s
+TimeoutStartSec=0
+LimitNOFILE=40000
+
+ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/run/kubelet.uuid
+ExecStartPre=-/bin/mkdir -p /var/lib/kubelet
+ExecStartPre=-/bin/mkdir -p {{ kubelet_flexvolumes_plugins_dir }}
+
+EnvironmentFile={{kube_config_dir}}/kubelet.env
+# stage1-fly mounts /proc /sys /dev so no need to duplicate the mounts
+ExecStart=/usr/bin/rkt run \
+{% if kubelet_load_modules == true %}
+        --volume modprobe,kind=host,source=/usr/sbin/modprobe \
+        --volume lib-modules,kind=host,source=/lib/modules \
+{% endif %}
+        --volume os-release,kind=host,source=/etc/os-release,readOnly=true \
+        --volume hosts,kind=host,source=/etc/hosts,readOnly=true \
+        --volume dns,kind=host,source=/etc/resolv.conf \
+        --volume etc-kubernetes,kind=host,source={{ kube_config_dir }},readOnly=false \
+        --volume etc-ssl-certs,kind=host,source=/etc/ssl/certs,readOnly=true \
+        --volume etcd-ssl,kind=host,source={{ etcd_config_dir }},readOnly=true \
+        --volume run,kind=host,source=/run,readOnly=false \
+        {% for dir in ssl_ca_dirs -%}
+        --volume {{ dir | regex_replace('^/(.*)$', '\\1' ) | regex_replace('/', '-') }},kind=host,source={{ dir }},readOnly=true \
+        {% endfor -%}
+        --volume var-lib-docker,kind=host,source={{ docker_daemon_graph }},readOnly=false \
+        --volume var-lib-kubelet,kind=host,source=/var/lib/kubelet,readOnly=false,recursive=true \
+        --volume var-log,kind=host,source=/var/log \
+{% if kube_network_plugin in ["calico", "weave", "canal", "flannel", "contiv", "cilium"] %}
+        --volume etc-cni,kind=host,source=/etc/cni,readOnly=true \
+        --volume opt-cni,kind=host,source=/opt/cni,readOnly=true \
+        --volume var-lib-cni,kind=host,source=/var/lib/cni,readOnly=false \
+{# we can run into issues with double mounting /var/lib/kubelet #}
+{# surely there's a better way to do this #}
+{% if '/var/lib/kubelet' not in kubelet_flexvolumes_plugins_dir %}
+        --volume flexvolumes,kind=host,source={{ kubelet_flexvolumes_plugins_dir }},readOnly=false \
+{% endif -%}
+{% if local_volume_provisioner_enabled %}
+        --volume local-volume-provisioner-base-dir,kind=host,source={{ local_volume_provisioner_base_dir }},readOnly=false \
+{# Not pretty, but needed to avoid double mount #}
+{% if local_volume_provisioner_base_dir not in local_volume_provisioner_mount_dir and local_volume_provisioner_mount_dir not in local_volume_provisioner_base_dir %}
+        --volume local-volume-provisioner-mount-dir,kind=host,source={{ local_volume_provisioner_mount_dir }},readOnly=false \
+{% endif %}
+{% endif %}
+{% if kubelet_load_modules == true %}
+        --mount volume=modprobe,target=/usr/sbin/modprobe \
+        --mount volume=lib-modules,target=/lib/modules \
+{% endif %}
+        --mount volume=etc-cni,target=/etc/cni \
+        --mount volume=opt-cni,target=/opt/cni \
+        --mount volume=var-lib-cni,target=/var/lib/cni \
+{% endif %}
+        --mount volume=os-release,target=/etc/os-release \
+        --mount volume=dns,target=/etc/resolv.conf \
+        --mount volume=etc-kubernetes,target={{ kube_config_dir }} \
+        --mount volume=etc-ssl-certs,target=/etc/ssl/certs \
+        --mount volume=etcd-ssl,target={{ etcd_config_dir }} \
+        --mount volume=run,target=/run \
+        {% for dir in ssl_ca_dirs -%}
+        --mount volume={{ dir | regex_replace('^/(.*)$', '\\1' ) | regex_replace('/', '-') }},target={{ dir }} \
+        {% endfor -%}
+        --mount volume=var-lib-docker,target=/var/lib/docker \
+        --mount volume=var-lib-kubelet,target=/var/lib/kubelet \
+        --mount volume=var-log,target=/var/log \
+        --mount volume=hosts,target=/etc/hosts \
+{# we can run into issues with double mounting /var/lib/kubelet #}
+{# surely there's a better way to do this #}
+{% if '/var/lib/kubelet' not in kubelet_flexvolumes_plugins_dir %}
+        --mount volume=flexvolumes,target={{ kubelet_flexvolumes_plugins_dir }} \
+{% endif -%}
+{% if local_volume_provisioner_enabled %}
+        --mount volume=local-volume-provisioner-base-dir,target={{ local_volume_provisioner_base_dir }} \
+{# Not pretty, but needed to avoid double mount #}
+{% if local_volume_provisioner_base_dir not in local_volume_provisioner_mount_dir and local_volume_provisioner_mount_dir not in local_volume_provisioner_base_dir %}
+        --mount volume=local-volume-provisioner-mount-dir,target={{ local_volume_provisioner_mount_dir }} \
+{% endif %}
+{% endif %}
+        --stage1-from-dir=stage1-fly.aci \
+{% if kube_hyperkube_image_repo == "docker" %}
+        --insecure-options=image \
+        docker://{{ hyperkube_image_repo }}:{{ hyperkube_image_tag }} \
+{% else %}
+        {{ hyperkube_image_repo }}:{{ hyperkube_image_tag }} \
+{% endif %}
+        --uuid-file-save=/var/run/kubelet.uuid \
+        --debug --exec=/kubelet -- \
+                $KUBE_LOGTOSTDERR \
+                $KUBE_LOG_LEVEL \
+                $KUBELET_API_SERVER \
+                $KUBELET_ADDRESS \
+                $KUBELET_PORT \
+                $KUBELET_HOSTNAME \
+                $KUBE_ALLOW_PRIV \
+                $KUBELET_ARGS \
+                $DOCKER_SOCKET \
+                $KUBELET_REGISTER_NODE \
+                $KUBELET_NETWORK_PLUGIN \
+                $KUBELET_VOLUME_PLUGIN \
+                $KUBELET_CLOUDPROVIDER
+
+ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/kubelet.uuid
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/kubernetes-recover/node/templates/kubelet.standard.env.j2
+++ b/roles/kubernetes-recover/node/templates/kubelet.standard.env.j2
@@ -1,0 +1,126 @@
+# logging to stderr means we get it in the systemd journal
+KUBE_LOGTOSTDERR="--logtostderr=true"
+KUBE_LOG_LEVEL="--v={{ kube_log_level }}"
+# The address for the info server to serve on (set to 0.0.0.0 or "" for all interfaces)
+KUBELET_ADDRESS="--address={{ kubelet_bind_address }} --node-ip={{ kubelet_address }}"
+# The port for the info server to serve on
+# KUBELET_PORT="--port=10250"
+{% if kube_override_hostname|default('') %}
+# You may leave this blank to use the actual hostname
+KUBELET_HOSTNAME="--hostname-override={{ kube_override_hostname }}"
+{% endif %}
+{# Base kubelet args #}
+{% set kubelet_args_base %}
+--pod-manifest-path={{ kube_manifest_dir }} \
+--cadvisor-port={{ kube_cadvisor_port }} \
+--pod-infra-container-image={{ pod_infra_image_repo }}:{{ pod_infra_image_tag }} \
+--node-status-update-frequency={{ kubelet_status_update_frequency }} \
+--docker-disable-shared-pid={{ kubelet_disable_shared_pid }} \
+--client-ca-file={{ kube_cert_dir }}/ca.pem \
+--tls-cert-file={{ kube_cert_dir }}/node-{{ inventory_hostname }}.pem \
+--tls-private-key-file={{ kube_cert_dir }}/node-{{ inventory_hostname }}-key.pem \
+--anonymous-auth=false \
+--read-only-port={{ kube_read_only_port }} \
+{% if kube_version | version_compare('v1.6', '>=') %}
+{# flag got removed with 1.7.0 #}
+{% if kube_version | version_compare('v1.7', '<') %}
+--enable-cri={{ kubelet_enable_cri }} \
+{% endif %}
+--cgroup-driver={{ kubelet_cgroup_driver|default(kubelet_cgroup_driver_detected) }} \
+--cgroups-per-qos={{ kubelet_cgroups_per_qos }} \
+--max-pods={{ kubelet_max_pods }} \
+{% if kube_version | version_compare('v1.8', '<') %}
+--experimental-fail-swap-on={{ kubelet_fail_swap_on|default(true)}} \
+{% else %}
+--fail-swap-on={{ kubelet_fail_swap_on|default(true)}} \
+{% endif %}
+{% if kubelet_authentication_token_webhook %}
+--authentication-token-webhook \
+{% endif %}
+{% if kubelet_authorization_mode_webhook %}
+--authorization-mode=Webhook \
+{% endif %}
+--enforce-node-allocatable={{ kubelet_enforce_node_allocatable }} {% endif %}{% endset %}
+
+{# DNS settings for kubelet #}
+{% if dns_mode in ['kubedns', 'coredns'] %}
+{% set kubelet_args_cluster_dns %}--cluster-dns={{ skydns_server }}{% endset %}
+{% elif dns_mode == 'coredns_dual' %}
+{% set kubelet_args_cluster_dns %}--cluster-dns={{ skydns_server }},{{ skydns_server_secondary }}{% endset %}
+{% elif dns_mode == 'dnsmasq_kubedns' %}
+{% set kubelet_args_cluster_dns %}--cluster-dns={{ dnsmasq_dns_server }}{% endset %}
+{% elif dns_mode == 'manual' %}
+{% set kubelet_args_cluster_dns %}--cluster-dns={{ manual_dns_server }}{% endset %}
+{% else %}
+{% set kubelet_args_cluster_dns %}{% endset %}
+{% endif %}
+{% set kubelet_args_dns %}{{ kubelet_args_cluster_dns }} --cluster-domain={{ dns_domain }} --resolv-conf={{ kube_resolv_conf }}{% endset %}
+
+{# Location of the apiserver #}
+{% if kube_version | version_compare('v1.8', '<') %}
+{% set kubelet_args_kubeconfig %}--kubeconfig={{ kube_config_dir}}/node-kubeconfig.yaml --require-kubeconfig{% endset %}
+{% else %}
+{% set kubelet_args_kubeconfig %}--kubeconfig={{ kube_config_dir}}/node-kubeconfig.yaml{% endset %}
+{% endif %}
+
+{% if standalone_kubelet|bool %}
+{# We are on a master-only host. Make the master unschedulable in this case. #}
+{% if kube_version | version_compare('v1.6', '>=') %}
+{# Set taints on the master so that it's unschedulable by default. Use node-role.kubernetes.io/master taint like kubeadm. #}
+{% set kubelet_args_kubeconfig %}{{ kubelet_args_kubeconfig }} --register-with-taints=node-role.kubernetes.io/master=:NoSchedule{% endset %}
+{% else %}
+{# --register-with-taints was added in 1.6 so just register unschedulable if Kubernetes < 1.6 #}
+{% set kubelet_args_kubeconfig %}{{ kubelet_args_kubeconfig }} --register-schedulable=false{% endset %}
+{% endif %}
+{% endif %}
+
+{# Node reserved CPU/memory #}
+{% if is_kube_master|bool %}
+{% set kube_reserved %}--kube-reserved cpu={{ kube_master_cpu_reserved }},memory={{ kube_master_memory_reserved|regex_replace('Mi', 'M') }}{% endset %}
+{% else %}
+{% set kube_reserved %}--kube-reserved cpu={{ kube_cpu_reserved }},memory={{ kube_memory_reserved|regex_replace('Mi', 'M') }}{% endset %}
+{% endif %}
+
+{# Kubelet node labels #}
+{% set role_node_labels = [] %}
+{% if inventory_hostname in groups['kube-master'] %}
+{%   set dummy = role_node_labels.append('node-role.kubernetes.io/master=true') %}
+{%   if not standalone_kubelet|bool %}
+{%     set dummy = role_node_labels.append('node-role.kubernetes.io/node=true') %}
+{%   endif %}
+{% else %}
+{%   set dummy = role_node_labels.append('node-role.kubernetes.io/node=true') %}
+{% endif %}
+{% if inventory_hostname in groups['kube-ingress']|default([]) %}
+{%   set dummy = role_node_labels.append('node-role.kubernetes.io/ingress=true') %}
+{% endif %}
+{% set inventory_node_labels = [] %}
+{% if node_labels is defined %}
+{%   for labelname, labelvalue in node_labels.iteritems() %}
+{%     set dummy = inventory_node_labels.append('%s=%s'|format(labelname, labelvalue)) %}
+{%   endfor %}
+{% endif %}
+{% set all_node_labels = role_node_labels + inventory_node_labels %}
+
+KUBELET_ARGS="{{ kubelet_args_base }} {{ kubelet_args_dns }} {{ kubelet_args_kubeconfig }} {{ kube_reserved }} --node-labels={{ all_node_labels | join(',') }} {% if kube_feature_gates %} --feature-gates={{ kube_feature_gates|join(',') }} {% endif %} {% if kubelet_custom_flags is string %} {{kubelet_custom_flags}} {% else %}{% for flag in kubelet_custom_flags %} {{flag}} {% endfor %}{% endif %}"
+{% if kube_network_plugin is defined and kube_network_plugin in ["calico", "canal", "flannel", "weave", "contiv", "cilium"] %}
+KUBELET_NETWORK_PLUGIN="--network-plugin=cni --cni-conf-dir=/etc/cni/net.d --cni-bin-dir=/opt/cni/bin"
+{% elif kube_network_plugin is defined and kube_network_plugin == "weave" %}
+DOCKER_SOCKET="--docker-endpoint=unix:/var/run/weave/weave.sock"
+{% elif kube_network_plugin is defined and kube_network_plugin == "cloud" %}
+KUBELET_NETWORK_PLUGIN="--hairpin-mode=promiscuous-bridge --network-plugin=kubenet"
+{% endif %}
+
+KUBELET_VOLUME_PLUGIN="--volume-plugin-dir={{ kubelet_flexvolumes_plugins_dir }}"
+
+# Should this cluster be allowed to run privileged docker containers
+KUBE_ALLOW_PRIV="--allow-privileged=true"
+{% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere"] %}
+KUBELET_CLOUDPROVIDER="--cloud-provider={{ cloud_provider }} --cloud-config={{ kube_config_dir }}/cloud_config"
+{% elif cloud_provider is defined and cloud_provider == "aws" %}
+KUBELET_CLOUDPROVIDER="--cloud-provider={{ cloud_provider }}"
+{% else %}
+KUBELET_CLOUDPROVIDER=""
+{% endif %}
+
+PATH={{ bin_dir }}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

--- a/roles/kubernetes-recover/node/templates/manifests/kube-proxy.manifest.j2
+++ b/roles/kubernetes-recover/node/templates/manifests/kube-proxy.manifest.j2
@@ -1,0 +1,101 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kube-proxy
+  namespace: kube-system
+  labels:
+    k8s-app: kube-proxy
+  annotations:
+    kubespray.kube-proxy-cert/serial: "{{ kube_proxy_cert_serial }}"
+spec:
+  hostNetwork: true
+{% if kube_version | version_compare('v1.6', '>=') %}
+  dnsPolicy: ClusterFirst
+{% endif %}
+  containers:
+  - name: kube-proxy
+    image: {{ hyperkube_image_repo }}:{{ hyperkube_image_tag }}
+    imagePullPolicy: {{ k8s_image_pull_policy }}
+    resources:
+      limits:
+        cpu: {{ kube_proxy_cpu_limit }}
+        memory: {{ kube_proxy_memory_limit }}
+      requests:
+        cpu: {{ kube_proxy_cpu_requests }}
+        memory: {{ kube_proxy_memory_requests }}
+    livenessProbe:
+      httpGet:
+        host: 127.0.0.1
+        path: /healthz
+        port: 10256
+      failureThreshold: 8
+      initialDelaySeconds: 15
+      periodSeconds: 10
+      successThreshold: 1
+      timeoutSeconds: 15
+    command:
+    - /hyperkube
+    - proxy
+    - --v={{ kube_log_level }}
+    - --kubeconfig={{kube_config_dir}}/kube-proxy-kubeconfig.yaml
+    - --bind-address={{ ip | default(ansible_default_ipv4.address) }}
+    - --cluster-cidr={{ kube_pods_subnet }}
+    - --proxy-mode={{ kube_proxy_mode }}
+    - --oom-score-adj=-998
+    - --healthz-bind-address=127.0.0.1
+{% if kube_proxy_masquerade_all and kube_proxy_mode == "iptables" %}
+    - --masquerade-all
+{% elif kube_proxy_mode == 'ipvs' %}
+    - --masquerade-all
+{% if kube_version | version_compare('v1.10', '<') %}
+    - --feature-gates=SupportIPVSProxyMode=true
+{% endif %}
+    - --ipvs-min-sync-period=5s
+    - --ipvs-sync-period=5s
+    - --ipvs-scheduler=rr
+{% endif %}
+    securityContext:
+      privileged: true
+    volumeMounts:
+    - mountPath: /etc/ssl/certs
+      name: ssl-certs-host
+      readOnly: true
+    - mountPath: "{{ kube_config_dir }}/ssl"
+      name: etc-kube-ssl
+      readOnly: true
+    - mountPath: "{{ kube_config_dir }}/kube-proxy-kubeconfig.yaml"
+      name: kubeconfig
+      readOnly: true
+    - mountPath: /var/run/dbus
+      name: var-run-dbus
+      readOnly: false
+    - mountPath: /lib/modules
+      name: lib-modules
+      readOnly: true
+    - mountPath: /run/xtables.lock
+      name: xtables-lock
+      readOnly: false
+  volumes:
+  - name: ssl-certs-host
+    hostPath:
+{% if ansible_os_family == 'RedHat' %}
+      path: /etc/pki/tls
+{% else %}
+      path: /usr/share/ca-certificates
+{% endif %}
+  - name: etc-kube-ssl
+    hostPath:
+      path: "{{ kube_config_dir }}/ssl"
+  - name: kubeconfig
+    hostPath:
+      path: "{{ kube_config_dir }}/kube-proxy-kubeconfig.yaml"
+  - name: var-run-dbus
+    hostPath:
+      path: /var/run/dbus
+  - hostPath:
+      path: /lib/modules
+    name: lib-modules
+  - hostPath:
+      path: /run/xtables.lock
+      type: FileOrCreate
+    name: xtables-lock

--- a/roles/kubernetes-recover/node/templates/manifests/nginx-proxy.manifest.j2
+++ b/roles/kubernetes-recover/node/templates/manifests/nginx-proxy.manifest.j2
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-proxy
+  namespace: kube-system
+  labels:
+    k8s-app: kube-nginx
+spec:
+  hostNetwork: true
+  containers:
+  - name: nginx-proxy
+    image: {{ nginx_image_repo }}:{{ nginx_image_tag }}
+    imagePullPolicy: {{ k8s_image_pull_policy }}
+    resources:
+      limits:
+        cpu: {{ nginx_cpu_limit }}
+        memory: {{ nginx_memory_limit }}
+      requests:
+        cpu: {{ nginx_cpu_requests }}
+        memory: {{ nginx_memory_requests }}
+    securityContext:
+      privileged: true
+    volumeMounts:
+    - mountPath: /etc/nginx
+      name: etc-nginx
+      readOnly: true
+  volumes:
+  - name: etc-nginx
+    hostPath:
+      path: /etc/nginx

--- a/roles/kubernetes-recover/node/templates/nginx.conf.j2
+++ b/roles/kubernetes-recover/node/templates/nginx.conf.j2
@@ -1,0 +1,26 @@
+error_log stderr notice;
+
+worker_processes auto;
+events {
+  multi_accept on;
+  use epoll;
+  worker_connections 1024;
+}
+
+stream {
+        upstream kube_apiserver {
+            least_conn;
+            {% for host in groups['kube-master'] -%}
+            server {{ hostvars[host]['access_ip'] | default(hostvars[host]['ip'] | default(hostvars[host]['ansible_default_ipv4']['address'])) }}:{{ kube_apiserver_port }};
+            {% endfor %}
+        }
+
+        server {
+            listen        127.0.0.1:{{ nginx_kube_apiserver_port|default(kube_apiserver_port) }};
+            proxy_pass    kube_apiserver;
+            proxy_timeout 10m;
+            proxy_connect_timeout 1s;
+
+        }
+
+}

--- a/roles/kubernetes-recover/node/templates/node-kubeconfig.yaml.j2
+++ b/roles/kubernetes-recover/node/templates/node-kubeconfig.yaml.j2
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Config
+clusters:
+- name: local
+  cluster:
+    certificate-authority: {{ kube_cert_dir }}/ca.pem
+    server: {{ kube_apiserver_endpoint }}
+users:
+- name: kubelet
+  user:
+    client-certificate: {{ kube_cert_dir }}/node-{{ inventory_hostname }}.pem
+    client-key: {{ kube_cert_dir }}/node-{{ inventory_hostname }}-key.pem
+contexts:
+- context:
+    cluster: local
+    user: kubelet
+  name: kubelet-{{ cluster_name }}
+current-context: kubelet-{{ cluster_name }}

--- a/roles/kubernetes-recover/node/templates/openstack-cloud-config.j2
+++ b/roles/kubernetes-recover/node/templates/openstack-cloud-config.j2
@@ -1,0 +1,41 @@
+[Global]
+auth-url="{{ openstack_auth_url }}"
+username="{{ openstack_username }}"
+password="{{ openstack_password }}"
+region="{{ openstack_region }}"
+tenant-id="{{ openstack_tenant_id }}"
+{% if openstack_tenant_name is defined and openstack_tenant_name != "" %}
+tenant-name="{{ openstack_tenant_name }}"
+{% endif %}
+{% if openstack_domain_name is defined and openstack_domain_name != "" %}
+domain-name="{{ openstack_domain_name }}"
+{% elif openstack_domain_id is defined and openstack_domain_id != "" %}
+domain-id ="{{ openstack_domain_id }}"
+{% endif %}
+
+{% if openstack_blockstorage_version is defined %}
+[BlockStorage]
+bs-version={{ openstack_blockstorage_version }}
+{% endif %}
+
+{% if openstack_lbaas_enabled and openstack_lbaas_subnet_id is defined %}
+[LoadBalancer]
+subnet-id={{ openstack_lbaas_subnet_id }}
+{% if openstack_lbaas_floating_network_id is defined %}
+floating-network-id={{ openstack_lbaas_floating_network_id }}
+{% endif %}
+{% if openstack_lbaas_use_octavia is defined %}
+use-octavia={{ openstack_lbaas_use_octavia }}
+{% endif %}
+{% if openstack_lbaas_method is defined %}
+lb-method={{ openstack_lbaas_method }}
+{% endif %}
+{% if openstack_lbaas_provider is defined %}
+lb-provider={{ openstack_lbaas_provider }}
+{% endif %}
+
+create-monitor={{ openstack_lbaas_create_monitor }}
+monitor-delay={{ openstack_lbaas_monitor_delay }}
+monitor-timeout={{ openstack_lbaas_monitor_timeout }}
+monitor-max-retries={{ openstack_lbaas_monitor_max_retries }}
+{% endif %}

--- a/roles/kubernetes-recover/node/templates/vsphere-cloud-config.j2
+++ b/roles/kubernetes-recover/node/templates/vsphere-cloud-config.j2
@@ -1,0 +1,41 @@
+[Global]
+user = "{{ vsphere_user }}"
+password = "{{ vsphere_password }}"
+port = {{ vsphere_vcenter_port }}
+insecure-flag = {{ vsphere_insecure }}
+
+{% if kube_version | version_compare('v1.9.2', '>=') %}
+datacenters = "{{ vsphere_datacenter }}"
+{% else %}
+datastore = "{{ vsphere_datastore }}"
+datacenter = "{{ vsphere_datacenter }}"
+working-dir = "{{ vsphere_working_dir }}"
+server = "{{ vsphere_vcenter_ip }}"
+{% if vsphere_vm_uuid is defined and vsphere_vm_uuid != ""  %}
+vm-uuid = "{{ vsphere_vm_uuid }}"
+{% endif %}
+{% endif %}
+
+{% if kube_version | version_compare('v1.9.2', '>=') %}
+
+[VirtualCenter "{{ vsphere_vcenter_ip }}"]
+
+
+[Workspace]
+server = "{{ vsphere_vcenter_ip }}"
+datacenter = "{{ vsphere_datacenter }}"
+folder = "{{ vsphere_working_dir }}"
+default-datastore = "{{ vsphere_datastore }}"
+{% if vsphere_resource_pool is defined and vsphere_resource_pool != ""  %}
+resourcepool-path = "{{ vsphere_resource_pool }}"
+{% endif %}
+{% endif %}
+
+
+[Disk]
+scsicontrollertype = {{ vsphere_scsi_controller_type }}
+
+{% if vsphere_public_network is defined and vsphere_public_network != ""  %}
+[Network]
+public-network = {{ vsphere_public_network }}
+{% endif %}

--- a/roles/kubernetes-recover/preinstall/defaults/main.yml
+++ b/roles/kubernetes-recover/preinstall/defaults/main.yml
@@ -1,0 +1,35 @@
+---
+run_gitinfos: false
+
+# Set to true to allow pre-checks to fail and continue deployment
+ignore_assert_errors: false
+
+epel_enabled: false
+
+common_required_pkgs:
+  - python-httplib2
+  - "{{ (ansible_distribution == 'openSUSE Tumbleweed') | ternary('openssl-1_1', 'openssl') }}"
+  - curl
+  - rsync
+  - bash-completion
+  - socat
+  - unzip
+
+# Set to true if your network does not support IPv6
+# This maybe necessary for pulling Docker images from
+# GCE docker repository
+disable_ipv6_dns: false
+
+kube_cert_group: kube-cert
+kube_config_dir: /etc/kubernetes
+
+# Container Linux by CoreOS cloud init config file to define /etc/resolv.conf content
+# for hostnet pods and infra needs
+resolveconf_cloud_init_conf: /etc/resolveconf_cloud_init.conf
+
+# All inventory hostnames will be written into each /etc/hosts file.
+populate_inventory_to_hosts_file: true
+
+preinstall_selinux_state: permissive
+
+sysctl_file_path: "/etc/sysctl.d/99-sysctl.conf"

--- a/roles/kubernetes-recover/preinstall/files/dhclient_nodnsupdate
+++ b/roles/kubernetes-recover/preinstall/files/dhclient_nodnsupdate
@@ -1,0 +1,4 @@
+#!/bin/sh
+make_resolv_conf() {
+    :
+}

--- a/roles/kubernetes-recover/preinstall/gen-gitinfos.sh
+++ b/roles/kubernetes-recover/preinstall/gen-gitinfos.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+set -e
+
+# Text color variables
+txtbld=$(tput bold)             # Bold
+bldred=${txtbld}$(tput setaf 1) #  red
+bldgre=${txtbld}$(tput setaf 2) #  green
+bldylw=${txtbld}$(tput setaf 3) #  yellow
+txtrst=$(tput sgr0)             # Reset
+err=${bldred}ERROR${txtrst}
+info=${bldgre}INFO${txtrst}
+warn=${bldylw}WARNING${txtrst}
+
+usage()
+{
+    cat << EOF
+Generates a file which contains useful git informations
+
+Usage : $(basename $0) [global|diff]
+    ex :
+      Generate git information
+      $(basename $0) global
+      Generate diff from latest tag
+      $(basename $0) diff
+EOF
+}
+
+if [ $# != 1 ]; then
+    printf "\n$err : Needs 1 argument\n"
+    usage
+    exit 2
+fi;
+
+current_commit=$(git rev-parse HEAD)
+latest_tag=$(git describe --abbrev=0 --tags)
+latest_tag_commit=$(git show-ref -s ${latest_tag})
+tags_list=$(git tag --points-at "${latest_tag}")
+
+case ${1} in
+    "global")
+cat<<EOF
+deployment date="$(date '+%d-%m-%Y %Hh%M')"
+deployment_timestamp=$(date '+%s')
+user="$USER"
+current commit (HEAD)="${current_commit}"
+current_commit_timestamp=$(git log -1 --pretty=format:%ct)
+latest tag(s) (current branch)="${tags_list}"
+latest tag commit="${latest_tag_commit}"
+current branch="$(git rev-parse --abbrev-ref HEAD)"
+branches list="$(git describe --contains --all HEAD)"
+git root directory="$(git rev-parse --show-toplevel)"
+EOF
+        if ! git diff-index --quiet HEAD --; then
+           printf "unstaged changes=\"/etc/.git-ansible.diff\""
+        fi
+
+        if [ "${current_commit}" = "${latest_tag_commit}" ]; then
+            printf "\ncurrent_commit_tag=\"${latest_tag}\""
+        else
+           printf "\nlast tag was "$(git describe --tags | awk -F- '{print $2}')" commits ago =\""
+           printf "$(git log --pretty=format:"    %h - %s" ${latest_tag}..HEAD)\""
+        fi
+        ;;
+
+    "diff")
+       git diff
+       ;;
+    *)
+        usage
+        printf "$err: Unknown argument ${1}"
+		exit 1;
+	    ;;
+esac

--- a/roles/kubernetes-recover/preinstall/handlers/main.yml
+++ b/roles/kubernetes-recover/preinstall/handlers/main.yml
@@ -1,0 +1,65 @@
+---
+- name: Preinstall | restart network
+  command: /bin/true
+  notify:
+    - Preinstall | reload network
+    - Preinstall | reload kubelet
+    - Preinstall | kube-controller configured
+    - Preinstall | kube-apiserver configured
+    - Preinstall | restart kube-controller-manager
+    - Preinstall | restart kube-apiserver
+  when: not ansible_os_family in ["CoreOS", "Container Linux by CoreOS"]
+
+  # FIXME(bogdando) https://github.com/projectcalico/felix/issues/1185
+- name: Preinstall | reload network
+  service:
+    name: >-
+      {% if ansible_os_family == "RedHat" -%}
+      network
+      {%- elif ansible_os_family == "Debian" -%}
+      networking
+      {%- endif %}
+    state: restarted
+  when: not ansible_os_family in ["CoreOS", "Container Linux by CoreOS"] and kube_network_plugin not in ['canal', 'calico']
+
+- name: Preinstall | update resolvconf for Container Linux by CoreOS
+  command: /bin/true
+  notify:
+    - Preinstall | apply resolvconf cloud-init
+    - Preinstall | reload kubelet
+  when: ansible_os_family in ["CoreOS", "Container Linux by CoreOS"]
+
+- name: Preinstall | apply resolvconf cloud-init
+  command: /usr/bin/coreos-cloudinit --from-file {{ resolveconf_cloud_init_conf }}
+  when: ansible_os_family in ["CoreOS", "Container Linux by CoreOS"]
+
+- name: Preinstall | reload kubelet
+  service:
+    name: kubelet
+    state: restarted
+  notify:
+    - Preinstall | kube-controller configured
+    - Preinstall | kube-apiserver configured
+    - Preinstall | restart kube-controller-manager
+    - Preinstall | restart kube-apiserver
+  when: not dns_early|bool
+
+# FIXME(mattymo): Also restart for kubeadm mode
+- name: Preinstall | kube-apiserver configured
+  stat: path="{{ kube_manifest_dir }}/kube-apiserver.manifest"
+  register: kube_apiserver_set
+  when: inventory_hostname in groups['kube-master'] and dns_mode != 'none' and resolvconf_mode == 'host_resolvconf'
+
+# FIXME(mattymo): Also restart for kubeadm mode
+- name: Preinstall | kube-controller configured
+  stat: path="{{ kube_manifest_dir }}/kube-controller-manager.manifest"
+  register: kube_controller_set
+  when: inventory_hostname in groups['kube-master'] and dns_mode != 'none' and resolvconf_mode == 'host_resolvconf'
+
+- name: Preinstall | restart kube-controller-manager
+  shell: "docker ps -f name=k8s_POD_kube-controller-manager* -q | xargs --no-run-if-empty docker rm -f"
+  when: inventory_hostname in groups['kube-master'] and dns_mode != 'none' and resolvconf_mode == 'host_resolvconf' and kube_controller_set.stat.exists
+
+- name: Preinstall | restart kube-apiserver
+  shell: "docker ps -f name=k8s_POD_kube-apiserver* -q | xargs --no-run-if-empty docker rm -f"
+  when: inventory_hostname in groups['kube-master'] and dns_mode != 'none' and resolvconf_mode == 'host_resolvconf'

--- a/roles/kubernetes-recover/preinstall/meta/main.yml
+++ b/roles/kubernetes-recover/preinstall/meta/main.yml
@@ -1,0 +1,7 @@
+---
+dependencies:
+  - role: adduser
+    user: "{{ addusers.kube }}"
+    when: not is_atomic
+    tags:
+      - kubelet

--- a/roles/kubernetes-recover/preinstall/tasks/dhclient-hooks-undo.yml
+++ b/roles/kubernetes-recover/preinstall/tasks/dhclient-hooks-undo.yml
@@ -1,0 +1,25 @@
+---
+
+# These tasks will undo changes done by kubespray in the past if needed (e.g. when upgrading from kubespray 2.0.x
+# or when changing resolvconf_mode)
+
+- name: Remove kubespray specific config from dhclient config
+  blockinfile:
+    dest: "{{dhclientconffile}}"
+    state: absent
+    backup: yes
+    follow: yes
+    marker: "# Ansible entries {mark}"
+  when: dhclientconffile is defined
+  notify: Preinstall | restart network
+
+- name: Remove kubespray specific dhclient hook
+  file:
+    path: "{{ dhclienthookfile }}"
+    state: absent
+  when: dhclienthookfile is defined
+  notify: Preinstall | restart network
+
+# We need to make sure the network is restarted early enough so that docker can later pick up the correct system
+# nameservers and search domains
+- meta: flush_handlers

--- a/roles/kubernetes-recover/preinstall/tasks/dhclient-hooks.yml
+++ b/roles/kubernetes-recover/preinstall/tasks/dhclient-hooks.yml
@@ -1,0 +1,34 @@
+---
+- name: Configure dhclient to supersede search/domain/nameservers
+  blockinfile:
+    block: |-
+      {% for item in [ supersede_domain, supersede_search, supersede_nameserver ] -%}
+      {{ item }}
+      {% endfor %}
+    dest: "{{dhclientconffile}}"
+    create: yes
+    state: present
+    insertbefore: BOF
+    backup: yes
+    follow: yes
+    marker: "# Ansible entries {mark}"
+  notify: Preinstall | restart network
+  when: dhclientconffile is defined
+
+- name: Configure dhclient hooks for resolv.conf (non-RH)
+  template:
+    src: dhclient_dnsupdate.sh.j2
+    dest: "{{ dhclienthookfile }}"
+    owner: root
+    mode: 0755
+  notify: Preinstall | restart network
+  when: ansible_os_family != "RedHat"
+
+- name: Configure dhclient hooks for resolv.conf (RH-only)
+  template:
+    src: dhclient_dnsupdate_rh.sh.j2
+    dest: "{{ dhclienthookfile }}"
+    owner: root
+    mode: 0755
+  notify: Preinstall | restart network
+  when: ansible_os_family == "RedHat"

--- a/roles/kubernetes-recover/preinstall/tasks/etchosts.yml
+++ b/roles/kubernetes-recover/preinstall/tasks/etchosts.yml
@@ -1,0 +1,39 @@
+---
+- name: Hosts | populate inventory into hosts file
+  blockinfile:
+    dest: /etc/hosts
+    block: |-
+      {% for item in (groups['k8s-cluster'] + groups['etcd'] + groups['calico-rr']|default([]))|unique -%}{{ hostvars[item]['access_ip'] | default(hostvars[item]['ip'] | default(hostvars[item]['ansible_default_ipv4']['address'])) }}{% if (item != hostvars[item]['ansible_hostname']) %} {{ hostvars[item]['ansible_hostname'] }} {{ hostvars[item]['ansible_hostname'] }}.{{ dns_domain }}{% endif %} {{ item }} {{ item }}.{{ dns_domain }}
+      {% endfor %}
+    state: present
+    create: yes
+    backup: yes
+    marker: "# Ansible inventory hosts {mark}"
+  when: populate_inventory_to_hosts_file
+
+- name: Hosts | populate kubernetes loadbalancer address into hosts file
+  lineinfile:
+    dest: /etc/hosts
+    regexp: ".*{{ apiserver_loadbalancer_domain_name }}$"
+    line: "{{ loadbalancer_apiserver.address }} {{ apiserver_loadbalancer_domain_name }}"
+    state: present
+    backup: yes
+  when:
+    - loadbalancer_apiserver is defined
+    - loadbalancer_apiserver.address is defined
+
+- name: Hosts | localhost ipv4 in hosts file
+  lineinfile:
+    dest: /etc/hosts
+    line: "127.0.0.1 localhost localhost.localdomain"
+    regexp: '^127.0.0.1.*$'
+    state: present
+    backup: yes
+
+- name: Hosts | localhost ipv6 in hosts file
+  lineinfile:
+    dest: /etc/hosts
+    line: "::1 localhost6 localhost6.localdomain"
+    regexp: '^::1.*$'
+    state: present
+    backup: yes

--- a/roles/kubernetes-recover/preinstall/tasks/growpart-azure-centos-7.yml
+++ b/roles/kubernetes-recover/preinstall/tasks/growpart-azure-centos-7.yml
@@ -1,0 +1,27 @@
+---
+
+# Running growpart seems to be only required on Azure, as other Cloud Providers do this at boot time
+
+- name: install growpart
+  package:
+    name: cloud-utils-growpart
+    state: latest
+
+- name: check if growpart needs to be run
+  command: growpart -N /dev/sda 1
+  failed_when: False
+  changed_when: "'NOCHANGE:' not in growpart_needed.stdout"
+  register: growpart_needed
+
+- name: check fs type
+  command: file -Ls /dev/sda1
+  changed_when: False
+  register: fs_type
+
+- name: run growpart
+  command: growpart /dev/sda 1
+  when: growpart_needed.changed
+
+- name: run xfs_growfs
+  command: xfs_growfs /dev/sda1
+  when: growpart_needed.changed and 'XFS' in fs_type.stdout

--- a/roles/kubernetes-recover/preinstall/tasks/main.yml
+++ b/roles/kubernetes-recover/preinstall/tasks/main.yml
@@ -1,0 +1,309 @@
+---
+- import_tasks: verify-settings.yml
+  tags:
+    - asserts
+
+# This is run before bin_dir is pinned because these tasks are run on localhost
+- import_tasks: pre_upgrade.yml
+  run_once: true
+  tags:
+    - upgrade
+
+- name: Force binaries directory for Container Linux by CoreOS
+  set_fact:
+    bin_dir: "/opt/bin"
+  when: ansible_os_family in ["CoreOS", "Container Linux by CoreOS"]
+  tags:
+    - facts
+
+- name: check bin dir exists
+  file:
+    path: "{{bin_dir}}"
+    state: directory
+    owner: root
+  become: true
+  tags:
+    - bootstrap-os
+
+- import_tasks: set_facts.yml
+  tags:
+    - facts
+
+- name: gather os specific variables
+  include_vars: "{{ item }}"
+  with_first_found:
+    - files:
+        - "{{ ansible_distribution|lower }}-{{ ansible_distribution_version|lower|replace('/', '_') }}.yml"
+        - "{{ ansible_distribution|lower }}-{{ ansible_distribution_release }}.yml"
+        - "{{ ansible_distribution|lower }}-{{ ansible_distribution_major_version|lower|replace('/', '_') }}.yml"
+        - "{{ ansible_distribution|lower }}.yml"
+        - "{{ ansible_os_family|lower }}.yml"
+        - defaults.yml
+      paths:
+        - ../vars
+      skip: true
+  tags:
+    - facts
+
+- name: Create kubernetes directories
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: kube
+  when: inventory_hostname in groups['k8s-cluster']
+  tags:
+    - kubelet
+    - k8s-secrets
+    - kube-controller-manager
+    - kube-apiserver
+    - bootstrap-os
+    - apps
+    - network
+    - master
+    - node
+  with_items:
+    - "{{ kube_config_dir }}"
+    - "{{ kube_config_dir }}/ssl"
+    - "{{ kube_manifest_dir }}"
+    - "{{ kube_script_dir }}"
+
+- name: check cloud_provider value
+  fail:
+    msg: "If set the 'cloud_provider' var must be set either to 'generic', 'gce', 'aws', 'azure', 'openstack', 'vsphere', or external"
+  when:
+    - cloud_provider is defined
+    - cloud_provider not in ['generic', 'gce', 'aws', 'azure', 'openstack', 'vsphere', 'external']
+  tags:
+    - cloud-provider
+    - facts
+
+- name: Create cni directories
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: kube
+  with_items:
+    - "/etc/cni/net.d"
+    - "/opt/cni/bin"
+  when:
+    - kube_network_plugin in ["calico", "weave", "canal", "flannel", "contiv", "cilium"]
+    - inventory_hostname in groups['k8s-cluster']
+  tags:
+    - network
+    - cilium
+    - calico
+    - weave
+    - canal
+    - contiv
+    - bootstrap-os
+
+- name: Create local volume provisioner directories
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: kube
+  with_items:
+    - "{{ local_volume_provisioner_base_dir }}"
+    - "{{ local_volume_provisioner_mount_dir }}"
+  when:
+    - inventory_hostname in groups['k8s-cluster']
+    - local_volume_provisioner_enabled
+  tags:
+    - persistent_volumes
+
+- import_tasks: resolvconf.yml
+  when:
+    - dns_mode != 'none'
+    - resolvconf_mode == 'host_resolvconf'
+  tags:
+    - bootstrap-os
+    - resolvconf
+
+- name: Update package management cache (YUM)
+  yum:
+    update_cache: yes
+    name: '*'
+  register: yum_task_result
+  until: yum_task_result|succeeded
+  retries: 4
+  delay: "{{ retry_stagger | random + 3 }}"
+  when:
+    - ansible_pkg_mgr == 'yum'
+    - ansible_distribution != 'RedHat'
+    - not is_atomic
+  tags: bootstrap-os
+
+- name: Expire management cache (YUM) for Updation - Redhat
+  shell: yum clean expire-cache
+  register: expire_cache_output
+  until: expire_cache_output|succeeded
+  retries: 4
+  delay: "{{ retry_stagger | random + 3 }}"
+  when:
+    - ansible_pkg_mgr == 'yum'
+    - ansible_distribution == 'RedHat'
+    - not is_atomic
+  tags: bootstrap-os
+
+- name: Update package management cache (YUM) - Redhat
+  shell: yum makecache
+  register: make_cache_output
+  until: make_cache_output|succeeded
+  retries: 4
+  delay: "{{ retry_stagger | random + 3 }}"
+  when:
+    - ansible_pkg_mgr == 'yum'
+    - ansible_distribution == 'RedHat'
+    - expire_cache_output.rc == 0
+    - not is_atomic
+  tags: bootstrap-os
+
+- name: Update package management cache (zypper) - SUSE
+  shell: zypper -n --gpg-auto-import-keys ref
+  register: make_cache_output
+  until: make_cache_output|succeeded
+  retries: 4
+  delay: "{{ retry_stagger | random + 3 }}"
+  when:
+    - ansible_pkg_mgr == 'zypper'
+  tags: bootstrap-os
+
+- name: Update package management cache (APT)
+  apt:
+    update_cache: yes
+    cache_valid_time: 3600
+  when: ansible_os_family == "Debian"
+  tags:
+    - bootstrap-os
+
+- name: Install python-dnf for latest RedHat versions
+  command: dnf install -y python-dnf yum
+  register: dnf_task_result
+  until: dnf_task_result|succeeded
+  retries: 4
+  delay: "{{ retry_stagger | random + 3 }}"
+  when:
+    - ansible_distribution == "Fedora"
+    - ansible_distribution_major_version|int > 21
+    - not is_atomic
+  changed_when: False
+  tags:
+    - bootstrap-os
+
+- name: Install epel-release on RedHat/CentOS
+  yum:
+    name: epel-release
+    state: present
+  when:
+    - ansible_distribution in ["CentOS","RedHat"]
+    - not is_atomic
+    - epel_enabled|bool
+  tags:
+    - bootstrap-os
+
+- name: Install packages requirements
+  action:
+    module: "{{ ansible_pkg_mgr }}"
+    name: "{{ item }}"
+    state: latest
+  register: pkgs_task_result
+  until: pkgs_task_result|succeeded
+  retries: 4
+  delay: "{{ retry_stagger | random + 3 }}"
+  with_items: "{{required_pkgs | default([]) | union(common_required_pkgs|default([]))}}"
+  when: not (ansible_os_family in ["CoreOS", "Container Linux by CoreOS"] or is_atomic)
+  tags:
+    - bootstrap-os
+
+# Todo : selinux configuration
+- name: Confirm selinux deployed
+  stat:
+    path: /etc/selinux/config
+  when: ansible_os_family == "RedHat"
+  register: slc
+
+- name: Set selinux policy
+  selinux:
+    policy: targeted
+    state: "{{ preinstall_selinux_state }}"
+  when:
+    - ansible_os_family == "RedHat"
+    - slc.stat.exists == True
+  changed_when: False
+  tags:
+    - bootstrap-os
+
+- name: Disable IPv6 DNS lookup
+  lineinfile:
+    dest: /etc/gai.conf
+    line: "precedence ::ffff:0:0/96  100"
+    state: present
+    backup: yes
+  when:
+    - disable_ipv6_dns
+    - not ansible_os_family in ["CoreOS", "Container Linux by CoreOS"]
+  tags:
+    - bootstrap-os
+
+- name: Stat sysctl file configuration
+  stat:
+    path: "{{sysctl_file_path}}"
+  register: sysctl_file_stat
+  tags:
+    - bootstrap-os
+
+- name: Change sysctl file path to link source if linked
+  set_fact:
+    sysctl_file_path: "{{sysctl_file_stat.stat.lnk_source}}"
+  when:
+    - sysctl_file_stat.stat.islnk is defined
+    - sysctl_file_stat.stat.islnk
+  tags:
+    - bootstrap-os
+
+- name: Enable ip forwarding
+  sysctl:
+    sysctl_file: "{{sysctl_file_path}}"
+    name: net.ipv4.ip_forward
+    value: 1
+    state: present
+    reload: yes
+  tags:
+    - bootstrap-os
+
+- import_tasks: etchosts.yml
+  tags:
+    - bootstrap-os
+    - etchosts
+
+- import_tasks: dhclient-hooks.yml
+  when:
+    - dns_mode != 'none'
+    - resolvconf_mode == 'host_resolvconf'
+    - not ansible_os_family in ["CoreOS", "Container Linux by CoreOS"]
+  tags:
+    - bootstrap-os
+    - resolvconf
+
+- import_tasks: dhclient-hooks-undo.yml
+  when:
+    - dns_mode != 'none'
+    - resolvconf_mode != 'host_resolvconf'
+    - not ansible_os_family in ["CoreOS", "Container Linux by CoreOS"]
+  tags:
+    - bootstrap-os
+    - resolvconf
+
+- name: Check if we are running inside a Azure VM
+  stat:
+    path: /var/lib/waagent/
+  register: azure_check
+  tags:
+    - bootstrap-os
+
+- import_tasks: growpart-azure-centos-7.yml
+  when:
+    - azure_check.stat.exists
+    - ansible_distribution in ["CentOS","RedHat"]
+  tags:
+    - bootstrap-os

--- a/roles/kubernetes-recover/preinstall/tasks/pre_upgrade.yml
+++ b/roles/kubernetes-recover/preinstall/tasks/pre_upgrade.yml
@@ -1,0 +1,28 @@
+---
+- name: "Pre-upgrade | check if old credential dir exists"
+  local_action:
+    module: stat
+    path: "{{ inventory_dir }}/../credentials"
+  vars:
+    ansible_python_interpreter: "/usr/bin/env python"
+  register: old_credential_dir
+  become: no
+
+- name: "Pre-upgrade | check if new credential dir exists"
+  local_action:
+    module: stat
+    path: "{{ inventory_dir }}/credentials"
+  vars:
+    ansible_python_interpreter: "/usr/bin/env python"
+  register: new_credential_dir
+  become: no
+  when: old_credential_dir.stat.exists
+
+- name: "Pre-upgrade | move data from old credential dir to new"
+  local_action: command mv {{ inventory_dir }}/../credentials {{ inventory_dir }}/credentials
+  args:
+    creates: "{{ inventory_dir }}/credentials"
+  vars:
+    ansible_python_interpreter: "/usr/bin/env python"
+  become: no
+  when: old_credential_dir.stat.exists and not new_credential_dir.stat.exists

--- a/roles/kubernetes-recover/preinstall/tasks/resolvconf.yml
+++ b/roles/kubernetes-recover/preinstall/tasks/resolvconf.yml
@@ -1,0 +1,60 @@
+---
+- name: create temporary resolveconf cloud init file
+  command: cp -f /etc/resolv.conf "{{ resolvconffile }}"
+  when: ansible_os_family in ["CoreOS", "Container Linux by CoreOS"]
+
+- name: Add domain/search/nameservers/options to resolv.conf
+  blockinfile:
+    dest: "{{resolvconffile}}"
+    block: |-
+      {% for item in [domainentry] + [searchentries] + nameserverentries.split(',') -%}
+      {{ item }}
+      {% endfor %}
+      options ndots:{{ ndots }}
+      options timeout:2
+      options attempts:2
+    state: present
+    insertbefore: BOF
+    create: yes
+    backup: yes
+    follow: yes
+    marker: "# Ansible entries {mark}"
+  notify: Preinstall | restart network
+
+- name: Remove search/domain/nameserver options before block
+  replace:
+    dest: "{{item[0]}}"
+    regexp: '^{{ item[1] }}[^#]*(?=# Ansible entries BEGIN)'
+    backup: yes
+    follow: yes
+  with_nested:
+    - "{{ [resolvconffile, base|default(''), head|default('')] | difference(['']) }}"
+    - [ 'search ', 'nameserver ', 'domain ', 'options ' ]
+  notify: Preinstall | restart network
+
+- name: Remove search/domain/nameserver options after block
+  replace:
+    dest: "{{item[0]}}"
+    regexp: '(# Ansible entries END\n(?:(?!^{{ item[1] }}).*\n)*)(?:^{{ item[1] }}.*\n?)+'
+    replace: '\1'
+    backup: yes
+    follow: yes
+  with_nested:
+    - "{{ [resolvconffile, base|default(''), head|default('')] | difference(['']) }}"
+    - [ 'search ', 'nameserver ', 'domain ', 'options ' ]
+  notify: Preinstall | restart network
+
+
+- name: get temporary resolveconf cloud init file content
+  command: cat {{ resolvconffile }}
+  register: cloud_config
+  when: ansible_os_family in ["CoreOS", "Container Linux by CoreOS"]
+
+- name: persist resolvconf cloud init file
+  template:
+    dest: "{{resolveconf_cloud_init_conf}}"
+    src: resolvconf.j2
+    owner: root
+    mode: 0644
+  notify: Preinstall | update resolvconf for Container Linux by CoreOS
+  when: ansible_os_family in ["CoreOS", "Container Linux by CoreOS"]

--- a/roles/kubernetes-recover/preinstall/tasks/set_facts.yml
+++ b/roles/kubernetes-recover/preinstall/tasks/set_facts.yml
@@ -1,0 +1,17 @@
+---
+- name: check if atomic host
+  stat:
+    path: /run/ostree-booted
+  register: ostree
+
+- set_fact:
+    is_atomic: "{{ ostree.stat.exists }}"
+
+- set_fact:
+    kube_cert_group: "kube"
+  when: is_atomic
+
+- import_tasks: set_resolv_facts.yml
+  tags:
+    - resolvconf
+    - facts

--- a/roles/kubernetes-recover/preinstall/tasks/set_resolv_facts.yml
+++ b/roles/kubernetes-recover/preinstall/tasks/set_resolv_facts.yml
@@ -1,0 +1,113 @@
+---
+- name: check resolvconf
+  shell: which resolvconf
+  register: resolvconf
+  failed_when: false
+  changed_when: false
+  check_mode: no
+
+- set_fact:
+    resolvconf: >-
+      {%- if resolvconf.rc == 0 -%}true{%- else -%}false{%- endif -%}
+
+- set_fact:
+    bogus_domains: |-
+      {% for d in [ 'default.svc.' + dns_domain, 'svc.' + dns_domain ] + searchdomains|default([]) -%}
+      {{dns_domain}}.{{d}}./{{d}}.{{d}}./com.{{d}}./
+      {%- endfor %}
+    cloud_resolver: >-
+      {%- if cloud_provider is defined and cloud_provider == 'gce' -%}
+        ['169.254.169.254']
+      {%- elif cloud_provider is defined and cloud_provider == 'aws' -%}
+        ['169.254.169.253']
+      {%- else -%}
+        []
+      {%- endif -%}
+
+- name: check if kubelet is configured
+  stat:
+    path: "{{ kube_config_dir }}/kubelet.env"
+  register: kubelet_configured
+  changed_when: false
+
+- name: check if early DNS configuration stage
+  set_fact:
+    dns_early: >-
+      {%- if kubelet_configured.stat.exists -%}false{%- else -%}true{%- endif -%}
+
+- name: target resolv.conf files
+  set_fact:
+    resolvconffile: /etc/resolv.conf
+    base: >-
+      {%- if resolvconf|bool -%}/etc/resolvconf/resolv.conf.d/base{%- endif -%}
+    head: >-
+      {%- if resolvconf|bool -%}/etc/resolvconf/resolv.conf.d/head{%- endif -%}
+  when: not ansible_os_family in ["CoreOS", "Container Linux by CoreOS"]
+
+- name: target temporary resolvconf cloud init file (Container Linux by CoreOS)
+  set_fact:
+    resolvconffile: /tmp/resolveconf_cloud_init_conf
+  when: ansible_os_family in ["CoreOS", "Container Linux by CoreOS"]
+
+- name: check if /etc/dhclient.conf exists
+  stat:
+    path: /etc/dhclient.conf
+  register: dhclient_stat
+
+- name: target dhclient conf file for /etc/dhclient.conf
+  set_fact:
+    dhclientconffile: /etc/dhclient.conf
+  when: dhclient_stat.stat.exists
+
+- name: check if /etc/dhcp/dhclient.conf exists
+  stat:
+    path: /etc/dhcp/dhclient.conf
+  register: dhcp_dhclient_stat
+
+- name: target dhclient conf file for /etc/dhcp/dhclient.conf
+  set_fact:
+    dhclientconffile: /etc/dhcp/dhclient.conf
+  when: dhcp_dhclient_stat.stat.exists
+
+- name: target dhclient hook file for Red Hat family
+  set_fact:
+    dhclienthookfile: /etc/dhcp/dhclient.d/zdnsupdate.sh
+  when: ansible_os_family == "RedHat"
+
+- name: target dhclient hook file for Debian family
+  set_fact:
+    dhclienthookfile: /etc/dhcp/dhclient-exit-hooks.d/zdnsupdate
+  when: ansible_os_family == "Debian"
+
+- name: generate search domains to resolvconf
+  set_fact:
+    searchentries:
+      search {{ ([ 'default.svc.' + dns_domain, 'svc.' + dns_domain ] + searchdomains|default([])) | join(' ') }}
+    domainentry:
+      domain {{ dns_domain }}
+    supersede_search:
+      supersede domain-search "{{ ([ 'default.svc.' + dns_domain, 'svc.' + dns_domain ] + searchdomains|default([])) | join('", "') }}";
+    supersede_domain:
+      supersede domain-name "{{ dns_domain }}";
+
+- name: pick dnsmasq cluster IP or default resolver
+  set_fact:
+    dnsmasq_server: |-
+      {%- if dns_mode in ['kubedns', 'coredns'] and not dns_early|bool -%}
+        {{ [ skydns_server ] + upstream_dns_servers|default([]) }}
+      {%- elif dns_mode == 'coredns_dual' and not dns_early|bool -%}
+        {{ [ skydns_server ] + [ skydns_server_secondary ] + upstream_dns_servers|default([]) }}
+      {%- elif dns_mode == 'manual' and not dns_early|bool -%}
+        {{ [ manual_dns_server ] + upstream_dns_servers|default([]) }}
+      {%- elif dns_early|bool -%}
+        {{ upstream_dns_servers|default([]) }}
+      {%- else -%}
+        {{ [ dnsmasq_dns_server ] }}
+      {%- endif -%}
+
+- name: generate nameservers to resolvconf
+  set_fact:
+    nameserverentries:
+      nameserver {{( dnsmasq_server + nameservers|d([]) + cloud_resolver|d([])) | join(',nameserver ')}}
+    supersede_nameserver:
+      supersede domain-name-servers {{( dnsmasq_server + nameservers|d([]) + cloud_resolver|d([])) | join(', ') }};

--- a/roles/kubernetes-recover/preinstall/tasks/verify-settings.yml
+++ b/roles/kubernetes-recover/preinstall/tasks/verify-settings.yml
@@ -1,0 +1,111 @@
+---
+- name: Stop if ansible version is too low
+  assert:
+    that:
+      - ansible_version.full|version_compare('2.3.0', '>=')
+  run_once: yes
+
+- name: Stop if non systemd OS type
+  assert:
+    that: ansible_service_mgr == "systemd"
+  ignore_errors: "{{ ignore_assert_errors }}"
+
+- name: Stop if unknown OS
+  assert:
+    that: ansible_distribution in ['RedHat', 'CentOS', 'Fedora', 'Ubuntu', 'Debian', 'CoreOS', 'Container Linux by CoreOS', 'openSUSE Leap', 'openSUSE Tumbleweed']
+  ignore_errors: "{{ ignore_assert_errors }}"
+
+- name: Stop if unknown network plugin
+  assert:
+    that: network_plugin in ['calico', 'canal', 'flannel', 'weave', 'cloud']
+  when: network_plugin is defined
+  ignore_errors: "{{ ignore_assert_errors }}"
+
+- name: Stop if incompatible network plugin and cloudprovider
+  assert:
+    that: network_plugin != 'calico'
+    msg: "Azure and Calico are not compatible. See https://github.com/projectcalico/calicoctl/issues/949 for details."
+  when: cloud_provider is defined and cloud_provider == 'azure'
+  ignore_errors: "{{ ignore_assert_errors }}"
+
+# simplify this items-list when   https://github.com/ansible/ansible/issues/15753  is resolved
+- name: "Stop if known booleans are set as strings (Use JSON format on CLI: -e \"{'key': true }\")"
+  assert:
+    that: item.value|type_debug == 'bool'
+    msg: "{{item.value}} isn't a bool"
+  run_once: yes
+  with_items:
+    - { name: kubeadm_enabled, value: "{{ kubeadm_enabled }}" }
+    - { name: download_run_once, value: "{{ download_run_once }}" }
+    - { name: deploy_netchecker, value: "{{ deploy_netchecker }}" }
+    - { name: download_always_pull, value: "{{ download_always_pull }}" }
+    - { name: efk_enabled, value: "{{ efk_enabled }}" }
+    - { name: helm_enabled, value: "{{ helm_enabled }}" }
+    - { name: openstack_lbaas_enabled, value: "{{ openstack_lbaas_enabled }}" }
+  ignore_errors: "{{ ignore_assert_errors }}"
+
+- name: Stop if even number of etcd hosts
+  assert:
+    that: groups.etcd|length is not divisibleby 2
+  ignore_errors: "{{ ignore_assert_errors }}"
+
+- name: Stop if memory is too small for masters
+  assert:
+    that: ansible_memtotal_mb >= 1500
+  ignore_errors: "{{ ignore_assert_errors }}"
+  when: inventory_hostname in groups['kube-master']
+
+- name: Stop if memory is too small for nodes
+  assert:
+    that: ansible_memtotal_mb >= 1024
+  ignore_errors: "{{ ignore_assert_errors }}"
+  when: inventory_hostname in groups['kube-node']
+
+# This assertion will fail on the safe side: One can indeed schedule more pods
+# on a node than the CIDR-range has space for when additional pods use the host
+# network namespace. It is impossible to ascertain the number of such pods at
+# provisioning time, so to establish a guarantee, we factor these out.
+# NOTICE: the check blatantly ignores the inet6-case
+- name: Guarantee that enough network address space is available for all pods
+  assert:
+    that: "{{ kubelet_max_pods <= (2 ** (32 - kube_network_node_prefix)) - 2 }}"
+    msg: "Do not schedule more pods on a node than inet addresses are available."
+  ignore_errors: "{{ ignore_assert_errors }}"
+  when:
+    - inventory_hostname in groups['kube-node']
+    - kube_network_node_prefix is defined
+
+- name: Stop if ip var does not match local ips
+  assert:
+    that: ip in ansible_all_ipv4_addresses
+  ignore_errors: "{{ ignore_assert_errors }}"
+  when: ip is defined
+
+- name: Stop if access_ip is not pingable
+  command: ping -c1 {{ access_ip }}
+  when: access_ip is defined
+  ignore_errors: "{{ ignore_assert_errors }}"
+
+- name: Stop if swap enabled
+  assert:
+    that: ansible_swaptotal_mb == 0
+  when: kubelet_fail_swap_on|default(true)
+  ignore_errors: "{{ ignore_assert_errors }}"
+
+- name: Stop if RBAC is not enabled when dashboard is enabled
+  assert:
+    that: rbac_enabled
+  when: dashboard_enabled
+  ignore_errors: "{{ ignore_assert_errors }}"
+
+- name: Stop if RBAC and anonymous-auth are not enabled when insecure port is disabled
+  assert:
+    that: rbac_enabled and kube_api_anonymous_auth
+  when: kube_apiserver_insecure_port == 0
+  ignore_errors: "{{ ignore_assert_errors }}"
+
+- name: Stop if kernel version is too low
+  assert:
+    that: ansible_kernel.split('-')[0]|version_compare('4.8', '>=')
+  when: kube_network_plugin == 'cilium'
+  ignore_errors: "{{ ignore_assert_errors }}"

--- a/roles/kubernetes-recover/preinstall/templates/ansible_git.j2
+++ b/roles/kubernetes-recover/preinstall/templates/ansible_git.j2
@@ -1,0 +1,3 @@
+; This file contains the information which identifies the deployment state relative to the git repo
+[default]
+{{ gitinfo.stdout }}

--- a/roles/kubernetes-recover/preinstall/templates/dhclient_dnsupdate.sh.j2
+++ b/roles/kubernetes-recover/preinstall/templates/dhclient_dnsupdate.sh.j2
@@ -1,0 +1,13 @@
+#!/bin/sh
+#
+# Prepend resolver options to /etc/resolv.conf after dhclient`
+# regenerates the file. See man (5) resolver for more details.
+#
+if [ $reason = "BOUND" ]; then
+  if [ -n "$new_domain_search" -o -n "$new_domain_name_servers" ]; then
+    RESOLV_CONF=$(cat /etc/resolv.conf | sed -r '/^options (timeout|attempts|ndots).*$/d')
+    OPTIONS="options timeout:2\noptions attempts:2\noptions ndots:{{ ndots }}"
+
+    printf "%b\n" "$RESOLV_CONF\n$OPTIONS" > /etc/resolv.conf
+  fi
+fi

--- a/roles/kubernetes-recover/preinstall/templates/dhclient_dnsupdate_rh.sh.j2
+++ b/roles/kubernetes-recover/preinstall/templates/dhclient_dnsupdate_rh.sh.j2
@@ -1,0 +1,17 @@
+#!/bin/sh
+#
+# Prepend resolver options to /etc/resolv.conf after dhclient`
+# regenerates the file. See man (5) resolver for more details.
+#
+zdnsupdate_config() {
+  if [ -n "$new_domain_search" -o -n "$new_domain_name_servers" ]; then
+    RESOLV_CONF=$(cat /etc/resolv.conf | sed -r '/^options (timeout|attempts|ndots).*$/d')
+    OPTIONS="options timeout:2\noptions attempts:2\noptions ndots:{{ ndots }}"
+
+    echo -e "$RESOLV_CONF\n$OPTIONS" > /etc/resolv.conf
+  fi
+}
+
+zdnsupdate_restore() {
+  :
+}

--- a/roles/kubernetes-recover/preinstall/templates/resolvconf.j2
+++ b/roles/kubernetes-recover/preinstall/templates/resolvconf.j2
@@ -1,0 +1,10 @@
+#cloud-config
+write_files:
+  - path: "/etc/resolv.conf"
+    permissions: "0644"
+    owner: "root"
+    content: |
+    {% for l in cloud_config.stdout_lines %}
+      {{ l }}
+    {% endfor %}
+    #

--- a/roles/kubernetes-recover/preinstall/vars/centos.yml
+++ b/roles/kubernetes-recover/preinstall/vars/centos.yml
@@ -1,0 +1,5 @@
+---
+required_pkgs:
+  - libselinux-python
+  - device-mapper-libs
+  - ebtables

--- a/roles/kubernetes-recover/preinstall/vars/debian.yml
+++ b/roles/kubernetes-recover/preinstall/vars/debian.yml
@@ -1,0 +1,7 @@
+---
+required_pkgs:
+  - python-apt
+  - aufs-tools
+  - apt-transport-https
+  - software-properties-common
+  - ebtables

--- a/roles/kubernetes-recover/preinstall/vars/fedora.yml
+++ b/roles/kubernetes-recover/preinstall/vars/fedora.yml
@@ -1,0 +1,5 @@
+---
+required_pkgs:
+  - libselinux-python
+  - device-mapper-libs
+  - ebtables

--- a/roles/kubernetes-recover/preinstall/vars/redhat.yml
+++ b/roles/kubernetes-recover/preinstall/vars/redhat.yml
@@ -1,0 +1,5 @@
+---
+required_pkgs:
+  - libselinux-python
+  - device-mapper-libs
+  - ebtables

--- a/roles/kubernetes-recover/preinstall/vars/suse.yml
+++ b/roles/kubernetes-recover/preinstall/vars/suse.yml
@@ -1,0 +1,4 @@
+---
+required_pkgs:
+  - device-mapper
+  - ebtables

--- a/roles/kubernetes-recover/preinstall/vars/ubuntu.yml
+++ b/roles/kubernetes-recover/preinstall/vars/ubuntu.yml
@@ -1,0 +1,7 @@
+---
+required_pkgs:
+  - python-apt
+  - aufs-tools
+  - apt-transport-https
+  - software-properties-common
+  - ebtables

--- a/roles/kubernetes-recover/secrets-bak/defaults/main.yml
+++ b/roles/kubernetes-recover/secrets-bak/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+kube_cert_group: kube-cert
+kube_vault_mount_path: "/kube"

--- a/roles/kubernetes-recover/secrets-bak/files/kube-gen-token.sh
+++ b/roles/kubernetes-recover/secrets-bak/files/kube-gen-token.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Copyright 2015 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+token_dir=${TOKEN_DIR:-/var/srv/kubernetes}
+token_file="${token_dir}/known_tokens.csv"
+
+create_accounts=($@)
+
+if [ ! -e "${token_file}" ]; then
+  touch "${token_file}"
+fi
+
+for account in "${create_accounts[@]}"; do
+  if grep ",${account}," "${token_file}" ; then
+    continue
+  fi
+  token=$(dd if=/dev/urandom bs=128 count=1 2>/dev/null | base64 | tr -d "=+/" | dd bs=32 count=1 2>/dev/null)
+  echo "${token},${account},${account}" >> "${token_file}"
+  echo "${token}" > "${token_dir}/${account}.token"
+  echo "Added ${account}"
+done

--- a/roles/kubernetes-recover/secrets-bak/files/make-ssl.sh
+++ b/roles/kubernetes-recover/secrets-bak/files/make-ssl.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+
+# Author: Smana smainklh@gmail.com
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o pipefail
+
+usage()
+{
+    cat << EOF
+Create self signed certificates
+
+Usage : $(basename $0) -f <config> [-d <ssldir>]
+      -h | --help         : Show this message
+      -f | --config       : Openssl configuration file
+      -d | --ssldir       : Directory where the certificates will be installed
+
+      Environmental variables MASTERS and HOSTS should be set to generate keys
+      for each host.
+
+           ex :
+           MASTERS=node1 HOSTS="node1 node2" $(basename $0) -f openssl.conf -d /srv/ssl
+EOF
+}
+
+# Options parsing
+while (($#)); do
+    case "$1" in
+        -h | --help)   usage;   exit 0;;
+        -f | --config) CONFIG=${2}; shift 2;;
+        -d | --ssldir) SSLDIR="${2}"; shift 2;;
+        *)
+            usage
+            echo "ERROR : Unknown option"
+            exit 3
+        ;;
+    esac
+done
+
+if [ -z ${CONFIG} ]; then
+    echo "ERROR: the openssl configuration file is missing. option -f"
+    exit 1
+fi
+if [ -z ${SSLDIR} ]; then
+    SSLDIR="/etc/kubernetes/certs"
+fi
+
+tmpdir=$(mktemp -d /tmp/kubernetes_cacert.XXXXXX)
+trap 'rm -rf "${tmpdir}"' EXIT
+cd "${tmpdir}"
+
+mkdir -p "${SSLDIR}"
+
+# Root CA
+if [ -e "$SSLDIR/ca-key.pem" ]; then
+    # Reuse existing CA
+    cp $SSLDIR/{ca.pem,ca-key.pem} .
+else
+    openssl genrsa -out ca-key.pem 2048 > /dev/null 2>&1
+    openssl req -x509 -new -nodes -key ca-key.pem -days 36500 -out ca.pem -subj "/CN=kube-ca" > /dev/null 2>&1
+fi
+
+# Front proxy client CA
+if [ -e "$SSLDIR/front-proxy-ca-key.pem" ]; then
+    # Reuse existing front proxy CA
+    cp $SSLDIR/{front-proxy-ca.pem,front-proxy-ca-key.pem} .
+else
+    openssl genrsa -out front-proxy-ca-key.pem 2048 > /dev/null 2>&1
+    openssl req -x509 -new -nodes -key front-proxy-ca-key.pem -days 36500 -out front-proxy-ca.pem -subj "/CN=front-proxy-ca" > /dev/null 2>&1
+fi
+
+gen_key_and_cert() {
+    local name=$1
+    local subject=$2
+    openssl genrsa -out ${name}-key.pem 2048 > /dev/null 2>&1
+    openssl req -new -key ${name}-key.pem -out ${name}.csr -subj "${subject}" -config ${CONFIG} > /dev/null 2>&1
+    openssl x509 -req -in ${name}.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out ${name}.pem -days 36500 -extensions v3_req -extfile ${CONFIG} > /dev/null 2>&1
+}
+
+gen_key_and_cert_front_proxy() {
+    local name=$1
+    local subject=$2
+    openssl genrsa -out ${name}-key.pem 2048 > /dev/null 2>&1
+    openssl req -new -key ${name}-key.pem -out ${name}.csr -subj "${subject}" -config ${CONFIG} > /dev/null 2>&1
+    openssl x509 -req -in ${name}.csr -CA front-proxy-ca.pem -CAkey front-proxy-ca-key.pem -CAcreateserial -out ${name}.pem -days 36500 -extensions v3_req -extfile ${CONFIG} > /dev/null 2>&1
+}
+
+# Admins
+if [ -n "$MASTERS" ]; then
+
+    # service-account
+    # If --service-account-private-key-file was previously configured to use apiserver-key.pem then copy that to the new dedicated service-account signing key location to avoid disruptions
+    if [ -e "$SSLDIR/apiserver-key.pem" ] && ! [ -e "$SSLDIR/service-account-key.pem" ]; then
+       cp $SSLDIR/apiserver-key.pem $SSLDIR/service-account-key.pem
+    fi
+    # Generate dedicated service account signing key if one doesn't exist
+    if ! [ -e "$SSLDIR/apiserver-key.pem" ] && ! [ -e "$SSLDIR/service-account-key.pem" ]; then
+        openssl genrsa -out service-account-key.pem 2048 > /dev/null 2>&1
+    fi
+
+    # kube-apiserver
+    # Generate only if we don't have existing ca and apiserver certs
+    if ! [ -e "$SSLDIR/ca-key.pem" ] || ! [ -e "$SSLDIR/apiserver-key.pem" ]; then
+      gen_key_and_cert "apiserver" "/CN=kube-apiserver"
+      cat ca.pem >> apiserver.pem
+    fi
+    # If any host requires new certs, just regenerate scheduler and controller-manager master certs
+    # kube-scheduler
+    gen_key_and_cert "kube-scheduler" "/CN=system:kube-scheduler"
+    # kube-controller-manager
+    gen_key_and_cert "kube-controller-manager" "/CN=system:kube-controller-manager"
+    # metrics aggregator
+    gen_key_and_cert_front_proxy "front-proxy-client" "/CN=front-proxy-client"
+
+    for host in $MASTERS; do
+        cn="${host%%.*}"
+        # admin
+        gen_key_and_cert "admin-${host}" "/CN=kube-admin-${cn}/O=system:masters"
+    done
+fi
+
+# Nodes
+if [ -n "$HOSTS" ]; then
+    for host in $HOSTS; do
+        cn="${host%%.*}"
+        gen_key_and_cert "node-${host}" "/CN=system:node:${cn,,}/O=system:nodes"
+    done
+fi
+
+# system:node-proxier
+if [ -n "$HOSTS" ]; then
+    for host in $HOSTS; do
+        # kube-proxy
+        gen_key_and_cert "kube-proxy-${host}" "/CN=system:kube-proxy/O=system:node-proxier"
+    done
+fi
+
+# Install certs
+mv *.pem ${SSLDIR}/

--- a/roles/kubernetes-recover/secrets-bak/handlers/main.yml
+++ b/roles/kubernetes-recover/secrets-bak/handlers/main.yml
@@ -1,0 +1,15 @@
+---
+- name: set secret_changed
+  command: /bin/true
+  notify:
+    - set secret_changed to true
+    - clear kubeconfig for root user
+
+- name: set secret_changed to true
+  set_fact:
+    secret_changed: true
+
+- name: clear kubeconfig for root user
+  file:
+    path: /root/.kube/config
+    state: absent

--- a/roles/kubernetes-recover/secrets-bak/meta/main.yml
+++ b/roles/kubernetes-recover/secrets-bak/meta/main.yml
@@ -1,0 +1,2 @@
+---
+# NOTE: Dynamic task dependency on Vault Role if cert_management == "vault"

--- a/roles/kubernetes-recover/secrets-bak/tasks/check-certs.yml
+++ b/roles/kubernetes-recover/secrets-bak/tasks/check-certs.yml
@@ -1,0 +1,87 @@
+---
+- name: "Check_certs | check if the certs have already been generated on first master"
+  find:
+    paths: "{{ kube_cert_dir }}"
+    patterns: "ca.pem,ca-key.pem,admin-node*.pem,admin-node*-key.pem,front-proxy-ca.pem,front-proxy-ca-key.pem,front-proxy-client.pem,front-proxy-client-key.pem,apiserver.pem,apiserver-key.pem,kube-controller-manager.pem,kube-controller-manager-key.pem,kube-scheduler.pem,kube-scheduler-key.pem,kube-proxy-node*.pem,kube-proxy-node*-key.pem,node-node*.pemnode-node*-key.pem,service-account-key.pem"
+    get_checksum: true
+  delegate_to: "{{groups['kube-master'][0]}}"
+  register: kubecert_master
+  run_once: true
+
+- name: "Check_certs | Set default value for 'sync_certs', 'gen_certs', and 'secret_changed'  to false"
+  set_fact:
+    sync_certs: false
+    gen_certs: false
+    secret_changed: false
+
+- name: "Check_certs | Set 'gen_certs' to true"
+  set_fact:
+    gen_certs: true
+  when: "not item in kubecert_master.files|map(attribute='path') | list"
+  run_once: true
+  with_items: >-
+       ['{{ kube_cert_dir }}/ca.pem',
+       '{{ kube_cert_dir }}/ca-key.pem',
+       '{{ kube_cert_dir }}/apiserver.pem',
+       '{{ kube_cert_dir }}/apiserver-key.pem',
+       '{{ kube_cert_dir }}/kube-scheduler.pem',
+       '{{ kube_cert_dir }}/kube-scheduler-key.pem',
+       '{{ kube_cert_dir }}/kube-controller-manager.pem',
+       '{{ kube_cert_dir }}/kube-controller-manager-key.pem',
+       '{{ kube_cert_dir }}/front-proxy-ca.pem',
+       '{{ kube_cert_dir }}/front-proxy-ca-key.pem',
+       '{{ kube_cert_dir }}/front-proxy-client.pem',
+       '{{ kube_cert_dir }}/front-proxy-client-key.pem',
+       '{{ kube_cert_dir }}/service-account-key.pem',
+       {% for host in groups['kube-master'] %}
+       '{{ kube_cert_dir }}/admin-{{ host }}.pem'
+       '{{ kube_cert_dir }}/admin-{{ host }}-key.pem'
+       {% if not loop.last %}{{','}}{% endif %}
+       {% endfor %}]
+       {% for host in groups['k8s-cluster'] %}
+       '{{ kube_cert_dir }}/node-{{ host }}.pem'
+       '{{ kube_cert_dir }}/node-{{ host }}-key.pem'
+       '{{ kube_cert_dir }}/kube-proxy-{{ host }}.pem'
+       '{{ kube_cert_dir }}/kube-proxy-{{ host }}-key.pem'
+       {% if not loop.last %}{{','}}{% endif %}
+       {% endfor %}]
+
+- name: "Check_certs | Set 'gen_master_certs' to true"
+  set_fact:
+    gen_master_certs: |-
+      {%- set gen = False -%}
+      {% set existing_certs = kubecert_master.files|map(attribute='path')|list|sort %}
+      {% for cert in ['apiserver.pem', 'apiserver-key.pem',
+                      'admin-{{ inventory_hostname }}.pem','admin-{{ inventory_hostname }}-key.pem'
+                      'kube-scheduler.pem','kube-scheduler-key.pem',
+                      'kube-controller-manager.pem','kube-controller-manager-key.pem',
+                      'front-proxy-ca.pem','front-proxy-ca-key.pem',
+                      'front-proxy-client.pem','front-proxy-client-key.pem',
+                      'service-account-key.pem'] -%}
+        {% set cert_file = "%s/%s.pem"|format(kube_cert_dir, cert) %}
+        {% if not cert_file in existing_certs -%}
+        {%- set gen = True -%}
+        {% endif -%}
+      {% endfor %}
+      {{ gen }}
+  run_once: true
+
+- name: "Check_certs | Set 'gen_node_certs' to true"
+  set_fact:
+    gen_node_certs: |-
+      {
+      {% set existing_certs = kubecert_master.files|map(attribute='path')|list|sort %}
+      {% for host in groups['k8s-cluster'] -%}
+        {% set ca_cert = "%s/ca.pem"|format(kube_cert_dir) %}
+        {% set host_cert = "%s/node-%s-key.pem"|format(kube_cert_dir, host) %}
+        {% set host_cert2 = "%s/node-%s.pem"|format(kube_cert_dir, host) %}
+        {% set kube_proxy_cert = "%s/kube-proxy-%s-key.pem"|format(kube_cert_dir, host) %}
+        {% set kube_proxy_cert2 = "%s/kube-proxy-%s.pem"|format(kube_cert_dir, host) %}
+        {% if ca_cert in existing_certs and host_cert in existing_certs and host_cert2 in existing_certs and kube_proxy_cert in existing_certs and kube_proxy_cert2 in existing_certs -%}
+        "{{ host }}": False,
+        {% else -%}
+        "{{ host }}": True,
+        {% endif -%}
+      {% endfor %}
+      }
+  run_once: true

--- a/roles/kubernetes-recover/secrets-bak/tasks/check-tokens.yml
+++ b/roles/kubernetes-recover/secrets-bak/tasks/check-tokens.yml
@@ -1,0 +1,36 @@
+---
+- name: "Check_tokens | check if the tokens have already been generated on first master"
+  stat:
+    path: "{{ kube_token_dir }}/known_tokens.csv"
+  delegate_to: "{{groups['kube-master'][0]}}"
+  register: known_tokens_master
+  run_once: true
+
+- name: "Check_tokens | Set default value for 'sync_tokens' and 'gen_tokens' to false"
+  set_fact:
+    sync_tokens: false
+    gen_tokens: false
+
+- name: "Check_tokens | Set 'sync_tokens' and 'gen_tokens' to true"
+  set_fact:
+    gen_tokens: true
+  when: not known_tokens_master.stat.exists and kube_token_auth|default(true)
+  run_once: true
+
+- name: "Check tokens | check if a cert already exists"
+  stat:
+    path: "{{ kube_token_dir }}/known_tokens.csv"
+  register: known_tokens
+
+- name: "Check_tokens | Set 'sync_tokens' to true"
+  set_fact:
+    sync_tokens: true
+  when: >-
+      {%- set tokens = {'sync': False} -%}
+      {%- for server in groups['kube-master'] | intersect(ansible_play_batch)
+         if (not hostvars[server].known_tokens.stat.exists) or
+         (hostvars[server].known_tokens.stat.checksum|default('') != known_tokens_master.stat.checksum|default('')) -%}
+         {%- set _ = tokens.update({'sync': True}) -%}
+      {%- endfor -%}
+      {{ tokens.sync }}
+  run_once: true

--- a/roles/kubernetes-recover/secrets-bak/tasks/gen_certs_script.yml
+++ b/roles/kubernetes-recover/secrets-bak/tasks/gen_certs_script.yml
@@ -1,0 +1,217 @@
+---
+- name: "Gen_certs | Create kubernetes config directory (on {{groups['kube-master'][0]}})"
+  file:
+    path: "{{ kube_config_dir }}"
+    state: directory
+    owner: kube
+  run_once: yes
+  delegate_to: "{{groups['kube-master'][0]}}"
+  when: gen_certs|default(false)
+  tags:
+    - kubelet
+    - k8s-secrets
+    - kube-controller-manager
+    - kube-apiserver
+    - apps
+    - network
+    - master
+    - node
+
+- name: "Gen_certs | Create kubernetes script directory (on {{groups['kube-master'][0]}})"
+  file:
+    path: "{{ kube_script_dir }}"
+    state: directory
+    owner: kube
+  run_once: yes
+  delegate_to: "{{groups['kube-master'][0]}}"
+  when: gen_certs|default(false)
+  tags:
+    - k8s-secrets
+
+- name: Gen_certs | write openssl config
+  template:
+    src: "openssl.conf.j2"
+    dest: "{{ kube_config_dir }}/openssl.conf"
+  run_once: yes
+  delegate_to: "{{groups['kube-master'][0]}}"
+  when: gen_certs|default(false)
+
+- name: Gen_certs | copy certs generation script
+  copy:
+    src: "make-ssl.sh"
+    dest: "{{ kube_script_dir }}/make-ssl.sh"
+    mode: 0700
+  run_once: yes
+  delegate_to: "{{groups['kube-master'][0]}}"
+  when: gen_certs|default(false)
+
+- name: Gen_certs | run cert generation script
+  command: "{{ kube_script_dir }}/make-ssl.sh -f {{ kube_config_dir }}/openssl.conf -d {{ kube_cert_dir }}"
+  environment:
+    - MASTERS: "{% for m in groups['kube-master'] %}
+                  {% if gen_master_certs|default(false) %}
+                    {{ m }}
+                  {% endif %}
+                {% endfor %}"
+    - HOSTS: "{% for h in groups['k8s-cluster'] %}
+                {% if gen_node_certs[h]|default(true) %}
+                    {{ h }}
+                {% endif %}
+              {% endfor %}"
+  run_once: yes
+  delegate_to: "{{groups['kube-master'][0]}}"
+  when: gen_certs|default(false)
+  notify: set secret_changed
+
+- set_fact:
+    all_master_certs: "['ca-key.pem',
+                       'apiserver.pem',
+                       'apiserver-key.pem',
+                       'kube-scheduler.pem',
+                       'kube-scheduler-key.pem',
+                       'kube-controller-manager.pem',
+                       'kube-controller-manager-key.pem',
+                       'front-proxy-ca.pem',
+                       'front-proxy-ca-key.pem',
+                       'front-proxy-client.pem',
+                       'front-proxy-client-key.pem',
+                       'service-account-key.pem',
+                       {% for node in groups['kube-master'] %}
+                       'admin-{{ node }}.pem',
+                       'admin-{{ node }}-key.pem',
+                      {% endfor %}]"
+    my_master_certs: ['ca-key.pem',
+                      'admin-{{ inventory_hostname }}.pem',
+                      'admin-{{ inventory_hostname }}-key.pem',
+                      'apiserver.pem',
+                      'apiserver-key.pem',
+                      'front-proxy-ca.pem',
+                      'front-proxy-ca-key.pem',
+                      'front-proxy-client.pem',
+                      'front-proxy-client-key.pem',
+                      'service-account-key.pem',
+                      'kube-scheduler.pem',
+                      'kube-scheduler-key.pem',
+                      'kube-controller-manager.pem',
+                      'kube-controller-manager-key.pem']
+    all_node_certs: "['ca.pem',
+                    {% for node in groups['k8s-cluster'] %}
+                    'node-{{ node }}.pem',
+                    'node-{{ node }}-key.pem',
+                    'kube-proxy-{{ node }}.pem',
+                    'kube-proxy-{{ node }}-key.pem',
+                    {% endfor %}]"
+    my_node_certs: ['ca.pem',
+                    'node-{{ inventory_hostname }}.pem',
+                    'node-{{ inventory_hostname }}-key.pem',
+                    'kube-proxy-{{ inventory_hostname }}.pem',
+                    'kube-proxy-{{ inventory_hostname }}-key.pem']
+  tags:
+    - facts
+
+- name: "Check certs | check if a cert already exists on node"
+  find:
+    paths: "{{ kube_cert_dir }}"
+    patterns: "*.pem"
+    get_checksum: true
+  register: kubecert_node
+  when: inventory_hostname != groups['kube-master'][0]
+
+- name: "Check_certs | Set 'sync_certs' to true on masters"
+  set_fact:
+    sync_certs: true
+  when: inventory_hostname in groups['kube-master'] and
+        inventory_hostname != groups['kube-master'][0] and
+        (not item in kubecert_node.files | map(attribute='path') | map("basename") | list or
+        kubecert_node.files | selectattr("path", "equalto", "{{ kube_cert_dir }}/{{ item }}") | map(attribute="checksum")|first|default('') != kubecert_master.files | selectattr("path", "equalto", "{{ kube_cert_dir }}/{{ item }}") | map(attribute="checksum")|first|default(''))
+  with_items:
+    - "{{ my_master_certs + all_node_certs }}"
+
+- name: "Check_certs | Set 'sync_certs' to true on nodes"
+  set_fact:
+    sync_certs: true
+  when: inventory_hostname in groups['kube-node'] and
+        inventory_hostname != groups['kube-master'][0] and
+        (not item in kubecert_node.files | map(attribute='path') | map("basename") | list or
+        kubecert_node.files | selectattr("path", "equalto", "{{ kube_cert_dir }}/{{ item }}") | map(attribute="checksum")|first|default('') != kubecert_master.files | selectattr("path", "equalto", "{{ kube_cert_dir }}/{{ item }}") | map(attribute="checksum")|first|default(''))
+  with_items:
+    - "{{ my_node_certs }}"
+
+- name: Gen_certs | Gather master certs
+  shell: "tar cfz - -C {{ kube_cert_dir }} -T /dev/stdin <<< {{ my_master_certs|join(' ') }} {{ all_node_certs|join(' ') }} | base64 --wrap=0"
+  args:
+    executable: /bin/bash
+  no_log: true
+  register: master_cert_data
+  check_mode: no
+  delegate_to: "{{groups['kube-master'][0]}}"
+  when: inventory_hostname in groups['kube-master'] and sync_certs|default(false) and
+        inventory_hostname != groups['kube-master'][0]
+
+- name: Gen_certs | Gather node certs
+  shell: "tar cfz - -C {{ kube_cert_dir }} -T /dev/stdin <<< {{ my_node_certs|join(' ') }} | base64 --wrap=0"
+  args:
+    executable: /bin/bash
+  no_log: true
+  register: node_cert_data
+  check_mode: no
+  delegate_to: "{{groups['kube-master'][0]}}"
+  when: inventory_hostname in groups['kube-node'] and
+        sync_certs|default(false) and
+        inventory_hostname != groups['kube-master'][0]
+
+# NOTE(mattymo): Use temporary file to copy master certs because we have a ~200k
+# char limit when using shell command
+
+# FIXME(mattymo): Use tempfile module in ansible 2.3
+- name: Gen_certs | Prepare tempfile for unpacking certs on masters
+  command: mktemp /tmp/certsXXXXX.tar.gz
+  register: cert_tempfile
+  when: inventory_hostname in groups['kube-master'] and sync_certs|default(false) and
+        inventory_hostname != groups['kube-master'][0]
+
+- name: Gen_certs | Write master certs to tempfile
+  copy:
+    content: "{{master_cert_data.stdout}}"
+    dest: "{{cert_tempfile.stdout}}"
+    owner: root
+    mode: "0600"
+  when: inventory_hostname in groups['kube-master'] and sync_certs|default(false) and
+        inventory_hostname != groups['kube-master'][0]
+
+- name: Gen_certs | Unpack certs on masters
+  shell: "base64 -d < {{ cert_tempfile.stdout }} | tar xz -C {{ kube_cert_dir }}"
+  no_log: true
+  changed_when: false
+  check_mode: no
+  when: inventory_hostname in groups['kube-master'] and sync_certs|default(false) and
+        inventory_hostname != groups['kube-master'][0]
+  notify: set secret_changed
+
+- name: Gen_certs | Cleanup tempfile on masters
+  file:
+    path: "{{cert_tempfile.stdout}}"
+    state: absent
+  when: inventory_hostname in groups['kube-master'] and sync_certs|default(false) and
+        inventory_hostname != groups['kube-master'][0]
+
+- name: Gen_certs | Copy certs on nodes
+  shell: "base64 -d <<< '{{node_cert_data.stdout|quote}}' | tar xz -C {{ kube_cert_dir }}"
+  args:
+    executable: /bin/bash
+  no_log: true
+  changed_when: false
+  check_mode: no
+  when: inventory_hostname in groups['kube-node'] and
+        sync_certs|default(false) and
+        inventory_hostname != groups['kube-master'][0]
+  notify: set secret_changed
+
+- name: Gen_certs | check certificate permissions
+  file:
+    path: "{{ kube_cert_dir }}"
+    group: "{{ kube_cert_group }}"
+    state: directory
+    owner: kube
+    mode: "u=rwX,g-rwx,o-rwx"
+    recurse: yes

--- a/roles/kubernetes-recover/secrets-bak/tasks/gen_certs_vault.yml
+++ b/roles/kubernetes-recover/secrets-bak/tasks/gen_certs_vault.yml
@@ -1,0 +1,133 @@
+---
+- import_tasks: sync_kube_master_certs.yml
+  when: inventory_hostname in groups['kube-master']
+
+- import_tasks: sync_kube_node_certs.yml
+  when: inventory_hostname in groups['k8s-cluster']
+
+# Issue admin certs to kube-master hosts
+- include_tasks: ../../../vault/tasks/shared/issue_cert.yml
+  vars:
+    issue_cert_common_name: "admin"
+    issue_cert_copy_ca: "{{ item == kube_admin_certs_needed|first }}"
+    issue_cert_file_group: "{{ kube_cert_group }}"
+    issue_cert_file_owner: kube
+    issue_cert_hosts: "{{ groups['kube-master'] }}"
+    issue_cert_path: "{{ item }}"
+    issue_cert_role: kube-master
+    issue_cert_url: "{{ hostvars[groups.vault|first]['vault_leader_url'] }}"
+    issue_cert_mount_path: "{{ kube_vault_mount_path }}"
+  with_items: "{{ kube_admin_certs_needed|d([]) }}"
+  when: inventory_hostname in groups['kube-master']
+
+- name: gen_certs_vault | Set fact about certificate alt names
+  set_fact:
+    kube_cert_alt_names: >-
+      {{
+      groups['kube-master'] +
+      ['kubernetes.default.svc.cluster.local', 'kubernetes.default.svc', 'kubernetes.default', 'kubernetes'] +
+      ['localhost']
+      }}
+  run_once: true
+
+- name: gen_certs_vault | Add external load balancer domain name to certificate alt names
+  set_fact:
+    kube_cert_alt_names: "{{ kube_cert_alt_names + [apiserver_loadbalancer_domain_name] }}"
+  when: loadbalancer_apiserver is defined
+  run_once: true
+
+# Issue master components certs to kube-master hosts
+- include_tasks: ../../../vault/tasks/shared/issue_cert.yml
+  vars:
+    issue_cert_common_name: "kubernetes"
+    issue_cert_alt_names: "{{ kube_cert_alt_names }}"
+    issue_cert_file_group: "{{ kube_cert_group }}"
+    issue_cert_file_owner: kube
+    issue_cert_hosts: "{{ groups['kube-master'] }}"
+    issue_cert_ip_sans: >-
+        [
+        {%- for host in groups['kube-master']  -%}
+        "{{ hostvars[host]['ansible_default_ipv4']['address'] }}",
+        {%- if hostvars[host]['ip'] is defined -%}
+        "{{ hostvars[host]['ip'] }}",
+        {%- endif -%}
+        {%- endfor -%}
+        {%- if supplementary_addresses_in_ssl_keys is defined -%}
+        {%- for ip_item in supplementary_addresses_in_ssl_keys -%}
+        "{{ ip_item }}",
+        {%- endfor -%}
+        {%- endif -%}
+        "127.0.0.1","::1","{{ kube_apiserver_ip }}"
+        ]
+    issue_cert_path: "{{ item }}"
+    issue_cert_role: kube-master
+    issue_cert_url: "{{ hostvars[groups.vault|first]['vault_leader_url'] }}"
+    issue_cert_mount_path: "{{ kube_vault_mount_path }}"
+  with_items: "{{ kube_master_components_certs_needed|d([]) }}"
+  when: inventory_hostname in groups['kube-master']
+  notify: set secret_changed
+
+# Issue node certs to k8s-cluster nodes
+- include_tasks: ../../../vault/tasks/shared/issue_cert.yml
+  vars:
+    # Need to strip out the 'node-' prefix from the cert name so it can be used
+    # with the node authorization plugin ( CN matches kubelet node name )
+    issue_cert_common_name: "system:node:{{ item.rsplit('/', 1)[1].rsplit('.', 1)[0] | regex_replace('^node-', '') }}"
+    issue_cert_copy_ca: "{{ item == kube_node_certs_needed|first }}"
+    issue_cert_file_group: "{{ kube_cert_group }}"
+    issue_cert_file_owner: kube
+    issue_cert_hosts: "{{ groups['k8s-cluster'] }}"
+    issue_cert_path: "{{ item }}"
+    issue_cert_role: kube-node
+    issue_cert_url: "{{ hostvars[groups.vault|first]['vault_leader_url'] }}"
+    issue_cert_mount_path: "{{ kube_vault_mount_path }}"
+  with_items: "{{ kube_node_certs_needed|d([]) }}"
+  when: inventory_hostname in groups['k8s-cluster']
+
+# Issue proxy certs to k8s-cluster nodes
+- include_tasks: ../../../vault/tasks/shared/issue_cert.yml
+  vars:
+    issue_cert_common_name: "system:kube-proxy"
+    issue_cert_copy_ca: "{{ item == kube_proxy_certs_needed|first }}"
+    issue_cert_file_group: "{{ kube_cert_group }}"
+    issue_cert_file_owner: kube
+    issue_cert_hosts: "{{ groups['k8s-cluster'] }}"
+    issue_cert_path: "{{ item }}"
+    issue_cert_role: kube-proxy
+    issue_cert_url: "{{ hostvars[groups.vault|first]['vault_leader_url'] }}"
+    issue_cert_mount_path: "{{ kube_vault_mount_path }}"
+  with_items: "{{ kube_proxy_certs_needed|d([]) }}"
+  when: inventory_hostname in groups['k8s-cluster']
+
+# Issue front proxy cert to kube-master hosts
+- include_tasks: ../../../vault/tasks/shared/issue_cert.yml
+  vars:
+    issue_cert_common_name: "front-proxy-client"
+    issue_cert_copy_ca: "{{ item == kube_front_proxy_clients_certs_needed|first }}"
+    issue_cert_ca_filename: front-proxy-ca.pem
+    issue_cert_alt_names: "{{ kube_cert_alt_names }}"
+    issue_cert_file_group: "{{ kube_cert_group }}"
+    issue_cert_file_owner: kube
+    issue_cert_hosts: "{{ groups['kube-master'] }}"
+    issue_cert_ip_sans: >-
+        [
+        {%- for host in groups['kube-master']  -%}
+        "{{ hostvars[host]['ansible_default_ipv4']['address'] }}",
+        {%- if hostvars[host]['ip'] is defined -%}
+        "{{ hostvars[host]['ip'] }}",
+        {%- endif -%}
+        {%- endfor -%}
+        {%- if supplementary_addresses_in_ssl_keys is defined -%}
+        {%- for ip_item in supplementary_addresses_in_ssl_keys -%}
+        "{{ ip_item }}",
+        {%- endfor -%}
+        {%- endif -%}
+        "127.0.0.1","::1","{{ kube_apiserver_ip }}"
+        ]
+    issue_cert_path: "{{ item }}"
+    issue_cert_role: front-proxy-client
+    issue_cert_url: "{{ hostvars[groups.vault|first]['vault_leader_url'] }}"
+    issue_cert_mount_path: "{{ kube_vault_mount_path }}"
+  with_items: "{{ kube_front_proxy_clients_certs_needed|d([]) }}"
+  when: inventory_hostname in groups['kube-master']
+  notify: set secret_changed

--- a/roles/kubernetes-recover/secrets-bak/tasks/gen_tokens.yml
+++ b/roles/kubernetes-recover/secrets-bak/tasks/gen_tokens.yml
@@ -1,0 +1,58 @@
+---
+- name: Gen_tokens | copy tokens generation script
+  copy:
+    src: "kube-gen-token.sh"
+    dest: "{{ kube_script_dir }}/kube-gen-token.sh"
+    mode: 0700
+  run_once: yes
+  delegate_to: "{{groups['kube-master'][0]}}"
+  when: gen_tokens|default(false)
+
+- name: Gen_tokens | generate tokens for master components
+  command: "{{ kube_script_dir }}/kube-gen-token.sh {{ item[0] }}-{{ item[1] }}"
+  environment:
+    TOKEN_DIR: "{{ kube_token_dir }}"
+  with_nested:
+    - [ "system:kubectl" ]
+    - "{{ groups['kube-master'] }}"
+  register: gentoken_master
+  changed_when: "'Added' in gentoken_master.stdout"
+  notify: set secret_changed
+  run_once: yes
+  delegate_to: "{{groups['kube-master'][0]}}"
+  when: gen_tokens|default(false)
+
+- name: Gen_tokens | generate tokens for node components
+  command: "{{ kube_script_dir }}/kube-gen-token.sh {{ item[0] }}-{{ item[1] }}"
+  environment:
+    TOKEN_DIR: "{{ kube_token_dir }}"
+  with_nested:
+    - [ 'system:kubelet' ]
+    - "{{ groups['kube-node'] }}"
+  register: gentoken_node
+  changed_when: "'Added' in gentoken_node.stdout"
+  notify: set secret_changed
+  run_once: yes
+  delegate_to: "{{groups['kube-master'][0]}}"
+  when: gen_tokens|default(false)
+
+- name: Gen_tokens | Get list of tokens from first master
+  shell: "(find {{ kube_token_dir }} -maxdepth 1 -type f)"
+  register: tokens_list
+  check_mode: no
+  delegate_to: "{{groups['kube-master'][0]}}"
+  run_once: true
+  when: sync_tokens|default(false)
+
+- name: Gen_tokens | Gather tokens
+  shell: "tar cfz - {{ tokens_list.stdout_lines | join(' ') }} | base64 --wrap=0"
+  register: tokens_data
+  check_mode: no
+  delegate_to: "{{groups['kube-master'][0]}}"
+  run_once: true
+  when: sync_tokens|default(false)
+
+- name: Gen_tokens | Copy tokens on masters
+  shell: "echo '{{ tokens_data.stdout|quote }}' | base64 -d | tar xz -C /"
+  when: inventory_hostname in groups['kube-master'] and sync_tokens|default(false) and
+        inventory_hostname != groups['kube-master'][0] and tokens_data.stdout != ''

--- a/roles/kubernetes-recover/secrets-bak/tasks/main.yml
+++ b/roles/kubernetes-recover/secrets-bak/tasks/main.yml
@@ -1,0 +1,114 @@
+---
+- import_tasks: check-certs.yml
+  tags:
+    - k8s-secrets
+    - facts
+
+- import_tasks: check-tokens.yml
+  tags:
+    - k8s-secrets
+    - facts
+
+- name: Make sure the certificate directory exits
+  file:
+    path: "{{ kube_cert_dir }}"
+    state: directory
+    mode: o-rwx
+    group: "{{ kube_cert_group }}"
+
+- name: Make sure the tokens directory exits
+  file:
+    path: "{{ kube_token_dir }}"
+    state: directory
+    mode: o-rwx
+    group: "{{ kube_cert_group }}"
+
+#
+# The following directory creates make sure that the directories
+# exist on the first master for cases where the first master isn't
+# being run.
+#
+- name: "Gen_certs | Create kubernetes config directory (on {{groups['kube-master'][0]}})"
+  file:
+    path: "{{ kube_config_dir }}"
+    state: directory
+    owner: kube
+  run_once: yes
+  delegate_to: "{{groups['kube-master'][0]}}"
+  when: gen_certs|default(false) or gen_tokens|default(false)
+  tags:
+    - kubelet
+    - k8s-secrets
+    - kube-controller-manager
+    - kube-apiserver
+    - apps
+    - network
+    - master
+    - node
+
+- name: "Gen_certs | Create kubernetes script directory (on {{groups['kube-master'][0]}})"
+  file:
+    path: "{{ kube_script_dir }}"
+    state: directory
+    owner: kube
+  run_once: yes
+  delegate_to: "{{groups['kube-master'][0]}}"
+  when: gen_certs|default(false) or gen_tokens|default(false)
+  tags:
+    - k8s-secrets
+
+- name: "Get_tokens | Make sure the tokens directory exits (on {{groups['kube-master'][0]}})"
+  file:
+    path: "{{ kube_token_dir }}"
+    state: directory
+    mode: o-rwx
+    group: "{{ kube_cert_group }}"
+  run_once: yes
+  delegate_to: "{{groups['kube-master'][0]}}"
+  when: gen_tokens|default(false)
+
+- include_tasks: "gen_certs_{{ cert_management }}.yml"
+  tags:
+    - k8s-secrets
+
+- import_tasks: upd_ca_trust.yml
+  tags:
+    - k8s-secrets
+
+- name: "Gen_certs | Get certificate serials on kube masters"
+  shell: "openssl x509 -in {{ kube_cert_dir }}/{{ item }} -noout -serial | cut -d= -f2"
+  register: "master_certificate_serials"
+  changed_when: false
+  with_items:
+    - "admin-{{ inventory_hostname }}.pem"
+    - "apiserver.pem"
+    - "kube-controller-manager.pem"
+    - "kube-scheduler.pem"
+  when: inventory_hostname in groups['kube-master']
+
+- name: "Gen_certs | set kube master certificate serial facts"
+  set_fact:
+    etcd_admin_cert_serial: "{{ master_certificate_serials.results[0].stdout|default() }}"
+    apiserver_cert_serial: "{{ master_certificate_serials.results[1].stdout|default() }}"
+    controller_manager_cert_serial: "{{ master_certificate_serials.results[2].stdout|default() }}"
+    scheduler_cert_serial: "{{ master_certificate_serials.results[3].stdout|default() }}"
+  when: inventory_hostname in groups['kube-master']
+
+- name: "Gen_certs | Get certificate serials on kube nodes"
+  shell: "openssl x509 -in {{ kube_cert_dir }}/{{ item }} -noout -serial | cut -d= -f2"
+  register: "node_certificate_serials"
+  changed_when: false
+  with_items:
+    - "node-{{ inventory_hostname }}.pem"
+    - "kube-proxy-{{ inventory_hostname }}.pem"
+  when: inventory_hostname in groups['k8s-cluster']
+
+- name: "Gen_certs | set kube node certificate serial facts"
+  set_fact:
+    kubelet_cert_serial: "{{ node_certificate_serials.results[0].stdout|default() }}"
+    kube_proxy_cert_serial: "{{ node_certificate_serials.results[1].stdout|default() }}"
+  when: inventory_hostname in groups['k8s-cluster']
+
+- import_tasks: gen_tokens.yml
+  tags:
+    - k8s-secrets

--- a/roles/kubernetes-recover/secrets-bak/tasks/sync_kube_master_certs.yml
+++ b/roles/kubernetes-recover/secrets-bak/tasks/sync_kube_master_certs.yml
@@ -1,0 +1,89 @@
+---
+
+- name: sync_kube_master_certs | Create list of needed kube admin certs
+  set_fact:
+    kube_admin_cert_list: "{{ kube_admin_cert_list|d([]) + ['admin-' + inventory_hostname + '.pem'] }}"
+
+- include_tasks: ../../../vault/tasks/shared/sync_file.yml
+  vars:
+    sync_file: "{{ item }}"
+    sync_file_dir: "{{ kube_cert_dir }}"
+    sync_file_group: "{{ kube_cert_group }}"
+    sync_file_hosts: [ "{{ inventory_hostname }}" ]
+    sync_file_is_cert: true
+    sync_file_owner: kube
+  with_items: "{{ kube_admin_cert_list|d([]) }}"
+
+- name: sync_kube_master_certs | Set facts for kube admin sync_file results
+  set_fact:
+    kube_admin_certs_needed: "{{ kube_admin_certs_needed|default([]) + [item.path] }}"
+  with_items: "{{ sync_file_results|d([]) }}"
+  when: item.no_srcs|bool
+
+- name: sync_kube_master_certs | Unset sync_file_results after kube admin certs
+  set_fact:
+    sync_file_results: []
+
+- include_tasks: ../../../vault/tasks/shared/sync_file.yml
+  vars:
+    sync_file: "{{ item }}"
+    sync_file_dir: "{{ kube_cert_dir }}"
+    sync_file_group: "{{ kube_cert_group }}"
+    sync_file_hosts: "{{ groups['kube-master'] }}"
+    sync_file_is_cert: true
+    sync_file_owner: kube
+  with_items: ["apiserver.pem", "kube-scheduler.pem", "kube-controller-manager.pem", "service-account.pem"]
+
+- name: sync_kube_master_certs | Set facts for kube master components sync_file results
+  set_fact:
+    kube_master_components_certs_needed: "{{ kube_master_components_certs_needed|d([]) + [item.path] }}"
+  with_items: "{{ sync_file_results|d([]) }}"
+  when: item.no_srcs|bool
+
+- name: sync_kube_master_certs | Unset sync_file_results after kube master components cert
+  set_fact:
+    sync_file_results: []
+
+- include_tasks: ../../../vault/tasks/shared/sync_file.yml
+  vars:
+    sync_file: front-proxy-ca.pem
+    sync_file_dir: "{{ kube_cert_dir }}"
+    sync_file_group: "{{ kube_cert_group }}"
+    sync_file_hosts: "{{ groups['kube-master'] }}"
+    sync_file_owner: kube
+
+- name: sync_kube_master_certs | Unset sync_file_results after front-proxy-ca.pem
+  set_fact:
+    sync_file_results: []
+
+- include_tasks: ../../../vault/tasks/shared/sync_file.yml
+  vars:
+    sync_file: "{{ item }}"
+    sync_file_dir: "{{ kube_cert_dir }}"
+    sync_file_group: "{{ kube_cert_group }}"
+    sync_file_hosts: "{{ groups['kube-master'] }}"
+    sync_file_is_cert: true
+    sync_file_owner: kube
+  with_items: ["front-proxy-client.pem"]
+
+- name: sync_kube_master_certs | Set facts for front-proxy-client certs sync_file results
+  set_fact:
+    kube_front_proxy_clients_certs_needed: "{{ kube_front_proxy_clients_certs_needed|d([]) + [item.path] }}"
+  with_items: "{{ sync_file_results|d([]) }}"
+  when: item.no_srcs|bool
+
+- name: sync_kube_master_certs | Unset sync_file_results after front-proxy-client sync
+  set_fact:
+    sync_file_results: []
+
+- include_tasks: ../../../vault/tasks/shared/sync_file.yml
+  vars:
+    sync_file: ca.pem
+    sync_file_dir: "{{ kube_cert_dir }}"
+    sync_file_group: "{{ kube_cert_group }}"
+    sync_file_hosts: "{{ groups['kube-master'] }}"
+    sync_file_owner: kube
+
+- name: sync_kube_master_certs | Unset sync_file_results after ca.pem
+  set_fact:
+    sync_file_results: []

--- a/roles/kubernetes-recover/secrets-bak/tasks/sync_kube_node_certs.yml
+++ b/roles/kubernetes-recover/secrets-bak/tasks/sync_kube_node_certs.yml
@@ -1,0 +1,60 @@
+---
+
+- name: sync_kube_node_certs | Create list of needed certs
+  set_fact:
+    kube_node_cert_list: "{{ kube_node_cert_list|default([]) + ['node-' + inventory_hostname + '.pem'] }}"
+
+- include_tasks: ../../../vault/tasks/shared/sync_file.yml
+  vars:
+    sync_file: "{{ item }}"
+    sync_file_dir: "{{ kube_cert_dir }}"
+    sync_file_group: "{{ kube_cert_group }}"
+    sync_file_hosts: [ "{{ inventory_hostname }}" ]
+    sync_file_is_cert: true
+    sync_file_owner: kube
+  with_items: "{{ kube_node_cert_list|default([]) }}"
+
+- name: sync_kube_node_certs | Set facts for kube-master sync_file results
+  set_fact:
+    kube_node_certs_needed: "{{ kube_node_certs_needed|default([]) + [item.path] }}"
+  with_items: "{{ sync_file_results|d([]) }}"
+  when: item.no_srcs|bool
+
+- name: sync_kube_node_certs | Unset sync_file_results after kube node certs
+  set_fact:
+    sync_file_results: []
+
+- include_tasks: ../../../vault/tasks/shared/sync_file.yml
+  vars:
+    sync_file: ca.pem
+    sync_file_dir: "{{ kube_cert_dir }}"
+    sync_file_group: "{{ kube_cert_group }}"
+    sync_file_hosts: "{{ groups['k8s-cluster'] }}"
+    sync_file_owner: kube
+
+- name: sync_kube_node_certs | Unset sync_file_results after ca.pem
+  set_fact:
+    sync_file_results: []
+
+- name: sync_kube_node_certs | Create list of needed kube-proxy certs
+  set_fact:
+    kube_proxy_cert_list: "{{ kube_proxy_cert_list|default([]) + ['kube-proxy-' + inventory_hostname + '.pem'] }}"
+
+- include_tasks: ../../../vault/tasks/shared/sync_file.yml
+  vars:
+    sync_file: "{{ item }}"
+    sync_file_dir: "{{ kube_cert_dir }}"
+    sync_file_group: "{{ kube_cert_group }}"
+    sync_file_hosts: [ "{{ inventory_hostname }}" ]
+    sync_file_owner: kube
+  with_items: "{{ kube_proxy_cert_list|default([]) }}"
+
+- name: sync_kube_node_certs | Set facts for kube-proxy sync_file results
+  set_fact:
+    kube_proxy_certs_needed: "{{ kube_proxy_certs_needed|default([]) + [item.path] }}"
+  with_items: "{{ sync_file_results|d([]) }}"
+  when: item.no_srcs|bool
+
+- name: sync_kube_node_certs | Unset sync_file_results after kube proxy certs
+  set_fact:
+    sync_file_results: []

--- a/roles/kubernetes-recover/secrets-bak/tasks/upd_ca_trust.yml
+++ b/roles/kubernetes-recover/secrets-bak/tasks/upd_ca_trust.yml
@@ -1,0 +1,30 @@
+---
+- name: Gen_certs | target ca-certificates path
+  set_fact:
+    ca_cert_path: |-
+      {% if ansible_os_family == "Debian" -%}
+      /usr/local/share/ca-certificates/kube-ca.crt
+      {%- elif ansible_os_family == "RedHat" -%}
+      /etc/pki/ca-trust/source/anchors/kube-ca.crt
+      {%- elif ansible_os_family in ["CoreOS", "Container Linux by CoreOS"] -%}
+      /etc/ssl/certs/kube-ca.pem
+      {%- elif ansible_os_family == "Suse" -%}
+      /etc/pki/trust/anchors/kube-ca.pem
+      {%- endif %}
+  tags:
+    - facts
+
+- name: Gen_certs | add CA to trusted CA dir
+  copy:
+    src: "{{ kube_cert_dir }}/ca.pem"
+    dest: "{{ ca_cert_path }}"
+    remote_src: true
+  register: kube_ca_cert
+
+- name: Gen_certs | update ca-certificates (Debian/Ubuntu/SUSE/Container Linux by CoreOS)
+  command: update-ca-certificates
+  when: kube_ca_cert.changed and ansible_os_family in ["Debian", "CoreOS", "Container Linux by CoreOS", "Suse"]
+
+- name: Gen_certs | update ca-certificates (RedHat)
+  command: update-ca-trust extract
+  when: kube_ca_cert.changed and ansible_os_family == "RedHat"

--- a/roles/kubernetes-recover/secrets-bak/templates/openssl.conf.j2
+++ b/roles/kubernetes-recover/secrets-bak/templates/openssl.conf.j2
@@ -1,0 +1,42 @@
+{% set counter = {'dns': 6,'ip': 1,} %}{% macro increment(dct, key, inc=1)%}{% if dct.update({key: dct[key] + inc}) %} {% endif %}{% endmacro %}[req]
+req_extensions = v3_req
+distinguished_name = req_distinguished_name
+[req_distinguished_name]
+[ v3_req ]
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+subjectAltName = @alt_names
+[alt_names]
+DNS.1 = kubernetes
+DNS.2 = kubernetes.default
+DNS.3 = kubernetes.default.svc
+DNS.4 = kubernetes.default.svc.{{ dns_domain }}
+DNS.5 = localhost
+{% for host in groups['kube-master'] %}
+DNS.{{ counter["dns"] }} = {{ host }}{{ increment(counter, 'dns') }}
+{% endfor %}
+{% if apiserver_loadbalancer_domain_name is defined  %}
+DNS.{{ counter["dns"] }} = {{ apiserver_loadbalancer_domain_name }}{{ increment(counter, 'dns') }}
+{% endif %}
+{% for host in groups['kube-master'] %}
+{% if hostvars[host]['access_ip'] is defined  %}
+IP.{{ counter["ip"] }} = {{ hostvars[host]['access_ip'] }}{{ increment(counter, 'ip') }}
+{% endif %}
+IP.{{ counter["ip"] }} = {{ hostvars[host]['ip'] | default(hostvars[host]['ansible_default_ipv4']['address']) }}{{ increment(counter, 'ip') }}
+{% endfor %}
+{% if kube_apiserver_ip is defined  %}
+IP.{{ counter["ip"] }} = {{ kube_apiserver_ip }}{{ increment(counter, 'ip') }}
+{% endif %}
+{% if loadbalancer_apiserver is defined and loadbalancer_apiserver.address is defined  %}
+IP.{{ counter["ip"] }} = {{ loadbalancer_apiserver.address }}{{ increment(counter, 'ip') }}
+{% endif %}
+{% if supplementary_addresses_in_ssl_keys is defined %}
+{% for addr in supplementary_addresses_in_ssl_keys %}
+{% if addr | ipaddr %}
+IP.{{ counter["ip"] }} = {{ addr }}{{ increment(counter, 'ip') }}
+{% else %}
+DNS.{{ counter["dns"] }} = {{ addr }}{{ increment(counter, 'dns') }}
+{% endif %}
+{% endfor %}
+{% endif %}
+IP.{{ counter["ip"] }} = 127.0.0.1

--- a/roles/kubernetes-recover/secrets/defaults/main.yml
+++ b/roles/kubernetes-recover/secrets/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+kube_cert_group: kube-cert
+kube_vault_mount_path: "/kube"

--- a/roles/kubernetes-recover/secrets/files/kube-gen-token.sh
+++ b/roles/kubernetes-recover/secrets/files/kube-gen-token.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Copyright 2015 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+token_dir=${TOKEN_DIR:-/var/srv/kubernetes}
+token_file="${token_dir}/known_tokens.csv"
+
+create_accounts=($@)
+
+if [ ! -e "${token_file}" ]; then
+  touch "${token_file}"
+fi
+
+for account in "${create_accounts[@]}"; do
+  if grep ",${account}," "${token_file}" ; then
+    continue
+  fi
+  token=$(dd if=/dev/urandom bs=128 count=1 2>/dev/null | base64 | tr -d "=+/" | dd bs=32 count=1 2>/dev/null)
+  echo "${token},${account},${account}" >> "${token_file}"
+  echo "${token}" > "${token_dir}/${account}.token"
+  echo "Added ${account}"
+done

--- a/roles/kubernetes-recover/secrets/files/make-ssl.sh
+++ b/roles/kubernetes-recover/secrets/files/make-ssl.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+
+# Author: Smana smainklh@gmail.com
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o pipefail
+
+usage()
+{
+    cat << EOF
+Create self signed certificates
+
+Usage : $(basename $0) -f <config> [-d <ssldir>]
+      -h | --help         : Show this message
+      -f | --config       : Openssl configuration file
+      -d | --ssldir       : Directory where the certificates will be installed
+
+      Environmental variables MASTERS and HOSTS should be set to generate keys
+      for each host.
+
+           ex :
+           MASTERS=node1 HOSTS="node1 node2" $(basename $0) -f openssl.conf -d /srv/ssl
+EOF
+}
+
+# Options parsing
+while (($#)); do
+    case "$1" in
+        -h | --help)   usage;   exit 0;;
+        -f | --config) CONFIG=${2}; shift 2;;
+        -d | --ssldir) SSLDIR="${2}"; shift 2;;
+        *)
+            usage
+            echo "ERROR : Unknown option"
+            exit 3
+        ;;
+    esac
+done
+
+if [ -z ${CONFIG} ]; then
+    echo "ERROR: the openssl configuration file is missing. option -f"
+    exit 1
+fi
+if [ -z ${SSLDIR} ]; then
+    SSLDIR="/etc/kubernetes/certs"
+fi
+
+tmpdir=$(mktemp -d /tmp/kubernetes_cacert.XXXXXX)
+trap 'rm -rf "${tmpdir}"' EXIT
+cd "${tmpdir}"
+
+mkdir -p "${SSLDIR}"
+
+# Root CA
+if [ -e "$SSLDIR/ca-key.pem" ]; then
+    # Reuse existing CA
+    cp $SSLDIR/{ca.pem,ca-key.pem} .
+else
+    openssl genrsa -out ca-key.pem 2048 > /dev/null 2>&1
+    openssl req -x509 -new -nodes -key ca-key.pem -days 36500 -out ca.pem -subj "/CN=kube-ca" > /dev/null 2>&1
+fi
+
+# Front proxy client CA
+if [ -e "$SSLDIR/front-proxy-ca-key.pem" ]; then
+    # Reuse existing front proxy CA
+    cp $SSLDIR/{front-proxy-ca.pem,front-proxy-ca-key.pem} .
+else
+    openssl genrsa -out front-proxy-ca-key.pem 2048 > /dev/null 2>&1
+    openssl req -x509 -new -nodes -key front-proxy-ca-key.pem -days 36500 -out front-proxy-ca.pem -subj "/CN=front-proxy-ca" > /dev/null 2>&1
+fi
+
+gen_key_and_cert() {
+    local name=$1
+    local subject=$2
+    openssl genrsa -out ${name}-key.pem 2048 > /dev/null 2>&1
+    openssl req -new -key ${name}-key.pem -out ${name}.csr -subj "${subject}" -config ${CONFIG} > /dev/null 2>&1
+    openssl x509 -req -in ${name}.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out ${name}.pem -days 36500 -extensions v3_req -extfile ${CONFIG} > /dev/null 2>&1
+}
+
+gen_key_and_cert_front_proxy() {
+    local name=$1
+    local subject=$2
+    openssl genrsa -out ${name}-key.pem 2048 > /dev/null 2>&1
+    openssl req -new -key ${name}-key.pem -out ${name}.csr -subj "${subject}" -config ${CONFIG} > /dev/null 2>&1
+    openssl x509 -req -in ${name}.csr -CA front-proxy-ca.pem -CAkey front-proxy-ca-key.pem -CAcreateserial -out ${name}.pem -days 36500 -extensions v3_req -extfile ${CONFIG} > /dev/null 2>&1
+}
+
+# Admins
+if [ -n "$MASTERS" ]; then
+
+    # service-account
+    # If --service-account-private-key-file was previously configured to use apiserver-key.pem then copy that to the new dedicated service-account signing key location to avoid disruptions
+    if [ -e "$SSLDIR/apiserver-key.pem" ] && ! [ -e "$SSLDIR/service-account-key.pem" ]; then
+       cp $SSLDIR/apiserver-key.pem $SSLDIR/service-account-key.pem
+    fi
+    # Generate dedicated service account signing key if one doesn't exist
+    if ! [ -e "$SSLDIR/apiserver-key.pem" ] && ! [ -e "$SSLDIR/service-account-key.pem" ]; then
+        openssl genrsa -out service-account-key.pem 2048 > /dev/null 2>&1
+    fi
+
+    # kube-apiserver
+    # Generate only if we don't have existing ca and apiserver certs
+    if ! [ -e "$SSLDIR/ca-key.pem" ] || ! [ -e "$SSLDIR/apiserver-key.pem" ]; then
+      gen_key_and_cert "apiserver" "/CN=kube-apiserver"
+      cat ca.pem >> apiserver.pem
+    fi
+    # If any host requires new certs, just regenerate scheduler and controller-manager master certs
+    # kube-scheduler
+    gen_key_and_cert "kube-scheduler" "/CN=system:kube-scheduler"
+    # kube-controller-manager
+    gen_key_and_cert "kube-controller-manager" "/CN=system:kube-controller-manager"
+    # metrics aggregator
+    gen_key_and_cert_front_proxy "front-proxy-client" "/CN=front-proxy-client"
+
+    for host in $MASTERS; do
+        cn="${host%%.*}"
+        # admin
+        gen_key_and_cert "admin-${host}" "/CN=kube-admin-${cn}/O=system:masters"
+    done
+fi
+
+# Nodes
+if [ -n "$HOSTS" ]; then
+    for host in $HOSTS; do
+        cn="${host%%.*}"
+        gen_key_and_cert "node-${host}" "/CN=system:node:${cn,,}/O=system:nodes"
+    done
+fi
+
+# system:node-proxier
+if [ -n "$HOSTS" ]; then
+    for host in $HOSTS; do
+        # kube-proxy
+        gen_key_and_cert "kube-proxy-${host}" "/CN=system:kube-proxy/O=system:node-proxier"
+    done
+fi
+
+# Install certs
+if [ -e "$SSLDIR/ca-key.pem" ]; then
+    # No pass existing CA
+    rm -f ca.pem ca-key.pem
+fi
+
+mv *.pem ${SSLDIR}/

--- a/roles/kubernetes-recover/secrets/handlers/main.yml
+++ b/roles/kubernetes-recover/secrets/handlers/main.yml
@@ -1,0 +1,15 @@
+---
+- name: set secret_changed
+  command: /bin/true
+  notify:
+    - set secret_changed to true
+    - clear kubeconfig for root user
+
+- name: set secret_changed to true
+  set_fact:
+    secret_changed: true
+
+- name: clear kubeconfig for root user
+  file:
+    path: /root/.kube/config
+    state: absent

--- a/roles/kubernetes-recover/secrets/meta/main.yml
+++ b/roles/kubernetes-recover/secrets/meta/main.yml
@@ -1,0 +1,2 @@
+---
+# NOTE: Dynamic task dependency on Vault Role if cert_management == "vault"

--- a/roles/kubernetes-recover/secrets/tasks/check-certs.yml
+++ b/roles/kubernetes-recover/secrets/tasks/check-certs.yml
@@ -1,0 +1,82 @@
+---
+- name: "Check_certs | check if the certs have already been generated on first master"
+  find:
+    paths: "{{ kube_cert_dir }}"
+    patterns: "*.pem"
+    get_checksum: true
+  delegate_to: "{{groups['kube-master'][0]}}"
+  register: kubecert_master
+  run_once: true
+
+- name: "Check_certs | Set default value for 'sync_certs', 'gen_certs', and 'secret_changed'  to false"
+  set_fact:
+    sync_certs: false
+    gen_certs: false
+    secret_changed: false
+
+- name: "Check_certs | Set 'gen_certs' to true"
+  set_fact:
+    gen_certs: true
+  when: "not item in kubecert_master.files|map(attribute='path') | list"
+  run_once: true
+  with_items: >-
+       ['{{ kube_cert_dir }}/ca.pem',
+       '{{ kube_cert_dir }}/apiserver.pem',
+       '{{ kube_cert_dir }}/apiserver-key.pem',
+       '{{ kube_cert_dir }}/kube-scheduler.pem',
+       '{{ kube_cert_dir }}/kube-scheduler-key.pem',
+       '{{ kube_cert_dir }}/kube-controller-manager.pem',
+       '{{ kube_cert_dir }}/kube-controller-manager-key.pem',
+       '{{ kube_cert_dir }}/front-proxy-ca.pem',
+       '{{ kube_cert_dir }}/front-proxy-ca-key.pem',
+       '{{ kube_cert_dir }}/front-proxy-client.pem',
+       '{{ kube_cert_dir }}/front-proxy-client-key.pem',
+       '{{ kube_cert_dir }}/service-account-key.pem',
+       {% for host in groups['kube-master'] %}
+       '{{ kube_cert_dir }}/admin-{{ host }}.pem',
+       '{{ kube_cert_dir }}/admin-{{ host }}-key.pem'
+       {% if not loop.last %}{{','}}{% endif %}
+       {% endfor %},
+       {% for host in groups['k8s-cluster'] %}
+       '{{ kube_cert_dir }}/node-{{ host }}.pem',
+       '{{ kube_cert_dir }}/node-{{ host }}-key.pem',
+       '{{ kube_cert_dir }}/kube-proxy-{{ host }}.pem',
+       '{{ kube_cert_dir }}/kube-proxy-{{ host }}-key.pem'
+       {% if not loop.last %}{{','}}{% endif %}
+       {% endfor %}]
+
+- name: "Check_certs | Set 'gen_master_certs' to true"
+  set_fact:
+    gen_master_certs: |-
+      {%- set gen = False -%}
+      {% set existing_certs = kubecert_master.files|map(attribute='path')|list|sort %}
+      {% for cert in ['apiserver.pem', 'apiserver-key.pem',
+                      'kube-scheduler.pem','kube-scheduler-key.pem',
+                      'kube-controller-manager.pem','kube-controller-manager-key.pem',
+                      'front-proxy-ca.pem','front-proxy-ca-key.pem',
+                      'front-proxy-client.pem','front-proxy-client-key.pem',
+                      'service-account-key.pem'] -%}
+        {% set cert_file = "%s/%s.pem"|format(kube_cert_dir, cert) %}
+        {% if not cert_file in existing_certs -%}
+        {%- set gen = True -%}
+        {% endif -%}
+      {% endfor %}
+      {{ gen }}
+  run_once: true
+
+- name: "Check_certs | Set 'gen_node_certs' to true"
+  set_fact:
+    gen_node_certs: |-
+      {
+      {% set existing_certs = kubecert_master.files|map(attribute='path')|list|sort %}
+      {% for host in groups['k8s-cluster'] -%}
+        {% set host_cert = "%s/node-%s-key.pem"|format(kube_cert_dir, host) %}
+        {% set kube_proxy_cert = "%s/kube-proxy-%s-key.pem"|format(kube_cert_dir, host) %}
+        {% if host_cert in existing_certs and kube_proxy_cert in existing_certs -%}
+        "{{ host }}": False,
+        {% else -%}
+        "{{ host }}": True,
+        {% endif -%}
+      {% endfor %}
+      }
+  run_once: true

--- a/roles/kubernetes-recover/secrets/tasks/check-tokens.yml
+++ b/roles/kubernetes-recover/secrets/tasks/check-tokens.yml
@@ -1,0 +1,36 @@
+---
+- name: "Check_tokens | check if the tokens have already been generated on first master"
+  stat:
+    path: "{{ kube_token_dir }}/known_tokens.csv"
+  delegate_to: "{{groups['kube-master'][0]}}"
+  register: known_tokens_master
+  run_once: true
+
+- name: "Check_tokens | Set default value for 'sync_tokens' and 'gen_tokens' to false"
+  set_fact:
+    sync_tokens: false
+    gen_tokens: false
+
+- name: "Check_tokens | Set 'sync_tokens' and 'gen_tokens' to true"
+  set_fact:
+    gen_tokens: true
+  when: not known_tokens_master.stat.exists and kube_token_auth|default(true)
+  run_once: true
+
+- name: "Check tokens | check if a cert already exists"
+  stat:
+    path: "{{ kube_token_dir }}/known_tokens.csv"
+  register: known_tokens
+
+- name: "Check_tokens | Set 'sync_tokens' to true"
+  set_fact:
+    sync_tokens: true
+  when: >-
+      {%- set tokens = {'sync': False} -%}
+      {%- for server in groups['kube-master'] | intersect(ansible_play_batch)
+         if (not hostvars[server].known_tokens.stat.exists) or
+         (hostvars[server].known_tokens.stat.checksum|default('') != known_tokens_master.stat.checksum|default('')) -%}
+         {%- set _ = tokens.update({'sync': True}) -%}
+      {%- endfor -%}
+      {{ tokens.sync }}
+  run_once: true

--- a/roles/kubernetes-recover/secrets/tasks/gen_certs_script.yml
+++ b/roles/kubernetes-recover/secrets/tasks/gen_certs_script.yml
@@ -1,0 +1,217 @@
+---
+- name: "Gen_certs | Create kubernetes config directory (on {{groups['kube-master'][0]}})"
+  file:
+    path: "{{ kube_config_dir }}"
+    state: directory
+    owner: kube
+  run_once: yes
+  delegate_to: "{{groups['kube-master'][0]}}"
+  when: gen_certs|default(false)
+  tags:
+    - kubelet
+    - k8s-secrets
+    - kube-controller-manager
+    - kube-apiserver
+    - apps
+    - network
+    - master
+    - node
+
+- name: "Gen_certs | Create kubernetes script directory (on {{groups['kube-master'][0]}})"
+  file:
+    path: "{{ kube_script_dir }}"
+    state: directory
+    owner: kube
+  run_once: yes
+  delegate_to: "{{groups['kube-master'][0]}}"
+  when: gen_certs|default(false)
+  tags:
+    - k8s-secrets
+
+- name: Gen_certs | write openssl config
+  template:
+    src: "openssl.conf.j2"
+    dest: "{{ kube_config_dir }}/openssl.conf"
+  run_once: yes
+  delegate_to: "{{groups['kube-master'][0]}}"
+  when: gen_certs|default(false)
+
+- name: Gen_certs | copy certs generation script
+  copy:
+    src: "make-ssl.sh"
+    dest: "{{ kube_script_dir }}/make-ssl.sh"
+    mode: 0700
+  run_once: yes
+  delegate_to: "{{groups['kube-master'][0]}}"
+  when: gen_certs|default(false)
+
+- name: Gen_certs | run cert generation script
+  command: "{{ kube_script_dir }}/make-ssl.sh -f {{ kube_config_dir }}/openssl.conf -d {{ kube_cert_dir }}"
+  environment:
+    - MASTERS: "{% for m in groups['kube-master'] %}
+                  {% if gen_master_certs|default(false) %}
+                    {{ m }}
+                  {% endif %}
+                {% endfor %}"
+    - HOSTS: "{% for h in groups['k8s-cluster'] %}
+                {% if gen_node_certs[h]|default(true) %}
+                    {{ h }}
+                {% endif %}
+              {% endfor %}"
+  run_once: yes
+  delegate_to: "{{groups['kube-master'][0]}}"
+  when: gen_certs|default(false)
+  notify: set secret_changed
+
+- set_fact:
+    all_master_certs: "['ca-key.pem',
+                       'apiserver.pem',
+                       'apiserver-key.pem',
+                       'kube-scheduler.pem',
+                       'kube-scheduler-key.pem',
+                       'kube-controller-manager.pem',
+                       'kube-controller-manager-key.pem',
+                       'front-proxy-ca.pem',
+                       'front-proxy-ca-key.pem',
+                       'front-proxy-client.pem',
+                       'front-proxy-client-key.pem',
+                       'service-account-key.pem',
+                       {% for node in groups['kube-master'] %}
+                       'admin-{{ node }}.pem',
+                       'admin-{{ node }}-key.pem',
+                      {% endfor %}]"
+    my_master_certs: ['ca-key.pem',
+                      'admin-{{ inventory_hostname }}.pem',
+                      'admin-{{ inventory_hostname }}-key.pem',
+                      'apiserver.pem',
+                      'apiserver-key.pem',
+                      'front-proxy-ca.pem',
+                      'front-proxy-ca-key.pem',
+                      'front-proxy-client.pem',
+                      'front-proxy-client-key.pem',
+                      'service-account-key.pem',
+                      'kube-scheduler.pem',
+                      'kube-scheduler-key.pem',
+                      'kube-controller-manager.pem',
+                      'kube-controller-manager-key.pem']
+    all_node_certs: "['ca.pem',
+                    {% for node in groups['k8s-cluster'] %}
+                    'node-{{ node }}.pem',
+                    'node-{{ node }}-key.pem',
+                    'kube-proxy-{{ node }}.pem',
+                    'kube-proxy-{{ node }}-key.pem',
+                    {% endfor %}]"
+    my_node_certs: ['ca.pem',
+                    'node-{{ inventory_hostname }}.pem',
+                    'node-{{ inventory_hostname }}-key.pem',
+                    'kube-proxy-{{ inventory_hostname }}.pem',
+                    'kube-proxy-{{ inventory_hostname }}-key.pem']
+  tags:
+    - facts
+
+- name: "Check certs | check if a cert already exists on node"
+  find:
+    paths: "{{ kube_cert_dir }}"
+    patterns: "*.pem"
+    get_checksum: true
+  register: kubecert_node
+  when: inventory_hostname != groups['kube-master'][0]
+
+- name: "Check_certs | Set 'sync_certs' to true on masters"
+  set_fact:
+    sync_certs: true
+  when: inventory_hostname in groups['kube-master'] and
+        inventory_hostname != groups['kube-master'][0] and
+        (not item in kubecert_node.files | map(attribute='path') | map("basename") | list or
+        kubecert_node.files | selectattr("path", "equalto", "{{ kube_cert_dir }}/{{ item }}") | map(attribute="checksum")|first|default('') != kubecert_master.files | selectattr("path", "equalto", "{{ kube_cert_dir }}/{{ item }}") | map(attribute="checksum")|first|default(''))
+  with_items:
+    - "{{ my_master_certs + all_node_certs }}"
+
+- name: "Check_certs | Set 'sync_certs' to true on nodes"
+  set_fact:
+    sync_certs: true
+  when: inventory_hostname in groups['kube-node'] and
+        inventory_hostname != groups['kube-master'][0] and
+        (not item in kubecert_node.files | map(attribute='path') | map("basename") | list or
+        kubecert_node.files | selectattr("path", "equalto", "{{ kube_cert_dir }}/{{ item }}") | map(attribute="checksum")|first|default('') != kubecert_master.files | selectattr("path", "equalto", "{{ kube_cert_dir }}/{{ item }}") | map(attribute="checksum")|first|default(''))
+  with_items:
+    - "{{ my_node_certs }}"
+
+- name: Gen_certs | Gather master certs
+  shell: "tar cfz - -C {{ kube_cert_dir }} -T /dev/stdin <<< {{ my_master_certs|join(' ') }} {{ all_node_certs|join(' ') }} | base64 --wrap=0"
+  args:
+    executable: /bin/bash
+  no_log: true
+  register: master_cert_data
+  check_mode: no
+  delegate_to: "{{groups['kube-master'][0]}}"
+  when: inventory_hostname in groups['kube-master'] and sync_certs|default(false) and
+        inventory_hostname != groups['kube-master'][0]
+
+- name: Gen_certs | Gather node certs
+  shell: "tar cfz - -C {{ kube_cert_dir }} -T /dev/stdin <<< {{ my_node_certs|join(' ') }} | base64 --wrap=0"
+  args:
+    executable: /bin/bash
+  no_log: true
+  register: node_cert_data
+  check_mode: no
+  delegate_to: "{{groups['kube-master'][0]}}"
+  when: inventory_hostname in groups['kube-node'] and
+        sync_certs|default(false) and
+        inventory_hostname != groups['kube-master'][0]
+
+# NOTE(mattymo): Use temporary file to copy master certs because we have a ~200k
+# char limit when using shell command
+
+# FIXME(mattymo): Use tempfile module in ansible 2.3
+- name: Gen_certs | Prepare tempfile for unpacking certs on masters
+  command: mktemp /tmp/certsXXXXX.tar.gz
+  register: cert_tempfile
+  when: inventory_hostname in groups['kube-master'] and sync_certs|default(false) and
+        inventory_hostname != groups['kube-master'][0]
+
+- name: Gen_certs | Write master certs to tempfile
+  copy:
+    content: "{{master_cert_data.stdout}}"
+    dest: "{{cert_tempfile.stdout}}"
+    owner: root
+    mode: "0600"
+  when: inventory_hostname in groups['kube-master'] and sync_certs|default(false) and
+        inventory_hostname != groups['kube-master'][0]
+
+- name: Gen_certs | Unpack certs on masters
+  shell: "base64 -d < {{ cert_tempfile.stdout }} | tar xz -C {{ kube_cert_dir }}"
+  no_log: true
+  changed_when: false
+  check_mode: no
+  when: inventory_hostname in groups['kube-master'] and sync_certs|default(false) and
+        inventory_hostname != groups['kube-master'][0]
+  notify: set secret_changed
+
+- name: Gen_certs | Cleanup tempfile on masters
+  file:
+    path: "{{cert_tempfile.stdout}}"
+    state: absent
+  when: inventory_hostname in groups['kube-master'] and sync_certs|default(false) and
+        inventory_hostname != groups['kube-master'][0]
+
+- name: Gen_certs | Copy certs on nodes
+  shell: "base64 -d <<< '{{node_cert_data.stdout|quote}}' | tar xz -C {{ kube_cert_dir }}"
+  args:
+    executable: /bin/bash
+  no_log: true
+  changed_when: false
+  check_mode: no
+  when: inventory_hostname in groups['kube-node'] and
+        sync_certs|default(false) and
+        inventory_hostname != groups['kube-master'][0]
+  notify: set secret_changed
+
+- name: Gen_certs | check certificate permissions
+  file:
+    path: "{{ kube_cert_dir }}"
+    group: "{{ kube_cert_group }}"
+    state: directory
+    owner: kube
+    mode: "u=rwX,g-rwx,o-rwx"
+    recurse: yes

--- a/roles/kubernetes-recover/secrets/tasks/gen_certs_vault.yml
+++ b/roles/kubernetes-recover/secrets/tasks/gen_certs_vault.yml
@@ -1,0 +1,133 @@
+---
+- import_tasks: sync_kube_master_certs.yml
+  when: inventory_hostname in groups['kube-master']
+
+- import_tasks: sync_kube_node_certs.yml
+  when: inventory_hostname in groups['k8s-cluster']
+
+# Issue admin certs to kube-master hosts
+- include_tasks: ../../../vault/tasks/shared/issue_cert.yml
+  vars:
+    issue_cert_common_name: "admin"
+    issue_cert_copy_ca: "{{ item == kube_admin_certs_needed|first }}"
+    issue_cert_file_group: "{{ kube_cert_group }}"
+    issue_cert_file_owner: kube
+    issue_cert_hosts: "{{ groups['kube-master'] }}"
+    issue_cert_path: "{{ item }}"
+    issue_cert_role: kube-master
+    issue_cert_url: "{{ hostvars[groups.vault|first]['vault_leader_url'] }}"
+    issue_cert_mount_path: "{{ kube_vault_mount_path }}"
+  with_items: "{{ kube_admin_certs_needed|d([]) }}"
+  when: inventory_hostname in groups['kube-master']
+
+- name: gen_certs_vault | Set fact about certificate alt names
+  set_fact:
+    kube_cert_alt_names: >-
+      {{
+      groups['kube-master'] +
+      ['kubernetes.default.svc.cluster.local', 'kubernetes.default.svc', 'kubernetes.default', 'kubernetes'] +
+      ['localhost']
+      }}
+  run_once: true
+
+- name: gen_certs_vault | Add external load balancer domain name to certificate alt names
+  set_fact:
+    kube_cert_alt_names: "{{ kube_cert_alt_names + [apiserver_loadbalancer_domain_name] }}"
+  when: loadbalancer_apiserver is defined
+  run_once: true
+
+# Issue master components certs to kube-master hosts
+- include_tasks: ../../../vault/tasks/shared/issue_cert.yml
+  vars:
+    issue_cert_common_name: "kubernetes"
+    issue_cert_alt_names: "{{ kube_cert_alt_names }}"
+    issue_cert_file_group: "{{ kube_cert_group }}"
+    issue_cert_file_owner: kube
+    issue_cert_hosts: "{{ groups['kube-master'] }}"
+    issue_cert_ip_sans: >-
+        [
+        {%- for host in groups['kube-master']  -%}
+        "{{ hostvars[host]['ansible_default_ipv4']['address'] }}",
+        {%- if hostvars[host]['ip'] is defined -%}
+        "{{ hostvars[host]['ip'] }}",
+        {%- endif -%}
+        {%- endfor -%}
+        {%- if supplementary_addresses_in_ssl_keys is defined -%}
+        {%- for ip_item in supplementary_addresses_in_ssl_keys -%}
+        "{{ ip_item }}",
+        {%- endfor -%}
+        {%- endif -%}
+        "127.0.0.1","::1","{{ kube_apiserver_ip }}"
+        ]
+    issue_cert_path: "{{ item }}"
+    issue_cert_role: kube-master
+    issue_cert_url: "{{ hostvars[groups.vault|first]['vault_leader_url'] }}"
+    issue_cert_mount_path: "{{ kube_vault_mount_path }}"
+  with_items: "{{ kube_master_components_certs_needed|d([]) }}"
+  when: inventory_hostname in groups['kube-master']
+  notify: set secret_changed
+
+# Issue node certs to k8s-cluster nodes
+- include_tasks: ../../../vault/tasks/shared/issue_cert.yml
+  vars:
+    # Need to strip out the 'node-' prefix from the cert name so it can be used
+    # with the node authorization plugin ( CN matches kubelet node name )
+    issue_cert_common_name: "system:node:{{ item.rsplit('/', 1)[1].rsplit('.', 1)[0] | regex_replace('^node-', '') }}"
+    issue_cert_copy_ca: "{{ item == kube_node_certs_needed|first }}"
+    issue_cert_file_group: "{{ kube_cert_group }}"
+    issue_cert_file_owner: kube
+    issue_cert_hosts: "{{ groups['k8s-cluster'] }}"
+    issue_cert_path: "{{ item }}"
+    issue_cert_role: kube-node
+    issue_cert_url: "{{ hostvars[groups.vault|first]['vault_leader_url'] }}"
+    issue_cert_mount_path: "{{ kube_vault_mount_path }}"
+  with_items: "{{ kube_node_certs_needed|d([]) }}"
+  when: inventory_hostname in groups['k8s-cluster']
+
+# Issue proxy certs to k8s-cluster nodes
+- include_tasks: ../../../vault/tasks/shared/issue_cert.yml
+  vars:
+    issue_cert_common_name: "system:kube-proxy"
+    issue_cert_copy_ca: "{{ item == kube_proxy_certs_needed|first }}"
+    issue_cert_file_group: "{{ kube_cert_group }}"
+    issue_cert_file_owner: kube
+    issue_cert_hosts: "{{ groups['k8s-cluster'] }}"
+    issue_cert_path: "{{ item }}"
+    issue_cert_role: kube-proxy
+    issue_cert_url: "{{ hostvars[groups.vault|first]['vault_leader_url'] }}"
+    issue_cert_mount_path: "{{ kube_vault_mount_path }}"
+  with_items: "{{ kube_proxy_certs_needed|d([]) }}"
+  when: inventory_hostname in groups['k8s-cluster']
+
+# Issue front proxy cert to kube-master hosts
+- include_tasks: ../../../vault/tasks/shared/issue_cert.yml
+  vars:
+    issue_cert_common_name: "front-proxy-client"
+    issue_cert_copy_ca: "{{ item == kube_front_proxy_clients_certs_needed|first }}"
+    issue_cert_ca_filename: front-proxy-ca.pem
+    issue_cert_alt_names: "{{ kube_cert_alt_names }}"
+    issue_cert_file_group: "{{ kube_cert_group }}"
+    issue_cert_file_owner: kube
+    issue_cert_hosts: "{{ groups['kube-master'] }}"
+    issue_cert_ip_sans: >-
+        [
+        {%- for host in groups['kube-master']  -%}
+        "{{ hostvars[host]['ansible_default_ipv4']['address'] }}",
+        {%- if hostvars[host]['ip'] is defined -%}
+        "{{ hostvars[host]['ip'] }}",
+        {%- endif -%}
+        {%- endfor -%}
+        {%- if supplementary_addresses_in_ssl_keys is defined -%}
+        {%- for ip_item in supplementary_addresses_in_ssl_keys -%}
+        "{{ ip_item }}",
+        {%- endfor -%}
+        {%- endif -%}
+        "127.0.0.1","::1","{{ kube_apiserver_ip }}"
+        ]
+    issue_cert_path: "{{ item }}"
+    issue_cert_role: front-proxy-client
+    issue_cert_url: "{{ hostvars[groups.vault|first]['vault_leader_url'] }}"
+    issue_cert_mount_path: "{{ kube_vault_mount_path }}"
+  with_items: "{{ kube_front_proxy_clients_certs_needed|d([]) }}"
+  when: inventory_hostname in groups['kube-master']
+  notify: set secret_changed

--- a/roles/kubernetes-recover/secrets/tasks/gen_tokens.yml
+++ b/roles/kubernetes-recover/secrets/tasks/gen_tokens.yml
@@ -1,0 +1,58 @@
+---
+- name: Gen_tokens | copy tokens generation script
+  copy:
+    src: "kube-gen-token.sh"
+    dest: "{{ kube_script_dir }}/kube-gen-token.sh"
+    mode: 0700
+  run_once: yes
+  delegate_to: "{{groups['kube-master'][0]}}"
+  when: gen_tokens|default(false)
+
+- name: Gen_tokens | generate tokens for master components
+  command: "{{ kube_script_dir }}/kube-gen-token.sh {{ item[0] }}-{{ item[1] }}"
+  environment:
+    TOKEN_DIR: "{{ kube_token_dir }}"
+  with_nested:
+    - [ "system:kubectl" ]
+    - "{{ groups['kube-master'] }}"
+  register: gentoken_master
+  changed_when: "'Added' in gentoken_master.stdout"
+  notify: set secret_changed
+  run_once: yes
+  delegate_to: "{{groups['kube-master'][0]}}"
+  when: gen_tokens|default(false)
+
+- name: Gen_tokens | generate tokens for node components
+  command: "{{ kube_script_dir }}/kube-gen-token.sh {{ item[0] }}-{{ item[1] }}"
+  environment:
+    TOKEN_DIR: "{{ kube_token_dir }}"
+  with_nested:
+    - [ 'system:kubelet' ]
+    - "{{ groups['kube-node'] }}"
+  register: gentoken_node
+  changed_when: "'Added' in gentoken_node.stdout"
+  notify: set secret_changed
+  run_once: yes
+  delegate_to: "{{groups['kube-master'][0]}}"
+  when: gen_tokens|default(false)
+
+- name: Gen_tokens | Get list of tokens from first master
+  shell: "(find {{ kube_token_dir }} -maxdepth 1 -type f)"
+  register: tokens_list
+  check_mode: no
+  delegate_to: "{{groups['kube-master'][0]}}"
+  run_once: true
+  when: sync_tokens|default(false)
+
+- name: Gen_tokens | Gather tokens
+  shell: "tar cfz - {{ tokens_list.stdout_lines | join(' ') }} | base64 --wrap=0"
+  register: tokens_data
+  check_mode: no
+  delegate_to: "{{groups['kube-master'][0]}}"
+  run_once: true
+  when: sync_tokens|default(false)
+
+- name: Gen_tokens | Copy tokens on masters
+  shell: "echo '{{ tokens_data.stdout|quote }}' | base64 -d | tar xz -C /"
+  when: inventory_hostname in groups['kube-master'] and sync_tokens|default(false) and
+        inventory_hostname != groups['kube-master'][0] and tokens_data.stdout != ''

--- a/roles/kubernetes-recover/secrets/tasks/main.yml
+++ b/roles/kubernetes-recover/secrets/tasks/main.yml
@@ -1,0 +1,114 @@
+---
+- import_tasks: check-certs.yml
+  tags:
+    - k8s-secrets
+    - facts
+
+- import_tasks: check-tokens.yml
+  tags:
+    - k8s-secrets
+    - facts
+
+- name: Make sure the certificate directory exits
+  file:
+    path: "{{ kube_cert_dir }}"
+    state: directory
+    mode: o-rwx
+    group: "{{ kube_cert_group }}"
+
+- name: Make sure the tokens directory exits
+  file:
+    path: "{{ kube_token_dir }}"
+    state: directory
+    mode: o-rwx
+    group: "{{ kube_cert_group }}"
+
+#
+# The following directory creates make sure that the directories
+# exist on the first master for cases where the first master isn't
+# being run.
+#
+- name: "Gen_certs | Create kubernetes config directory (on {{groups['kube-master'][0]}})"
+  file:
+    path: "{{ kube_config_dir }}"
+    state: directory
+    owner: kube
+  run_once: yes
+  delegate_to: "{{groups['kube-master'][0]}}"
+  when: gen_certs|default(false) or gen_tokens|default(false)
+  tags:
+    - kubelet
+    - k8s-secrets
+    - kube-controller-manager
+    - kube-apiserver
+    - apps
+    - network
+    - master
+    - node
+
+- name: "Gen_certs | Create kubernetes script directory (on {{groups['kube-master'][0]}})"
+  file:
+    path: "{{ kube_script_dir }}"
+    state: directory
+    owner: kube
+  run_once: yes
+  delegate_to: "{{groups['kube-master'][0]}}"
+  when: gen_certs|default(false) or gen_tokens|default(false)
+  tags:
+    - k8s-secrets
+
+- name: "Get_tokens | Make sure the tokens directory exits (on {{groups['kube-master'][0]}})"
+  file:
+    path: "{{ kube_token_dir }}"
+    state: directory
+    mode: o-rwx
+    group: "{{ kube_cert_group }}"
+  run_once: yes
+  delegate_to: "{{groups['kube-master'][0]}}"
+  when: gen_tokens|default(false)
+
+- include_tasks: "gen_certs_{{ cert_management }}.yml"
+  tags:
+    - k8s-secrets
+
+- import_tasks: upd_ca_trust.yml
+  tags:
+    - k8s-secrets
+
+- name: "Gen_certs | Get certificate serials on kube masters"
+  shell: "openssl x509 -in {{ kube_cert_dir }}/{{ item }} -noout -serial | cut -d= -f2"
+  register: "master_certificate_serials"
+  changed_when: false
+  with_items:
+    - "admin-{{ inventory_hostname }}.pem"
+    - "apiserver.pem"
+    - "kube-controller-manager.pem"
+    - "kube-scheduler.pem"
+  when: inventory_hostname in groups['kube-master']
+
+- name: "Gen_certs | set kube master certificate serial facts"
+  set_fact:
+    etcd_admin_cert_serial: "{{ master_certificate_serials.results[0].stdout|default() }}"
+    apiserver_cert_serial: "{{ master_certificate_serials.results[1].stdout|default() }}"
+    controller_manager_cert_serial: "{{ master_certificate_serials.results[2].stdout|default() }}"
+    scheduler_cert_serial: "{{ master_certificate_serials.results[3].stdout|default() }}"
+  when: inventory_hostname in groups['kube-master']
+
+- name: "Gen_certs | Get certificate serials on kube nodes"
+  shell: "openssl x509 -in {{ kube_cert_dir }}/{{ item }} -noout -serial | cut -d= -f2"
+  register: "node_certificate_serials"
+  changed_when: false
+  with_items:
+    - "node-{{ inventory_hostname }}.pem"
+    - "kube-proxy-{{ inventory_hostname }}.pem"
+  when: inventory_hostname in groups['k8s-cluster']
+
+- name: "Gen_certs | set kube node certificate serial facts"
+  set_fact:
+    kubelet_cert_serial: "{{ node_certificate_serials.results[0].stdout|default() }}"
+    kube_proxy_cert_serial: "{{ node_certificate_serials.results[1].stdout|default() }}"
+  when: inventory_hostname in groups['k8s-cluster']
+
+- import_tasks: gen_tokens.yml
+  tags:
+    - k8s-secrets

--- a/roles/kubernetes-recover/secrets/tasks/sync_kube_master_certs.yml
+++ b/roles/kubernetes-recover/secrets/tasks/sync_kube_master_certs.yml
@@ -1,0 +1,89 @@
+---
+
+- name: sync_kube_master_certs | Create list of needed kube admin certs
+  set_fact:
+    kube_admin_cert_list: "{{ kube_admin_cert_list|d([]) + ['admin-' + inventory_hostname + '.pem'] }}"
+
+- include_tasks: ../../../vault/tasks/shared/sync_file.yml
+  vars:
+    sync_file: "{{ item }}"
+    sync_file_dir: "{{ kube_cert_dir }}"
+    sync_file_group: "{{ kube_cert_group }}"
+    sync_file_hosts: [ "{{ inventory_hostname }}" ]
+    sync_file_is_cert: true
+    sync_file_owner: kube
+  with_items: "{{ kube_admin_cert_list|d([]) }}"
+
+- name: sync_kube_master_certs | Set facts for kube admin sync_file results
+  set_fact:
+    kube_admin_certs_needed: "{{ kube_admin_certs_needed|default([]) + [item.path] }}"
+  with_items: "{{ sync_file_results|d([]) }}"
+  when: item.no_srcs|bool
+
+- name: sync_kube_master_certs | Unset sync_file_results after kube admin certs
+  set_fact:
+    sync_file_results: []
+
+- include_tasks: ../../../vault/tasks/shared/sync_file.yml
+  vars:
+    sync_file: "{{ item }}"
+    sync_file_dir: "{{ kube_cert_dir }}"
+    sync_file_group: "{{ kube_cert_group }}"
+    sync_file_hosts: "{{ groups['kube-master'] }}"
+    sync_file_is_cert: true
+    sync_file_owner: kube
+  with_items: ["apiserver.pem", "kube-scheduler.pem", "kube-controller-manager.pem", "service-account.pem"]
+
+- name: sync_kube_master_certs | Set facts for kube master components sync_file results
+  set_fact:
+    kube_master_components_certs_needed: "{{ kube_master_components_certs_needed|d([]) + [item.path] }}"
+  with_items: "{{ sync_file_results|d([]) }}"
+  when: item.no_srcs|bool
+
+- name: sync_kube_master_certs | Unset sync_file_results after kube master components cert
+  set_fact:
+    sync_file_results: []
+
+- include_tasks: ../../../vault/tasks/shared/sync_file.yml
+  vars:
+    sync_file: front-proxy-ca.pem
+    sync_file_dir: "{{ kube_cert_dir }}"
+    sync_file_group: "{{ kube_cert_group }}"
+    sync_file_hosts: "{{ groups['kube-master'] }}"
+    sync_file_owner: kube
+
+- name: sync_kube_master_certs | Unset sync_file_results after front-proxy-ca.pem
+  set_fact:
+    sync_file_results: []
+
+- include_tasks: ../../../vault/tasks/shared/sync_file.yml
+  vars:
+    sync_file: "{{ item }}"
+    sync_file_dir: "{{ kube_cert_dir }}"
+    sync_file_group: "{{ kube_cert_group }}"
+    sync_file_hosts: "{{ groups['kube-master'] }}"
+    sync_file_is_cert: true
+    sync_file_owner: kube
+  with_items: ["front-proxy-client.pem"]
+
+- name: sync_kube_master_certs | Set facts for front-proxy-client certs sync_file results
+  set_fact:
+    kube_front_proxy_clients_certs_needed: "{{ kube_front_proxy_clients_certs_needed|d([]) + [item.path] }}"
+  with_items: "{{ sync_file_results|d([]) }}"
+  when: item.no_srcs|bool
+
+- name: sync_kube_master_certs | Unset sync_file_results after front-proxy-client sync
+  set_fact:
+    sync_file_results: []
+
+- include_tasks: ../../../vault/tasks/shared/sync_file.yml
+  vars:
+    sync_file: ca.pem
+    sync_file_dir: "{{ kube_cert_dir }}"
+    sync_file_group: "{{ kube_cert_group }}"
+    sync_file_hosts: "{{ groups['kube-master'] }}"
+    sync_file_owner: kube
+
+- name: sync_kube_master_certs | Unset sync_file_results after ca.pem
+  set_fact:
+    sync_file_results: []

--- a/roles/kubernetes-recover/secrets/tasks/sync_kube_node_certs.yml
+++ b/roles/kubernetes-recover/secrets/tasks/sync_kube_node_certs.yml
@@ -1,0 +1,60 @@
+---
+
+- name: sync_kube_node_certs | Create list of needed certs
+  set_fact:
+    kube_node_cert_list: "{{ kube_node_cert_list|default([]) + ['node-' + inventory_hostname + '.pem'] }}"
+
+- include_tasks: ../../../vault/tasks/shared/sync_file.yml
+  vars:
+    sync_file: "{{ item }}"
+    sync_file_dir: "{{ kube_cert_dir }}"
+    sync_file_group: "{{ kube_cert_group }}"
+    sync_file_hosts: [ "{{ inventory_hostname }}" ]
+    sync_file_is_cert: true
+    sync_file_owner: kube
+  with_items: "{{ kube_node_cert_list|default([]) }}"
+
+- name: sync_kube_node_certs | Set facts for kube-master sync_file results
+  set_fact:
+    kube_node_certs_needed: "{{ kube_node_certs_needed|default([]) + [item.path] }}"
+  with_items: "{{ sync_file_results|d([]) }}"
+  when: item.no_srcs|bool
+
+- name: sync_kube_node_certs | Unset sync_file_results after kube node certs
+  set_fact:
+    sync_file_results: []
+
+- include_tasks: ../../../vault/tasks/shared/sync_file.yml
+  vars:
+    sync_file: ca.pem
+    sync_file_dir: "{{ kube_cert_dir }}"
+    sync_file_group: "{{ kube_cert_group }}"
+    sync_file_hosts: "{{ groups['k8s-cluster'] }}"
+    sync_file_owner: kube
+
+- name: sync_kube_node_certs | Unset sync_file_results after ca.pem
+  set_fact:
+    sync_file_results: []
+
+- name: sync_kube_node_certs | Create list of needed kube-proxy certs
+  set_fact:
+    kube_proxy_cert_list: "{{ kube_proxy_cert_list|default([]) + ['kube-proxy-' + inventory_hostname + '.pem'] }}"
+
+- include_tasks: ../../../vault/tasks/shared/sync_file.yml
+  vars:
+    sync_file: "{{ item }}"
+    sync_file_dir: "{{ kube_cert_dir }}"
+    sync_file_group: "{{ kube_cert_group }}"
+    sync_file_hosts: [ "{{ inventory_hostname }}" ]
+    sync_file_owner: kube
+  with_items: "{{ kube_proxy_cert_list|default([]) }}"
+
+- name: sync_kube_node_certs | Set facts for kube-proxy sync_file results
+  set_fact:
+    kube_proxy_certs_needed: "{{ kube_proxy_certs_needed|default([]) + [item.path] }}"
+  with_items: "{{ sync_file_results|d([]) }}"
+  when: item.no_srcs|bool
+
+- name: sync_kube_node_certs | Unset sync_file_results after kube proxy certs
+  set_fact:
+    sync_file_results: []

--- a/roles/kubernetes-recover/secrets/tasks/upd_ca_trust.yml
+++ b/roles/kubernetes-recover/secrets/tasks/upd_ca_trust.yml
@@ -1,0 +1,30 @@
+---
+- name: Gen_certs | target ca-certificates path
+  set_fact:
+    ca_cert_path: |-
+      {% if ansible_os_family == "Debian" -%}
+      /usr/local/share/ca-certificates/kube-ca.crt
+      {%- elif ansible_os_family == "RedHat" -%}
+      /etc/pki/ca-trust/source/anchors/kube-ca.crt
+      {%- elif ansible_os_family in ["CoreOS", "Container Linux by CoreOS"] -%}
+      /etc/ssl/certs/kube-ca.pem
+      {%- elif ansible_os_family == "Suse" -%}
+      /etc/pki/trust/anchors/kube-ca.pem
+      {%- endif %}
+  tags:
+    - facts
+
+- name: Gen_certs | add CA to trusted CA dir
+  copy:
+    src: "{{ kube_cert_dir }}/ca.pem"
+    dest: "{{ ca_cert_path }}"
+    remote_src: true
+  register: kube_ca_cert
+
+- name: Gen_certs | update ca-certificates (Debian/Ubuntu/SUSE/Container Linux by CoreOS)
+  command: update-ca-certificates
+  when: kube_ca_cert.changed and ansible_os_family in ["Debian", "CoreOS", "Container Linux by CoreOS", "Suse"]
+
+- name: Gen_certs | update ca-certificates (RedHat)
+  command: update-ca-trust extract
+  when: kube_ca_cert.changed and ansible_os_family == "RedHat"

--- a/roles/kubernetes-recover/secrets/templates/openssl.conf.j2
+++ b/roles/kubernetes-recover/secrets/templates/openssl.conf.j2
@@ -1,0 +1,42 @@
+{% set counter = {'dns': 6,'ip': 1,} %}{% macro increment(dct, key, inc=1)%}{% if dct.update({key: dct[key] + inc}) %} {% endif %}{% endmacro %}[req]
+req_extensions = v3_req
+distinguished_name = req_distinguished_name
+[req_distinguished_name]
+[ v3_req ]
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+subjectAltName = @alt_names
+[alt_names]
+DNS.1 = kubernetes
+DNS.2 = kubernetes.default
+DNS.3 = kubernetes.default.svc
+DNS.4 = kubernetes.default.svc.{{ dns_domain }}
+DNS.5 = localhost
+{% for host in groups['kube-master'] %}
+DNS.{{ counter["dns"] }} = {{ host }}{{ increment(counter, 'dns') }}
+{% endfor %}
+{% if apiserver_loadbalancer_domain_name is defined  %}
+DNS.{{ counter["dns"] }} = {{ apiserver_loadbalancer_domain_name }}{{ increment(counter, 'dns') }}
+{% endif %}
+{% for host in groups['kube-master'] %}
+{% if hostvars[host]['access_ip'] is defined  %}
+IP.{{ counter["ip"] }} = {{ hostvars[host]['access_ip'] }}{{ increment(counter, 'ip') }}
+{% endif %}
+IP.{{ counter["ip"] }} = {{ hostvars[host]['ip'] | default(hostvars[host]['ansible_default_ipv4']['address']) }}{{ increment(counter, 'ip') }}
+{% endfor %}
+{% if kube_apiserver_ip is defined  %}
+IP.{{ counter["ip"] }} = {{ kube_apiserver_ip }}{{ increment(counter, 'ip') }}
+{% endif %}
+{% if loadbalancer_apiserver is defined and loadbalancer_apiserver.address is defined  %}
+IP.{{ counter["ip"] }} = {{ loadbalancer_apiserver.address }}{{ increment(counter, 'ip') }}
+{% endif %}
+{% if supplementary_addresses_in_ssl_keys is defined %}
+{% for addr in supplementary_addresses_in_ssl_keys %}
+{% if addr | ipaddr %}
+IP.{{ counter["ip"] }} = {{ addr }}{{ increment(counter, 'ip') }}
+{% else %}
+DNS.{{ counter["dns"] }} = {{ addr }}{{ increment(counter, 'dns') }}
+{% endif %}
+{% endfor %}
+{% endif %}
+IP.{{ counter["ip"] }} = 127.0.0.1

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -335,6 +335,17 @@ etcd_events_access_addresses: |-
   {% for item in groups['etcd'] -%}
     https://{{ hostvars[item]['access_ip'] | default(hostvars[item]['ip'] | default(hostvars[item]['ansible_default_ipv4']['address'])) }}:2381{% if not loop.last %},{% endif %}
   {%- endfor %}
+
+# old etcd members
+etcd_access_addresses_old: |-
+  {% for item in groups['etcd-old'] -%}
+    https://{{ hostvars[item]['access_ip'] | default(hostvars[item]['ip']) }}:2379{% if not loop.last %},{% endif %}
+  {%- endfor %}
+etcd_events_access_addresses_old: |-
+  {% for item in groups['etcd-old'] -%}
+    https://{{ hostvars[item]['access_ip'] | default(hostvars[item]['ip']) }}:2381{% if not loop.last %},{% endif %}
+  {%- endfor %}
+
 etcd_member_name: |-
   {% for host in groups['etcd'] %}
   {%   if inventory_hostname == host %}{{"etcd"+loop.index|string }}{% endif %}
@@ -347,3 +358,18 @@ etcd_events_peer_addresses: |-
   {% for item in groups['etcd'] -%}
     {{ "etcd"+loop.index|string }}-events=https://{{ hostvars[item].access_ip | default(hostvars[item].ip | default(hostvars[item].ansible_default_ipv4['address'])) }}:2382{% if not loop.last %},{% endif %}
   {%- endfor %}
+
+# change the way of getting etcd_member_name
+etcd_member_name_recover: |-
+  {% for host in groups['etcd'] %}
+  {%   if inventory_hostname == host %}{{ hostvars[host]['etcd_member_name'] }}{% endif %}
+  {% endfor %}
+etcd_peer_addresses_recover: |-
+  {% for item in groups['etcd'] -%}
+    {{ hostvars[item].etcd_member_name }}=https://{{ hostvars[item].access_ip | default(hostvars[item].ip | default(hostvars[item].ansible_default_ipv4['address'])) }}:2380{% if not loop.last %},{% endif %}
+  {%- endfor %}
+etcd_events_peer_addresses_recover: |-
+  {% for item in groups['etcd'] -%}
+    {{ hostvars[item].etcd_member_name }}-events=https://{{ hostvars[item].access_ip | default(hostvars[item].ip | default(hostvars[item].ansible_default_ipv4['address'])) }}:2382{% if not loop.last %},{% endif %}
+  {%- endfor %}
+


### PR DESCRIPTION
This is the code of issue #2936.

feature:
(1) When master is down, node will become master to recover to substitute.
(2) ETCD data will remain
(3) Docker will not restart, so the previous running containers will not be interrupted within nodes.
(4) Delete the shut-down master information
(5) I made automatic and manual methods to recover the master. Because automatic method requires another code, I submit the manual method at first.

behavior:
(1) ETCD cluster deletes fail(down) master, and adds new master without losing data. ETCD generates new admin certs and member certs dispatching to new master.
(2) Due to the facts that ETCD cluster IPs changed, the components that need to access the ETCD cluster should be restarted, such as apiserver, calico. They will restart in proper order, so it will not affect the running container on each node.
(3) Due to the fact that apiserver cluster IP changed, the components that need to access the apiserver cluster should be restarted, such as kube-controller-manager, kube-scheduler. They will restart in proper order, so it will not affect the running container on each node.

change:
https://github.com/elementyang/issue/blob/master/kubespray-change

I have already developed and test this module locally, and the code has not been put on Github yet.

Environment:
Cloud provider or hardware configuration: hardware configuration
OS (printf "$(uname -srm)\n$(cat /etc/os-release)\n"):
Linux 3.10.0-514.el7.x86_64 x86_64
NAME="CentOS Linux"
VERSION="7 (Core)"
ID="centos"
ID_LIKE="rhel fedora"
VERSION_ID="7"
PRETTY_NAME="CentOS Linux 7 (Core)"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:centos:centos:7"
HOME_URL="https://www.centos.org/"
BUG_REPORT_URL="https://bugs.centos.org/"

CENTOS_MANTISBT_PROJECT="CentOS-7"
CENTOS_MANTISBT_PROJECT_VERSION="7"
REDHAT_SUPPORT_PRODUCT="centos"
REDHAT_SUPPORT_PRODUCT_VERSION="7"

Version of Ansible (ansible --version): ansible 2.5.5
Kubespray version (commit) (git rev-parse --short HEAD):
Develop this module based on master branch, commit: f624ba4.
The code has not pushed the Github yet.

Network plugin used: calico, flannel

Copy of your inventory file:
https://github.com/elementyang/issue/blob/master/kubespray-inventory

Command used to invoke ansible:
ansible-playbook -i inventory/mycluster/hosts-recover-master.ini recover-master.yml

Output of ansible run:

After running reconver master ansible, the result is:
https://github.com/elementyang/issue/blob/master/kubespray-result
