### PR TITLE
change create to apply

### DIFF
--- a/roles/network_plugin/calico/tasks/main.yml
+++ b/roles/network_plugin/calico/tasks/main.yml
@@ -113,7 +113,7 @@
     "apiVersion": "v1",
     "metadata": {"cidr": "{{ kube_pods_subnet }}"}
     }'
-    | {{ bin_dir }}/calicoctl create -f -
+    | {{ bin_dir }}/calicoctl apply -f -
   environment:
     NO_DEFAULT_POOLS: true
   run_once: true


### PR DESCRIPTION
When ippool config exists, 'create' operation is fault. We should use 'apply'.