### PR TITLE
dashboard_token_ttl option override possibility with default

### DIFF
--- a/roles/kubernetes-apps/ansible/defaults/main.yml
+++ b/roles/kubernetes-apps/ansible/defaults/main.yml
@@ -59,6 +59,9 @@ dashboard_certs_secret_name: kubernetes-dashboard-certs
 dashboard_tls_key_file: dashboard.key
 dashboard_tls_cert_file: dashboard.crt
 
+# Override dashboard default settings
+dashboard_token_ttl: "15 minutes"
+
 # SSL
 etcd_cert_dir: "/etc/ssl/etcd/ssl"
 canal_cert_dir: "/etc/canal/certs"

--- a/roles/kubernetes-apps/ansible/defaults/main.yml
+++ b/roles/kubernetes-apps/ansible/defaults/main.yml
@@ -60,7 +60,7 @@ dashboard_tls_key_file: dashboard.key
 dashboard_tls_cert_file: dashboard.crt
 
 # Override dashboard default settings
-dashboard_token_ttl: "15 minutes"
+dashboard_token_ttl: 900
 
 # SSL
 etcd_cert_dir: "/etc/ssl/etcd/ssl"

--- a/roles/kubernetes-apps/ansible/templates/dashboard.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/dashboard.yml.j2
@@ -166,6 +166,7 @@ spec:
           # If not specified, Dashboard will attempt to auto discover the API server and connect
           # to it. Uncomment only if the default does not work.
           # - --apiserver-host=http://my-address:port
+          - --token-ttl={{ dashboard_token_ttl }}
         volumeMounts:
         - name: kubernetes-dashboard-certs
           mountPath: /certs


### PR DESCRIPTION
As the default "15 minutes" session timeout is very low, and this cannot be overridden by user, I created a variable to optionally override it. For example "0" means infinite.

See:
- https://github.com/kubernetes/dashboard/issues/2815
- https://github.com/kubernetes/dashboard/wiki/Dashboard-arguments