### PR TITLE
Uninstall old versions of Docker

### DIFF
--- a/roles/docker/tasks/pre-upgrade.yml
+++ b/roles/docker/tasks/pre-upgrade.yml
@@ -6,6 +6,7 @@
   with_items:
     - docker
     - docker-engine
+    - docker.io
   when:
     - ansible_os_family == 'Debian'
     - (docker_versioned_pkg[docker_version | string] | search('docker-ce'))
@@ -19,6 +20,12 @@
     - docker-common
     - docker-engine
     - docker-selinux
+    - docker-client
+    - docker-client-latest
+    - docker-latest
+    - docker-latest-logrotate
+    - docker-logrotate
+    - docker-engine-selinux
   when:
     - ansible_os_family == 'RedHat'
     - (docker_versioned_pkg[docker_version | string] | search('docker-ce'))


### PR DESCRIPTION
Uninstall old versions of Docker:

[centos](https://docs.docker.com/install/linux/docker-ce/centos/#uninstall-old-versions)
```
$ sudo yum remove docker \
                  docker-client \
                  docker-client-latest \
                  docker-common \
                  docker-latest \
                  docker-latest-logrotate \
                  docker-logrotate \
                  docker-selinux \
                  docker-engine-selinux \
                  docker-engine
```

[debian](https://docs.docker.com/install/linux/docker-ce/debian/#uninstall-old-versions)
```
$ sudo apt-get remove docker docker-engine docker.io
```