### PR TITLE
Disable locksmithd on CoreOS if coreos_auto_upgrade set to false

### DIFF
--- a/inventory/sample/group_vars/all.yml
+++ b/inventory/sample/group_vars/all.yml
@@ -131,3 +131,6 @@ bin_dir: /usr/local/bin
 
 # The read-only port for the Kubelet to serve on with no authentication/authorization. Uncomment to enable.
 #kube_read_only_port: 10255
+
+# Does coreos need auto upgrade, default is true
+#coreos_auto_upgrade: true

--- a/roles/bootstrap-os/defaults/main.yml
+++ b/roles/bootstrap-os/defaults/main.yml
@@ -4,3 +4,6 @@ pip_python_coreos_modules:
   - six
 
 override_system_hostname: true
+
+
+coreos_auto_upgrade: true

--- a/roles/bootstrap-os/tasks/bootstrap-coreos.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-coreos.yml
@@ -65,4 +65,5 @@
 
 - name: Bootstrap | Disable auto-upgrade
   shell: "systemctl stop locksmithd.service && systemctl mask --now locksmithd.service"
-  when: not coreos_auto_upgrade
+  when:
+    - not coreos_auto_upgrade

--- a/roles/bootstrap-os/tasks/bootstrap-coreos.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-coreos.yml
@@ -62,3 +62,7 @@
   with_items: "{{pip_python_coreos_modules}}"
   environment:
     PATH: "{{ ansible_env.PATH }}:{{ bin_dir }}"
+
+- name: Bootstrap | Disable auto-upgrade
+  shell: "systemctl stop locksmithd.service && systemctl mask --now locksmithd.service"
+  when: not coreos_auto_upgrade


### PR DESCRIPTION
Fix issue https://github.com/kubernetes-incubator/kubespray/issues/3025

[Reason for this PR]
If we do not support it, it may make services down during os upgrade/restart.
And, for istio, it will not recovery after coreos restart sometimes. This will make whole services down
istio/istio#7412

Refer to:
https://coreos.com/os/docs/latest/update-strategies.html
https://github.com/kubernetes/kops/pull/4909  (kops already supported it)

