### PR TITLE
Fix label of registry in README

### DIFF
--- a/roles/kubernetes-apps/registry/README.md
+++ b/roles/kubernetes-apps/registry/README.md
@@ -110,18 +110,18 @@ metadata:
   name: kube-registry-v0
   namespace: kube-system
   labels:
-    k8s-app: kube-registry-upstream
+    k8s-app: registry
     version: v0
     kubernetes.io/cluster-service: "true"
 spec:
   replicas: 1
   selector:
-    k8s-app: kube-registry-upstream
+    k8s-app: registry
     version: v0
   template:
     metadata:
       labels:
-        k8s-app: kube-registry-upstream
+        k8s-app: registry
         version: v0
         kubernetes.io/cluster-service: "true"
     spec:
@@ -164,12 +164,12 @@ metadata:
   name: kube-registry
   namespace: kube-system
   labels:
-    k8s-app: kube-registry-upstream
+    k8s-app: registry
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "KubeRegistry"
 spec:
   selector:
-    k8s-app: kube-registry-upstream
+    k8s-app: registry
   ports:
   - name: registry
     port: 5000
@@ -257,7 +257,7 @@ You can use `kubectl` to set up a port-forward from your local node to a
 running Pod:
 
 ``` console
-$ POD=$(kubectl get pods --namespace kube-system -l k8s-app=kube-registry-upstream \
+$ POD=$(kubectl get pods --namespace kube-system -l k8s-app=registry \
             -o template --template '{{range .items}}{{.metadata.name}} {{.status.phase}}{{"\n"}}{{end}}' \
             | grep Running | head -1 | cut -f1 -d' ')
 


### PR DESCRIPTION
Udpate to be the same as https://github.com/kubernetes-incubator/kubespray/blob/329e97c4d35486c976efce4969e2f4a8c11c97b0/roles/kubernetes-apps/registry/templates/registry-rs.yml.j2 and https://github.com/kubernetes-incubator/kubespray/blob/329e97c4d35486c976efce4969e2f4a8c11c97b0/roles/kubernetes-apps/registry/templates/registry-svc.yml.j2