### PR TITLE
Service file binary place mismatch

### DIFF
--- a/roles/vault/templates/host.service.j2
+++ b/roles/vault/templates/host.service.j2
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 AmbientCapabilities=CAP_IPC_LOCK
-ExecStart=/usr/bin/vault server --config={{ vault_config_dir }}/config.json
+ExecStart={{ bin_dir }}/vault server --config={{ vault_config_dir }}/config.json
 LimitNOFILE=40000
 NotifyAccess=all
 Restart=always


### PR DESCRIPTION
According to cluster/binary.yml vault binary will be placed to `{{ bin_dir }}` and according to `inventory/sample/group_vars/all.yml` that is `bin_dir: /usr/local/bin`