### PR TITLE
Changing the libncurses version

### DIFF
--- a/roles/bootstrap-os/files/bootstrap.sh
+++ b/roles/bootstrap-os/files/bootstrap.sh
@@ -18,7 +18,7 @@ mv -n pypy-$PYPY_VERSION-linux64 pypy
 
 ## library fixup
 mkdir -p pypy/lib
-ln -snf /lib64/libncurses.so.5.9 $BINDIR/pypy/lib/libtinfo.so.5
+ln -snf /lib64/libncurses.so.6.1 $BINDIR/pypy/lib/libtinfo.so.5
 
 cat > $BINDIR/python <<EOF
 #!/bin/bash


### PR DESCRIPTION
As discussed in https://github.com/commercialhaskell/stack/issues/1012#issuecomment-387054798 this fixes the `cannot open shared object file` error.