### PR TITLE
ingress-nginx: Remove --publish-service flag

### DIFF
--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ds-ingress-nginx-controller.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ds-ingress-nginx-controller.yml.j2
@@ -41,7 +41,6 @@ spec:
             - --configmap=$(POD_NAMESPACE)/ingress-nginx
             - --tcp-services-configmap=$(POD_NAMESPACE)/tcp-services
             - --udp-services-configmap=$(POD_NAMESPACE)/udp-services
-            - --publish-service=$(POD_NAMESPACE)/ingress-nginx
             - --annotations-prefix=nginx.ingress.kubernetes.io
           securityContext:
             capabilities:


### PR DESCRIPTION
We do not use a service to expose ingress-nginx ports in kubespray. Right now
the pod log is spammed with missing service due that nginx-ingress-controller cannot found it.

Signed-off-by: Lars Greiss <l.greiss@mediacologne.de>