### PR TITLE
Netchecker manifests should not have j2 extension

### DIFF
--- a/roles/kubernetes-apps/ansible/tasks/netchecker.yml
+++ b/roles/kubernetes-apps/ansible/tasks/netchecker.yml
@@ -2,7 +2,7 @@
 
 - name: Kubernetes Apps | Check if netchecker-server manifest already exists
   stat:
-    path: "{{ kube_config_dir }}/netchecker-server-deployment.yml.j2"
+    path: "{{ kube_config_dir }}/netchecker-server-deployment.yml"
   register: netchecker_server_manifest
   tags:
     - facts
@@ -22,16 +22,16 @@
 
 - name: Kubernetes Apps | Lay Down Netchecker Template
   template:
-    src: "{{item.file}}"
+    src: "{{item.file}}.j2"
     dest: "{{kube_config_dir}}/{{item.file}}"
   with_items:
-    - {file: netchecker-agent-ds.yml.j2, type: ds, name: netchecker-agent}
-    - {file: netchecker-agent-hostnet-ds.yml.j2, type: ds, name: netchecker-agent-hostnet}
-    - {file: netchecker-server-sa.yml.j2, type: sa, name: netchecker-server}
-    - {file: netchecker-server-clusterrole.yml.j2, type: clusterrole, name: netchecker-server}
-    - {file: netchecker-server-clusterrolebinding.yml.j2, type: clusterrolebinding, name: netchecker-server}
-    - {file: netchecker-server-deployment.yml.j2, type: deployment, name: netchecker-server}
-    - {file: netchecker-server-svc.yml.j2, type: svc, name: netchecker-service}
+    - {file: netchecker-agent-ds.yml, type: ds, name: netchecker-agent}
+    - {file: netchecker-agent-hostnet-ds.yml, type: ds, name: netchecker-agent-hostnet}
+    - {file: netchecker-server-sa.yml, type: sa, name: netchecker-server}
+    - {file: netchecker-server-clusterrole.yml, type: clusterrole, name: netchecker-server}
+    - {file: netchecker-server-clusterrolebinding.yml, type: clusterrolebinding, name: netchecker-server}
+    - {file: netchecker-server-deployment.yml, type: deployment, name: netchecker-server}
+    - {file: netchecker-server-svc.yml, type: svc, name: netchecker-service}
   register: manifests
   when:
     - inventory_hostname == groups['kube-master'][0]


### PR DESCRIPTION
Currently, netchecker manifests are rendered with the same name as the src jinja template.