### PR TITLE
Remove double slash

### DIFF
--- a/roles/kubernetes/kubeadm/tasks/main.yml
+++ b/roles/kubernetes/kubeadm/tasks/main.yml
@@ -78,7 +78,7 @@
 # FIXME(mattymo): Reconcile kubelet kubeconfig filename for both deploy modes
 - name: Symlink kubelet kubeconfig for calico/canal
   file:
-    src: "{{ kube_config_dir }}//kubelet.conf"
+    src: "{{ kube_config_dir }}/kubelet.conf"
     dest: "{{ kube_config_dir }}/node-kubeconfig.yaml"
     state: link
     force: yes


### PR DESCRIPTION
Even without this PR, the operation works well.
However, it is better to use a single slash rather than a double slash in the path.