### PR TITLE
Add tags for coredns and kubedns

### DIFF
--- a/roles/kubernetes-apps/ansible/tasks/kubedns.yml
+++ b/roles/kubernetes-apps/ansible/tasks/kubedns.yml
@@ -19,6 +19,7 @@
     - rbac_enabled or item.type not in rbac_resources
   tags:
     - dnsmasq
+    - kubedns
 
 # see https://github.com/kubernetes/kubernetes/issues/45084, only needed for "old" kube-dns
 - name: Kubernetes Apps | Patch system:kube-dns ClusterRole
@@ -39,3 +40,4 @@
     - rbac_enabled and kubedns_version|version_compare("1.11.0", "<", strict=True)
   tags:
     - dnsmasq
+    - kubedns

--- a/roles/kubernetes-apps/ansible/tasks/main.yml
+++ b/roles/kubernetes-apps/ansible/tasks/main.yml
@@ -17,6 +17,9 @@
     - inventory_hostname == groups['kube-master'][0]
   tags:
     - upgrade
+    - dnsmasq
+    - coredns
+    - kubedns
 
 - name: Kubernetes Apps | CoreDNS
   import_tasks: "tasks/coredns.yml"
@@ -56,6 +59,8 @@
   delay: 5
   tags:
     - dnsmasq
+    - coredns
+    - kubedns
 
 - name: Kubernetes Apps | Netchecker
   import_tasks: tasks/netchecker.yml


### PR DESCRIPTION
Hi, 
I propose this PR in order to add tags for `kubedns` and `coredns` actions.
This PR will enables  calling kubernetes-apps in specified the dns provider with tags

It will also be usefull for us, in order to do a skip-tags when we don't want to upgrade the dns. The cleanup task, especially, is removing the dns in Kubernetes for some seconds.
