### PR TITLE
Fixed kubectl path.

### DIFF
--- a/roles/kubernetes/kubeadm/tasks/main.yml
+++ b/roles/kubernetes/kubeadm/tasks/main.yml
@@ -64,7 +64,7 @@
   shell: >-
     {{ bin_dir }}/kubectl get configmap kube-proxy -n kube-system -o yaml
     | sed 's#server:.*#server:\ {{ kube_apiserver_endpoint }}#g'
-    | kubectl replace -f -
+    | {{ bin_dir }}/kubectl replace -f -
   delegate_to: "{{groups['kube-master']|first}}"
   run_once: true
   when: is_kube_master and kubeadm_discovery_address != kube_apiserver_endpoint


### PR DESCRIPTION
I have following error due to lack of "kubectl  replace.." path:

```
TASK [kubernetes/kubeadm : Update server field in kube-proxy kubeconfig] *********************************************************
Friday 13 July 2018  15:19:43 +0000 (0:00:00.511)       0:04:24.103 ***********
fatal: [master1 -> 10.0.0.11]: FAILED! => {"changed": true, "cmd": "/usr/local/bin/kubectl get configmap kube-proxy -n kube-system -o yaml | sed 's#server:.*#server:\\ https://127.0.0.1:6443#g' | kubectl replace -f -", "delta": "0:00:00.240920", "end": "2018-07-13 15:19:43.775695", "msg": "non-zero return code", "rc": 127, "start": "2018-07-13 15:19:43.534775", "stderr": "/bin/sh: kubectl: command not found\nsed: couldn't flush stdout: Broken pipe", "stderr_lines": ["/bin/sh: kubectl: command not found", "sed: couldn't flush stdout: Broken pipe"], "stdout": "", "stdout_lines": []}
```

kubectl should be absolute path.
