### PR TITLE
Fixed discoveryTokenCACertHashes

### DIFF
--- a/roles/kubernetes/kubeadm/templates/kubeadm-client.conf.j2
+++ b/roles/kubernetes/kubeadm/templates/kubeadm-client.conf.j2
@@ -4,5 +4,5 @@ caCertPath: {{ kube_config_dir }}/ssl/ca.crt
 token: {{ kubeadm_token }}
 discoveryTokenAPIServers:
 - {{ kubeadm_discovery_address | replace("https://", "")}}
-DiscoveryTokenCACertHashes:
+discoveryTokenCACertHashes:
 - sha256:{{ kubeadm_ca_hash.stdout }}


### PR DESCRIPTION
I have following error while kubeadm join:

```
# /usr/local/bin/kubeadm join --config /etc/kubernetes/kubeadm-client.conf --discovery-token-unsafe-skip-ca-verification --ignore-preflight-errors=all
[discovery: Invalid value: "": using token-based discovery without discoveryTokenCACertHashes can be unsafe. set --discovery-token-unsafe-skip-ca-verification to continue
```

For kubeadm 1.11.1, following description in /etc/kubernetes/kubeadm-client.conf 

```
DiscoveryTokenCACertHashes:
```

should be 

```
discoveryTokenCACertHashes:
```

Sorry, I don't know other kubeadm version.
