### PR TITLE
Add support for docker 17.09

### DIFF
--- a/roles/docker/vars/debian.yml
+++ b/roles/docker/vars/debian.yml
@@ -9,6 +9,7 @@ docker_versioned_pkg:
   '1.12': docker-engine=1.12.6-0~debian-{{ ansible_distribution_release|lower }}
   '1.13': docker-engine=1.13.1-0~debian-{{ ansible_distribution_release|lower }}
   '17.03': docker-ce=17.03.2~ce-0~debian-{{ ansible_distribution_release|lower }}
+  '17.09': docker-ce=17.09.0~ce-0~debian-{{ ansible_distribution_release|lower }}
   'stable': docker-ce=17.03.2~ce-0~debian-{{ ansible_distribution_release|lower }}
   'edge': docker-ce=17.12.1~ce-0~debian-{{ ansible_distribution_release|lower }}
 

--- a/roles/docker/vars/redhat.yml
+++ b/roles/docker/vars/redhat.yml
@@ -11,6 +11,7 @@ docker_versioned_pkg:
   '1.12': docker-engine-1.12.6-1.el7.centos
   '1.13': docker-engine-1.13.1-1.el7.centos
   '17.03': docker-ce-17.03.2.ce-1.el7.centos
+  '17.09': docker-ce-17.09.0.ce-1.el7.centos
   'stable': docker-ce-17.03.2.ce-1.el7.centos
   'edge': docker-ce-17.12.1.ce-1.el7.centos
 

--- a/roles/docker/vars/ubuntu.yml
+++ b/roles/docker/vars/ubuntu.yml
@@ -8,6 +8,7 @@ docker_versioned_pkg:
   '1.12': docker-engine=1.12.6-0~ubuntu-{{ ansible_distribution_release|lower }}
   '1.13': docker-engine=1.13.1-0~ubuntu-{{ ansible_distribution_release|lower }}
   '17.03': docker-ce=17.03.2~ce-0~ubuntu-{{ ansible_distribution_release|lower }}
+  '17.09': docker-ce=17.09.0~ce-0~ubuntu-{{ ansible_distribution_release|lower }}
   'stable': docker-ce=17.03.2~ce-0~ubuntu-{{ ansible_distribution_release|lower }}
   'edge': docker-ce=17.12.1~ce-0~ubuntu-{{ ansible_distribution_release|lower }}
 


### PR DESCRIPTION
I require docker 17.09 to support docker containers running on bare metal hosts outside of kubernetes for an existing workload I have on the machines.