### PR TITLE
Add the path to kubectl binary

### DIFF
--- a/roles/remove-node/post-remove/tasks/main.yml
+++ b/roles/remove-node/post-remove/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Delete node
-  command: kubectl delete node {{ item }}
+  command: "{{ bin_dir}}/kubectl delete node {{ item }}"
   with_items:
     - "{{ node.split(',') | default(groups['kube-node']) }}"
   delegate_to: "{{ groups['kube-master']|first }}"


### PR DESCRIPTION
The post-remove action fails during the kubectl delete node action because with rc: 2, command not found. The kubectl is not in the system PATH and the full path to the binary is required