### PR TITLE
Add --dns-loop-detect to dnsmasq used in kube-dns

### DIFF
--- a/roles/kubernetes-apps/ansible/templates/kubedns-deploy.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/kubedns-deploy.yml.j2
@@ -127,6 +127,7 @@ spec:
         - --
         - -k
         - --cache-size=1000
+        - --dns-loop-detect
         - --log-facility=-
         - --server=/{{ dns_domain }}/127.0.0.1#10053
         - --server=/in-addr.arpa/127.0.0.1#10053


### PR DESCRIPTION
It prevents DNS loops when host's DNS server is a localhost DNS server,
or when DNS server of cluster is also added as an upstream DNS server

See:
https://github.com/kubernetes/kubernetes/issues/67299
https://github.com/kubernetes/kubernetes/pull/67302