### PR TITLE
fix glusterfs ppa and glusterfs server command name errors

### DIFF
--- a/contrib/network-storage/glusterfs/roles/glusterfs/client/defaults/main.yml
+++ b/contrib/network-storage/glusterfs/roles/glusterfs/client/defaults/main.yml
@@ -2,7 +2,7 @@
 # For Ubuntu.
 glusterfs_default_release: ""
 glusterfs_ppa_use: yes
-glusterfs_ppa_version: "3.8"
+glusterfs_ppa_version: "4.1"
 
 # Gluster configuration.
 gluster_mount_dir: /mnt/gluster

--- a/contrib/network-storage/glusterfs/roles/glusterfs/server/defaults/main.yml
+++ b/contrib/network-storage/glusterfs/roles/glusterfs/server/defaults/main.yml
@@ -2,7 +2,7 @@
 # For Ubuntu.
 glusterfs_default_release: ""
 glusterfs_ppa_use: yes
-glusterfs_ppa_version: "3.8"
+glusterfs_ppa_version: "3.12"
 
 # Gluster configuration.
 gluster_mount_dir: /mnt/gluster

--- a/contrib/network-storage/glusterfs/roles/glusterfs/server/vars/Debian.yml
+++ b/contrib/network-storage/glusterfs/roles/glusterfs/server/vars/Debian.yml
@@ -1,2 +1,2 @@
 ---
-glusterfs_daemon: glusterfs-server
+glusterfs_daemon: glusterd


### PR DESCRIPTION
Fix the following three errors when running the glusterfs anslible script (https://github.com/kubernetes-incubator/kubespray/tree/master/contrib/terraform/openstack#glusterfs-1):

```
fatal: [my-k8s-cluster-gfs-node-nf-2]: FAILED! => {"changed": false, "msg": "failed to fetch PPA information, error was: HTTP Error 404: Not Found"}
```

```
fatal: [my-k8s-cluster-k8s-master-1]: FAILED! => {"changed": false, "msg": "failed to fetch PPA information, error was: HTTP Error 404: Not Found"}
```

```
fatal: [my-k8s-cluster-gfs-node-nf-1]: FAILED! => {"changed": false, "msg": "Could not find the requested service glusterfs-server: host"}
```