### PR TITLE
set LC_ALL=C for growpart

### DIFF
--- a/roles/kubernetes/preinstall/tasks/growpart-azure-centos-7.yml
+++ b/roles/kubernetes/preinstall/tasks/growpart-azure-centos-7.yml
@@ -23,6 +23,8 @@
 - name: run growpart
   command: growpart /dev/sda 1
   when: growpart_needed.changed
+  environment: 
+    LC_ALL: C
 
 - name: run xfs_growfs
   command: xfs_growfs /dev/sda1

--- a/roles/kubernetes/preinstall/tasks/growpart-azure-centos-7.yml
+++ b/roles/kubernetes/preinstall/tasks/growpart-azure-centos-7.yml
@@ -12,6 +12,8 @@
   failed_when: False
   changed_when: "'NOCHANGE:' not in growpart_needed.stdout"
   register: growpart_needed
+  environment: 
+    LC_ALL: C
 
 - name: check fs type
   command: file -Ls /dev/sda1


### PR DESCRIPTION
growpart need correct locale to run, in my environment with `LC_ALL=zh_CN.UTF-8`, run growpart will cause error 

```
[woosley@somewhere kubespray]$ ssh 10.0.0.5 sudo growpart /dev/sda 1
unexpected output in sfdisk --version [sfdisk，来自 util-linux 2.23.2]
```
ansible book fail with below issues 
```
TASK [check if growpart needs to be run] *************************************************************************************************************************************************************************************************************************************
Monday 30 July 2018  22:59:39 +0000 (0:00:10.856)       0:00:11.980 ***********
changed: [node2] => {"changed": true, "cmd": ["growpart", "-N", "/dev/sda", "1"], "delta": "0:00:00.012517", "end": "2018-07-30 22:59:40.238878", "failed_when_result": false, "msg": "non-zero return code", "rc": 2, "start": "2018-07-30 22:59:40.226361", "stderr": "unexpected output in sfdisk --version [sfdisk，来自 util-linux 2.23.2]", "stderr_lines": ["unexpected output in sfdisk --version [sfdisk，来自 util-linux 2.23.2]"], "stdout": "", "stdout_lines": []}
changed: [node1] => {"changed": true, "cmd": ["growpart", "-N", "/dev/sda", "1"], "delta": "0:00:00.011767", "end": "2018-07-30 22:59:40.199070", "failed_when_result": false, "msg": "non-zero return code", "rc": 2, "start": "2018-07-30 22:59:40.187303", "stderr": "unexpected output in sfdisk --version [sfdisk，来自 util-linux 2.23.2]", "stderr_lines": ["unexpected output in sfdisk --version [sfdisk，来自 util-linux 2.23.2]"], "stdout": "", "stdout_lines": []}
changed: [node3] => {"changed": true, "cmd": ["growpart", "-N", "/dev/sda", "1"], "delta": "0:00:00.011736", "end": "2018-07-30 22:59:40.276873", "failed_when_result": false, "msg": "non-zero return code", "rc": 2, "start": "2018-07-30 22:59:40.265137", "stderr": "unexpected output in sfdisk --version [sfdisk，来自 util-linux 2.23.2]", "stderr_lines": ["unexpected output in sfdisk --version [sfdisk，来自 util-linux 2.23.2]"], "stdout": "", "stdout_lines": []}

TASK [check fs type] *********************************************************************************************************************************************************************************************************************************************************Monday 30 July 2018  22:59:40 +0000 (0:00:00.916)       0:00:12.896 ***********
ok: [node3] => {"changed": false, "cmd": ["file", "-Ls", "/dev/sda1"], "delta": "0:00:00.005797", "end": "2018-07-30 22:59:40.976262", "rc": 0, "start": "2018-07-30 22:59:40.970465", "stderr": "", "stderr_lines": [], "stdout": "/dev/sda1: SGI XFS filesystem data (blksz 4096, inosz 512, v2 dirs)", "stdout_lines": ["/dev/sda1: SGI XFS filesystem data (blksz 4096, inosz 512, v2 dirs)"]}
ok: [node1] => {"changed": false, "cmd": ["file", "-Ls", "/dev/sda1"], "delta": "0:00:00.006080", "end": "2018-07-30 22:59:40.965121", "rc": 0, "start": "2018-07-30 22:59:40.959041", "stderr": "", "stderr_lines": [], "stdout": "/dev/sda1: SGI XFS filesystem data (blksz 4096, inosz 512, v2 dirs)", "stdout_lines": ["/dev/sda1: SGI XFS filesystem data (blksz 4096, inosz 512, v2 dirs)"]}
ok: [node2] => {"changed": false, "cmd": ["file", "-Ls", "/dev/sda1"], "delta": "0:00:00.006079", "end": "2018-07-30 22:59:41.068639", "rc": 0, "start": "2018-07-30 22:59:41.062560", "stderr": "", "stderr_lines": [], "stdout": "/dev/sda1: SGI XFS filesystem data (blksz 4096, inosz 512, v2 dirs)", "stdout_lines": ["/dev/sda1: SGI XFS filesystem data (blksz 4096, inosz 512, v2 dirs)"]}

TASK [run growpart] **********************************************************************************************************************************************************************************************************************************************************Monday 30 July 2018  22:59:41 +0000 (0:00:00.772)       0:00:13.669 ***********
fatal: [node3]: FAILED! => {"changed": true, "cmd": ["growpart", "/dev/sda", "1"], "delta": "0:00:00.011268", "end": "2018-07-30 22:59:41.758652", "msg": "non-zero return code", "rc": 2, "start": "2018-07-30 22:59:41.747384", "stderr": "unexpected output in sfdisk --version [sfdisk，来自 util-linux 2.23.2]", "stderr_lines": ["unexpected output in sfdisk --version [sfdisk，来自 util-linux 2.23.2]"], "stdout": "", "stdout_lines": []}
fatal: [node1]: FAILED! => {"changed": true, "cmd": ["growpart", "/dev/sda", "1"], "delta": "0:00:00.011336", "end": "2018-07-30 22:59:41.758935", "msg": "non-zero return code", "rc": 2, "start": "2018-07-30 22:59:41.747599", "stderr": "unexpected output in sfdisk --version [sfdisk，来自 util-linux 2.23.2]", "stderr_lines": ["unexpected output in sfdisk --version [sfdisk，来自 util-linux 2.23.2]"], "stdout": "", "stdout_lines": []}
fatal: [node2]: FAILED! => {"changed": true, "cmd": ["growpart", "/dev/sda", "1"], "delta": "0:00:00.011859", "end": "2018-07-30 22:59:41.862100", "msg": "non-zero return code", "rc": 2, "start": "2018-07-30 22:59:41.850241", "stderr": "unexpected output in sfdisk --version [sfdisk，来自 util-linux 2.23.2]", "stderr_lines": ["unexpected output in sfdisk --version [sfdisk，来自 util-linux 2.23.2]"], "stdout": "", "stdout_lines": []}
        to retry, use: --limit @/home/woosley/kubespray/test.retry

```
this patch fix the issue by setting LC_ALL to C explicitly in the ansible task.