### PR TITLE
ingress-nginx: Remove duplicated securityContext

### DIFF
--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ds-ingress-nginx-controller.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ds-ingress-nginx-controller.yml.j2
@@ -86,5 +86,3 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
-          securityContext:
-            runAsNonRoot: false


### PR DESCRIPTION
upstream change.

see:

https://github.com/kubernetes/ingress-nginx/pull/2705

and

https://github.com/kubernetes/ingress-nginx/issues/2704

Signed-off-by: Lars Greiss <l.greiss@mediacologne.de>