### PR TITLE
Fix a broken symbolic link for group_vars

### DIFF
--- a/contrib/network-storage/glusterfs/group_vars
+++ b/contrib/network-storage/glusterfs/group_vars
@@ -1,1 +1,1 @@
-../../../inventory/group_vars
+../../../inventory/local/group_vars


### PR DESCRIPTION
The link to `contrib/network-storage/glusterfs/group_vars` was broken when restructuring.