### PR TITLE
PodSecurityPolicy admission controller support

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s-cluster.yml
@@ -172,6 +172,9 @@ k8s_image_pull_policy: IfNotPresent
 # audit log for kubernetes
 kubernetes_audit: false
 
+# pod security policy (RBAC must be enabled either by having 'RBAC' in authorization_modes or kubeadm enabled)
+podsecuritypolicy_enabled: false
+
 # Kubernetes dashboard
 # RBAC required. see docs/getting-started.md for access details.
 dashboard_enabled: true

--- a/roles/kubernetes-apps/ansible/defaults/main.yml
+++ b/roles/kubernetes-apps/ansible/defaults/main.yml
@@ -42,6 +42,12 @@ netchecker_server_memory_limit: 256M
 netchecker_server_cpu_requests: 50m
 netchecker_server_memory_requests: 64M
 
+# SecurityContext when PodSecurityPolicy is enabled
+netchecker_agent_user: 1000
+netchecker_server_user: 1000
+netchecker_agent_group: 1000
+netchecker_server_group: 1000
+
 # Dashboard
 dashboard_enabled: true
 dashboard_image_repo: gcr.io/google_containers/kubernetes-dashboard-{{ image_arch }}

--- a/roles/kubernetes-apps/ansible/tasks/netchecker.yml
+++ b/roles/kubernetes-apps/ansible/tasks/netchecker.yml
@@ -20,18 +20,32 @@
   tags:
     - upgrade
 
+- name: Kubernetes Apps | Netchecker Templates list
+  set_fact:
+    netchecker_templates:
+      - {file: netchecker-agent-sa.yml, type: sa, name: netchecker-agent}
+      - {file: netchecker-agent-ds.yml, type: ds, name: netchecker-agent}
+      - {file: netchecker-agent-hostnet-ds.yml, type: ds, name: netchecker-agent-hostnet}
+      - {file: netchecker-server-sa.yml, type: sa, name: netchecker-server}
+      - {file: netchecker-server-clusterrole.yml, type: clusterrole, name: netchecker-server}
+      - {file: netchecker-server-clusterrolebinding.yml, type: clusterrolebinding, name: netchecker-server}
+      - {file: netchecker-server-deployment.yml, type: deployment, name: netchecker-server}
+      - {file: netchecker-server-svc.yml, type: svc, name: netchecker-service}
+    netchecker_templates_for_psp:
+      - {file: netchecker-agent-hostnet-psp.yml, type: podsecuritypolicy, name: netchecker-agent-hostnet-policy}
+      - {file: netchecker-agent-hostnet-clusterrole.yml, type: clusterrole, name: netchecker-agent}
+      - {file: netchecker-agent-hostnet-clusterrolebinding.yml, type: clusterrolebinding, name: netchecker-agent}
+
+- name: Kubernetes Apps | Append extra templates to Netchecker Templates list for PodSecurityPolicy
+  set_fact:
+    netchecker_templates: "{{ netchecker_templates_for_psp + netchecker_templates}}"
+  when: podsecuritypolicy_enabled
+
 - name: Kubernetes Apps | Lay Down Netchecker Template
   template:
     src: "{{item.file}}.j2"
     dest: "{{kube_config_dir}}/{{item.file}}"
-  with_items:
-    - {file: netchecker-agent-ds.yml, type: ds, name: netchecker-agent}
-    - {file: netchecker-agent-hostnet-ds.yml, type: ds, name: netchecker-agent-hostnet}
-    - {file: netchecker-server-sa.yml, type: sa, name: netchecker-server}
-    - {file: netchecker-server-clusterrole.yml, type: clusterrole, name: netchecker-server}
-    - {file: netchecker-server-clusterrolebinding.yml, type: clusterrolebinding, name: netchecker-server}
-    - {file: netchecker-server-deployment.yml, type: deployment, name: netchecker-server}
-    - {file: netchecker-server-svc.yml, type: svc, name: netchecker-service}
+  with_items: "{{ netchecker_templates }}"
   register: manifests
   when:
     - inventory_hostname == groups['kube-master'][0]

--- a/roles/kubernetes-apps/ansible/templates/netchecker-agent-ds.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/netchecker-agent-ds.yml.j2
@@ -40,6 +40,12 @@ spec:
             requests:
               cpu: {{ netchecker_agent_cpu_requests }}
               memory: {{ netchecker_agent_memory_requests }}
+          securityContext:
+            runAsUser: {{ netchecker_agent_user | default('0') }}
+            runAsGroup: {{ netchecker_agent_group | default('0') }}
+{% if rbac_enabled %}
+      serviceAccountName: netchecker-agent
+{% endif %}
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 100%

--- a/roles/kubernetes-apps/ansible/templates/netchecker-agent-ds.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/netchecker-agent-ds.yml.j2
@@ -43,9 +43,7 @@ spec:
           securityContext:
             runAsUser: {{ netchecker_agent_user | default('0') }}
             runAsGroup: {{ netchecker_agent_group | default('0') }}
-{% if rbac_enabled %}
       serviceAccountName: netchecker-agent
-{% endif %}
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 100%

--- a/roles/kubernetes-apps/ansible/templates/netchecker-agent-hostnet-clusterrole.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/netchecker-agent-hostnet-clusterrole.yml.j2
@@ -1,20 +1,13 @@
----
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: calico-node
-  namespace: kube-system
+  name: psp:netchecker-agent-hostnet
+  namespace: {{ netcheck_namespace }}
 rules:
-  - apiGroups: [""]
-    resources:
-      - pods
-      - nodes
-    verbs:
-      - get
   - apiGroups:
     - policy
     resourceNames:
-    - privileged
+    - netchecker-agent-hostnet
     resources:
     - podsecuritypolicies
     verbs:

--- a/roles/kubernetes-apps/ansible/templates/netchecker-agent-hostnet-clusterrolebinding.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/netchecker-agent-hostnet-clusterrolebinding.yml.j2
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: psp:netchecker-agent-hostnet
+  namespace: {{ netcheck_namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: netchecker-agent-hostnet
+    namespace: {{ netcheck_namespace }}
+roleRef:
+  kind: ClusterRole
+  name: psp:netchecker-agent-hostnet
+  apiGroup: rbac.authorization.k8s.io

--- a/roles/kubernetes-apps/ansible/templates/netchecker-agent-hostnet-ds.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/netchecker-agent-hostnet-ds.yml.j2
@@ -47,9 +47,7 @@ spec:
           securityContext:
             runAsUser: {{ netchecker_agent_user | default('0') }}
             runAsGroup: {{ netchecker_agent_group | default('0') }}
-{% if rbac_enabled %}
       serviceAccountName: netchecker-agent
-{% endif %}
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 100%

--- a/roles/kubernetes-apps/ansible/templates/netchecker-agent-hostnet-ds.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/netchecker-agent-hostnet-ds.yml.j2
@@ -44,6 +44,12 @@ spec:
             requests:
               cpu: {{ netchecker_agent_cpu_requests }}
               memory: {{ netchecker_agent_memory_requests }}
+          securityContext:
+            runAsUser: {{ netchecker_agent_user | default('0') }}
+            runAsGroup: {{ netchecker_agent_group | default('0') }}
+{% if rbac_enabled %}
+      serviceAccountName: netchecker-agent
+{% endif %}
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 100%

--- a/roles/kubernetes-apps/ansible/templates/netchecker-agent-hostnet-psp.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/netchecker-agent-hostnet-psp.yml.j2
@@ -1,0 +1,45 @@
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: netchecker-agent-hostnet
+  annotations:
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
+{% if apparmor_enabled %}
+    apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
+{% endif %}
+  labels:
+    kubernetes.io/cluster-service: 'true'
+    addonmanager.kubernetes.io/mode: Reconcile
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  requiredDropCapabilities:
+    - ALL
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    - 'persistentVolumeClaim'
+  hostNetwork: true
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'MustRunAsNonRoot'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false

--- a/roles/kubernetes-apps/ansible/templates/netchecker-agent-sa.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/netchecker-agent-sa.yml.j2
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: netchecker-agent
+  namespace: {{ netcheck_namespace }}
+  labels:
+    kubernetes.io/cluster-service: "true"

--- a/roles/kubernetes-apps/ansible/templates/netchecker-server-deployment.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/netchecker-server-deployment.yml.j2
@@ -23,6 +23,9 @@ spec:
             requests:
               cpu: {{ netchecker_server_cpu_requests }}
               memory: {{ netchecker_server_memory_requests }}
+          securityContext:
+            runAsUser: {{ netchecker_server_user | default('0') }}
+            runAsGroup: {{ netchecker_server_group | default('0') }}
           ports:
             - containerPort: 8081
           args:

--- a/roles/kubernetes-apps/cluster_roles/tasks/main.yml
+++ b/roles/kubernetes-apps/cluster_roles/tasks/main.yml
@@ -11,6 +11,46 @@
   delay: 6
   when: inventory_hostname == groups['kube-master'][0]
 
+- name: Kubernetes Apps | Check AppArmor status
+  command: which apparmor_parser
+  register: apparmor_status
+  when:
+    - podsecuritypolicy_enabled
+    - inventory_hostname == groups['kube-master'][0]
+  failed_when: false
+
+- name: Kubernetes Apps | Set apparmor_enabled
+  set_fact:
+    apparmor_enabled: "{{ apparmor_status.rc == 0 }}"
+  when:
+    - podsecuritypolicy_enabled
+    - inventory_hostname == groups['kube-master'][0]
+
+- name: Kubernetes Apps | Render templates for PodSecurityPolicy
+  template:
+    src: "{{ item.file }}.j2"
+    dest: "{{ kube_config_dir }}/{{ item.file }}"
+  register: psp_manifests
+  with_items:
+    - {file: psp.yml, type: psp, name: psp}
+    - {file: psp-cr.yml, type: clusterrole, name: psp-cr}
+    - {file: psp-crb.yml, type: rolebinding, name: psp-crb}
+  when:
+    - podsecuritypolicy_enabled
+    - inventory_hostname == groups['kube-master'][0]
+
+- name: Kubernetes Apps | Add policies, roles, bindings for PodSecurityPolicy
+  kube:
+    name: "{{item.item.name}}"
+    kubectl: "{{bin_dir}}/kubectl"
+    resource: "{{item.item.type}}"
+    filename: "{{kube_config_dir}}/{{item.item.file}}"
+    state: "latest"
+  with_items: "{{ psp_manifests.results }}"
+  when:
+    - inventory_hostname == groups['kube-master'][0]
+    - not item|skipped
+
 - name: Kubernetes Apps | Add ClusterRoleBinding to admit nodes
   template:
     src: "node-crb.yml.j2"

--- a/roles/kubernetes-apps/cluster_roles/templates/psp-cr.yml.j2
+++ b/roles/kubernetes-apps/cluster_roles/templates/psp-cr.yml.j2
@@ -1,0 +1,35 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: psp:privileged
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - privileged
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: psp:restricted
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - restricted
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use

--- a/roles/kubernetes-apps/cluster_roles/templates/psp-crb.yml.j2
+++ b/roles/kubernetes-apps/cluster_roles/templates/psp-crb.yml.j2
@@ -1,0 +1,55 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: psp:any:restricted
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: psp:restricted
+subjects:
+- kind: Group
+  name: system:authenticated
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: psp:kube-system:privileged
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: psp:privileged
+subjects:
+- kind: Group
+  name: system:masters
+  apiGroup: rbac.authorization.k8s.io
+- kind: Group
+  name: system:serviceaccounts:kube-system
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: psp:nodes:privileged
+  namespace: kube-system
+  annotations:
+    kubernetes.io/description: 'Allow nodes to create privileged pods. Should
+      be used in combination with the NodeRestriction admission plugin to limit
+      nodes to mirror pods bound to themselves.'
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+    kubernetes.io/cluster-service: 'true'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: psp:privileged
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: system:nodes
+  - kind: User
+    apiGroup: rbac.authorization.k8s.io
+    # Legacy node ID
+    name: kubelet

--- a/roles/kubernetes-apps/cluster_roles/templates/psp.yml.j2
+++ b/roles/kubernetes-apps/cluster_roles/templates/psp.yml.j2
@@ -1,0 +1,77 @@
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: restricted
+  annotations:
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
+{% if apparmor_enabled %}
+    apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
+{% endif %}
+  labels:
+    kubernetes.io/cluster-service: 'true'
+    addonmanager.kubernetes.io/mode: Reconcile
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  requiredDropCapabilities:
+    - ALL
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    - 'persistentVolumeClaim'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'MustRunAsNonRoot'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: privileged
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+spec:
+  privileged: true
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - '*'
+  volumes:
+  - '*'
+  hostNetwork: true
+  hostPorts:
+  - min: 0
+    max: 65535
+  hostIPC: true
+  hostPID: true
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+  readOnlyRootFilesystem: false

--- a/roles/kubernetes-apps/external_provisioner/cephfs_provisioner/tasks/main.yml
+++ b/roles/kubernetes-apps/external_provisioner/cephfs_provisioner/tasks/main.yml
@@ -37,20 +37,33 @@
   when:
     - inventory_hostname == groups['kube-master'][0]
 
+- name: CephFS Provisioner | Templates list
+  set_fact:
+    cephfs_provisioner_templates:
+      - { name: 00-namespace, file: 00-namespace.yml, type: ns }
+      - { name: secret-cephfs-provisioner, file: secret-cephfs-provisioner.yml, type: secret }
+      - { name: sa-cephfs-provisioner, file: sa-cephfs-provisioner.yml, type: sa }
+      - { name: clusterrole-cephfs-provisioner, file: clusterrole-cephfs-provisioner.yml, type: clusterrole }
+      - { name: clusterrolebinding-cephfs-provisioner, file: clusterrolebinding-cephfs-provisioner.yml, type: clusterrolebinding }
+      - { name: role-cephfs-provisioner, file: role-cephfs-provisioner.yml, type: role }
+      - { name: rolebinding-cephfs-provisioner, file: rolebinding-cephfs-provisioner.yml, type: rolebinding }
+      - { name: deploy-cephfs-provisioner, file: deploy-cephfs-provisioner.yml, type: deploy }
+      - { name: sc-cephfs-provisioner, file: sc-cephfs-provisioner.yml, type: sc }
+    cephfs_provisioner_templates_for_psp:
+      - { name: psp-cephfs-provisioner, file: psp-cephfs-provisioner.yml, type: psp }
+
+- name: CephFS Provisioner | Append extra templates to CephFS Provisioner Templates list for PodSecurityPolicy
+  set_fact:
+    cephfs_provisioner_templates: "{{ cephfs_provisioner_templates_for_psp + cephfs_provisioner_templates }}"
+  when:
+    - podsecuritypolicy_enabled
+    - cephfs_provisioner_namespace != "kube-system"
+
 - name: CephFS Provisioner | Create manifests
   template:
     src: "{{ item.file }}.j2"
     dest: "{{ kube_config_dir }}/addons/cephfs_provisioner/{{ item.file }}"
-  with_items:
-    - { name: 00-namespace, file: 00-namespace.yml, type: ns }
-    - { name: secret-cephfs-provisioner, file: secret-cephfs-provisioner.yml, type: secret }
-    - { name: sa-cephfs-provisioner, file: sa-cephfs-provisioner.yml, type: sa }
-    - { name: clusterrole-cephfs-provisioner, file: clusterrole-cephfs-provisioner.yml, type: clusterrole }
-    - { name: clusterrolebinding-cephfs-provisioner, file: clusterrolebinding-cephfs-provisioner.yml, type: clusterrolebinding }
-    - { name: role-cephfs-provisioner, file: role-cephfs-provisioner.yml, type: role }
-    - { name: rolebinding-cephfs-provisioner, file: rolebinding-cephfs-provisioner.yml, type: rolebinding }
-    - { name: deploy-cephfs-provisioner, file: deploy-cephfs-provisioner.yml, type: deploy }
-    - { name: sc-cephfs-provisioner, file: sc-cephfs-provisioner.yml, type: sc }
+  with_items: "{{ cephfs_provisioner_templates }}"
   register: cephfs_provisioner_manifests
   when: inventory_hostname == groups['kube-master'][0]
 

--- a/roles/kubernetes-apps/external_provisioner/cephfs_provisioner/templates/clusterrole-cephfs-provisioner.yml.j2
+++ b/roles/kubernetes-apps/external_provisioner/cephfs_provisioner/templates/clusterrole-cephfs-provisioner.yml.j2
@@ -23,3 +23,11 @@ rules:
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "create", "delete"]
+  - apiGroups:
+    - policy
+    resourceNames:
+    - cephfs-provisioner
+    resources:
+    - podsecuritypolicies
+    verbs:
+    - use

--- a/roles/kubernetes-apps/external_provisioner/cephfs_provisioner/templates/psp-cephfs-provisioner.yml.j2
+++ b/roles/kubernetes-apps/external_provisioner/cephfs_provisioner/templates/psp-cephfs-provisioner.yml.j2
@@ -1,0 +1,45 @@
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: cephfs-provisioner
+  annotations:
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
+{% if apparmor_enabled %}
+    apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
+{% endif %}
+  labels:
+    kubernetes.io/cluster-service: 'true'
+    addonmanager.kubernetes.io/mode: Reconcile
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  requiredDropCapabilities:
+    - ALL
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    - 'persistentVolumeClaim'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false

--- a/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/tasks/main.yml
+++ b/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/tasks/main.yml
@@ -19,17 +19,32 @@
     group: root
     mode: 0755
 
+- name: Local Volume Provisioner | Templates list
+  set_fact:
+    local_volume_provisioner_templates:
+      - { name: local-volume-provisioner-ns, file: local-volume-provisioner-ns.yml, type: ns }
+      - { name: local-volume-provisioner-sa, file: local-volume-provisioner-sa.yml, type: sa }
+      - { name: local-volume-provisioner-clusterrolebinding, file: local-volume-provisioner-clusterrolebinding.yml, type: clusterrolebinding }
+      - { name: local-volume-provisioner-cm, file: local-volume-provisioner-cm.yml, type: cm }
+      - { name: local-volume-provisioner-ds, file: local-volume-provisioner-ds.yml, type: ds }
+      - { name: local-volume-provisioner-sc, file: local-volume-provisioner-sc.yml, type: sc }
+    local_volume_provisioner_templates_for_psp_not_system_ns:
+      - { name: local-volume-provisioner-psp, file: local-volume-provisioner-psp.yml, type: psp }
+      - { name: local-volume-provisioner-psp-role, file: local-volume-provisioner-psp-role.yml, type: role }
+      - { name: local-volume-provisioner-psp-rb, file: local-volume-provisioner-psp-rb.yml, type: rolebinding }
+
+- name: Local Volume Provisioner | Insert extra templates to Local Volume Provisioner templates list for PodSecurityPolicy
+  set_fact:
+    local_volume_provisioner_templates: "{{ local_volume_provisioner_templates[:2] + local_volume_provisioner_templates_for_psp_not_system_ns + local_volume_provisioner_templates[3:] }}"
+  when:
+    - podsecuritypolicy_enabled
+    - local_volume_provisioner_namespace != "kube-system"
+
 - name: Local Volume Provisioner | Create manifests
   template:
     src: "{{ item.file }}.j2"
     dest: "{{ kube_config_dir }}/addons/local_volume_provisioner/{{ item.file }}"
-  with_items:
-    - { name: local-volume-provisioner-ns, file: local-volume-provisioner-ns.yml, type: ns }
-    - { name: local-volume-provisioner-sa, file: local-volume-provisioner-sa.yml, type: sa }
-    - { name: local-volume-provisioner-clusterrolebinding, file: local-volume-provisioner-clusterrolebinding.yml, type, clusterrolebinding }
-    - { name: local-volume-provisioner-cm, file: local-volume-provisioner-cm.yml, type, cm }
-    - { name: local-volume-provisioner-ds, file: local-volume-provisioner-ds.yml, type, ds }
-    - { name: local-volume-provisioner-sc, file: local-volume-provisioner-sc.yml, type, sc }
+  with_items: "{{ local_volume_provisioner_templates }}"
   register: local_volume_provisioner_manifests
   when: inventory_hostname == groups['kube-master'][0]
 

--- a/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-psp-cr.yml.j2
+++ b/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-psp-cr.yml.j2
@@ -1,20 +1,13 @@
----
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: calico-node
-  namespace: kube-system
+  name: psp:local-volume-provisioner
+  namespace: {{ local_volume_provisioner_namespace }}
 rules:
-  - apiGroups: [""]
-    resources:
-      - pods
-      - nodes
-    verbs:
-      - get
   - apiGroups:
     - policy
     resourceNames:
-    - privileged
+    - local-volume-provisioner
     resources:
     - podsecuritypolicies
     verbs:

--- a/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-psp-rb.yml.j2
+++ b/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-psp-rb.yml.j2
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: psp:local-volume-provisioner
+  namespace: {{ local_volume_provisioner_namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: local-volume-provisioner
+    namespace: {{ local_volume_provisioner_namespace }}
+roleRef:
+  kind: ClusterRole
+  name: psp:local-volume-provisioner
+  apiGroup: rbac.authorization.k8s.io

--- a/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-psp.yml.j2
+++ b/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-psp.yml.j2
@@ -1,0 +1,44 @@
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: local-volume-provisioner
+  annotations:
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
+{% if apparmor_enabled %}
+    apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
+{% endif %}
+  labels:
+    kubernetes.io/cluster-service: 'true'
+    addonmanager.kubernetes.io/mode: Reconcile
+spec:
+  privileged: true
+  allowPrivilegeEscalation: true
+  requiredDropCapabilities:
+    - ALL
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'secret'
+    - 'downwardAPI'
+    - 'hostPath'
+  allowedHostPaths:
+    - pathPrefix: "{{ local_volume_provisioner_base_dir }}"
+      readOnly: false
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'RunAsAny'
+  readOnlyRootFilesystem: false

--- a/roles/kubernetes-apps/ingress_controller/cert_manager/defaults/main.yml
+++ b/roles/kubernetes-apps/ingress_controller/cert_manager/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 cert_manager_namespace: "cert-manager"
+cert_manager_user: 1001

--- a/roles/kubernetes-apps/ingress_controller/cert_manager/templates/deploy-cert-manager.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/cert_manager/templates/deploy-cert-manager.yml.j2
@@ -39,3 +39,5 @@ spec:
             requests:
               cpu: 10m
               memory: 32Mi
+          securityContext:
+            runAsUser: {{ cert_manager_user }}

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/tasks/main.yml
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/tasks/main.yml
@@ -28,23 +28,34 @@
   when:
     - inventory_hostname == groups['kube-master'][0]
 
+- name: NGINX Ingress Controller | Templates list
+  set_fact:
+    ingress_nginx_templates:
+      - { name: 00-namespace, file: 00-namespace.yml, type: ns }
+      - { name: deploy-default-backend, file: deploy-default-backend.yml, type: deploy }
+      - { name: svc-default-backend, file: svc-default-backend.yml, type: svc }
+      - { name: cm-ingress-nginx, file: cm-ingress-nginx.yml, type: cm }
+      - { name: cm-tcp-services, file: cm-tcp-services.yml, type: cm }
+      - { name: cm-udp-services, file: cm-udp-services.yml, type: cm }
+      - { name: sa-ingress-nginx, file: sa-ingress-nginx.yml, type: sa }
+      - { name: clusterrole-ingress-nginx, file: clusterrole-ingress-nginx.yml, type: clusterrole }
+      - { name: clusterrolebinding-ingress-nginx, file: clusterrolebinding-ingress-nginx.yml, type: clusterrolebinding }
+      - { name: role-ingress-nginx, file: role-ingress-nginx.yml, type: role }
+      - { name: rolebinding-ingress-nginx, file: rolebinding-ingress-nginx.yml, type: rolebinding }
+      - { name: ds-ingress-nginx-controller, file: ds-ingress-nginx-controller.yml, type: ds }
+    ingress_nginx_templates_for_psp:
+      - { name: psp-ingress-nginx, file: psp-ingress-nginx.yml, type: podsecuritypolicy }
+
+- name: NGINX Ingress Controller | Append extra templates to NGINX Ingress Templates list for PodSecurityPolicy
+  set_fact:
+    ingress_nginx_templates: "{{ ingress_nginx_templates_for_psp + ingress_nginx_templates }}"
+  when: podsecuritypolicy_enabled
+
 - name: NGINX Ingress Controller | Create manifests
   template:
     src: "{{ item.file }}.j2"
     dest: "{{ kube_config_dir }}/addons/ingress_nginx/{{ item.file }}"
-  with_items:
-    - { name: 00-namespace, file: 00-namespace.yml, type: ns }
-    - { name: deploy-default-backend, file: deploy-default-backend.yml, type: deploy }
-    - { name: svc-default-backend, file: svc-default-backend.yml, type: svc }
-    - { name: cm-ingress-nginx, file: cm-ingress-nginx.yml, type: cm }
-    - { name: cm-tcp-services, file: cm-tcp-services.yml, type: cm }
-    - { name: cm-udp-services, file: cm-udp-services.yml, type: cm }
-    - { name: sa-ingress-nginx, file: sa-ingress-nginx.yml, type: sa }
-    - { name: clusterrole-ingress-nginx, file: clusterrole-ingress-nginx.yml, type: clusterrole }
-    - { name: clusterrolebinding-ingress-nginx, file: clusterrolebinding-ingress-nginx.yml, type: clusterrolebinding }
-    - { name: role-ingress-nginx, file: role-ingress-nginx.yml, type: role }
-    - { name: rolebinding-ingress-nginx, file: rolebinding-ingress-nginx.yml, type: rolebinding }
-    - { name: ds-ingress-nginx-controller, file: ds-ingress-nginx-controller.yml, type: ds }
+  with_items: "{{ ingress_nginx_templates }}"
   register: ingress_nginx_manifests
   when:
     - inventory_hostname == groups['kube-master'][0]

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/psp-ingress-nginx.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/psp-ingress-nginx.yml.j2
@@ -1,0 +1,48 @@
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: ingress-nginx
+  annotations:
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
+{% if apparmor_enabled %}
+    apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
+{% endif %}
+  labels:
+    kubernetes.io/cluster-service: 'true'
+    addonmanager.kubernetes.io/mode: Reconcile
+spec:
+  privileged: false
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+    - NET_BIND_SERVICE
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    - 'persistentVolumeClaim'
+  hostNetwork: {{ ingress_nginx_host_network|bool }}
+  hostPorts:
+  - min: 0
+    max: 65535
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'MustRunAsNonRoot'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/role-ingress-nginx.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/role-ingress-nginx.yml.j2
@@ -22,3 +22,11 @@ rules:
   - apiGroups: [""]
     resources: ["endpoints"]
     verbs: ["get"]
+  - apiGroups:
+    - policy
+    resourceNames:
+    - ingress-nginx
+    resources:
+    - podsecuritypolicies
+    verbs:
+    - use

--- a/roles/kubernetes-apps/registry/tasks/main.yml
+++ b/roles/kubernetes-apps/registry/tasks/main.yml
@@ -8,15 +8,35 @@
     group: root
     mode: 0755
 
+- name: Registry | Templates list
+  set_fact:
+    registry_templates:
+      - { name: registry-ns, file: registry-ns.yml, type: ns }
+      - { name: registry-sa, file: registry-sa.yml, type: sa }
+      - { name: registry-proxy-sa, file: registry-proxy-sa.yml, type: sa }
+      - { name: registry-svc, file: registry-svc.yml, type: svc }
+      - { name: registry-rs, file: registry-rs.yml, type: rs }
+      - { name: registry-proxy-ds, file: registry-proxy-ds.yml, type: ds }
+    registry_templates_for_psp:
+      - { name: registry-psp, file: registry-psp.yml, type: psp }
+      - { name: registry-cr, file: registry-cr.yml, type: clusterrole }
+      - { name: registry-crb, file: registry-crb.yml, type: rolebinding }
+      - { name: registry-proxy-psp, file: registry-proxy-psp.yml, type: psp }
+      - { name: registry-proxy-cr, file: registry-proxy-cr.yml, type: clusterrole }
+      - { name: registry-proxy-crb, file: registry-proxy-crb.yml, type: rolebinding }
+
+- name: Registry | Append extra templates to Registry Templates list for PodSecurityPolicy
+  set_fact:
+    registry_templates: "{{ registry_templates[:3] + registry_templates_for_psp + registry_templates[4:] }}"
+  when:
+    - podsecuritypolicy_enabled
+    - registry_namespace != "kube-system"
+
 - name: Registry | Create manifests
   template:
     src: "{{ item.file }}.j2"
     dest: "{{ kube_config_dir }}/addons/registry/{{ item.file }}"
-  with_items:
-    - { name: registry-ns, file: registry-ns.yml, type: ns }
-    - { name: registry-svc, file: registry-svc.yml, type: svc }
-    - { name: registry-rs, file: registry-rs.yml, type: rs }
-    - { name: registry-proxy-ds, file: registry-proxy-ds.yml, type: ds }
+  with_items: "{{ registry_templates }}"
   register: registry_manifests
   when: inventory_hostname == groups['kube-master'][0]
 

--- a/roles/kubernetes-apps/registry/templates/registry-cr.yml.j2
+++ b/roles/kubernetes-apps/registry/templates/registry-cr.yml.j2
@@ -1,20 +1,14 @@
 ---
-kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
 metadata:
-  name: calico-node
-  namespace: kube-system
+  name: psp:registry
+  namespace: {{ registry_namespace }}
 rules:
-  - apiGroups: [""]
-    resources:
-      - pods
-      - nodes
-    verbs:
-      - get
   - apiGroups:
     - policy
     resourceNames:
-    - privileged
+    - registry
     resources:
     - podsecuritypolicies
     verbs:

--- a/roles/kubernetes-apps/registry/templates/registry-crb.yml.j2
+++ b/roles/kubernetes-apps/registry/templates/registry-crb.yml.j2
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: psp:registry
+  namespace: {{ registry_namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: registry
+    namespace: {{ registry_namespace }}
+roleRef:
+  kind: ClusterRole
+  name: psp:registry
+  apiGroup: rbac.authorization.k8s.io

--- a/roles/kubernetes-apps/registry/templates/registry-proxy-cr.yml.j2
+++ b/roles/kubernetes-apps/registry/templates/registry-proxy-cr.yml.j2
@@ -1,20 +1,14 @@
 ---
-kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
 metadata:
-  name: calico-node
-  namespace: kube-system
+  name: psp:registry-proxy
+  namespace: {{ registry_namespace }}
 rules:
-  - apiGroups: [""]
-    resources:
-      - pods
-      - nodes
-    verbs:
-      - get
   - apiGroups:
     - policy
     resourceNames:
-    - privileged
+    - registry-proxy
     resources:
     - podsecuritypolicies
     verbs:

--- a/roles/kubernetes-apps/registry/templates/registry-proxy-crb.yml.j2
+++ b/roles/kubernetes-apps/registry/templates/registry-proxy-crb.yml.j2
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: psp:registry-proxy
+  namespace: {{ registry_namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: registry-proxy
+    namespace: {{ registry_namespace }}
+roleRef:
+  kind: ClusterRole
+  name: psp:registry-proxy
+  apiGroup: rbac.authorization.k8s.io

--- a/roles/kubernetes-apps/registry/templates/registry-proxy-ds.yml.j2
+++ b/roles/kubernetes-apps/registry/templates/registry-proxy-ds.yml.j2
@@ -21,9 +21,7 @@ spec:
         kubernetes.io/cluster-service: "true"
         version: v{{ registry_proxy_image_tag }}
     spec:
-{% if rbac_enabled %}
       serviceAccountName: registry-proxy
-{% endif %}
       containers:
         - name: registry-proxy
           image: {{ registry_proxy_image_repo }}:{{ registry_proxy_image_tag }}

--- a/roles/kubernetes-apps/registry/templates/registry-proxy-ds.yml.j2
+++ b/roles/kubernetes-apps/registry/templates/registry-proxy-ds.yml.j2
@@ -21,6 +21,9 @@ spec:
         kubernetes.io/cluster-service: "true"
         version: v{{ registry_proxy_image_tag }}
     spec:
+{% if rbac_enabled %}
+      serviceAccountName: registry-proxy
+{% endif %}
       containers:
         - name: registry-proxy
           image: {{ registry_proxy_image_repo }}:{{ registry_proxy_image_tag }}

--- a/roles/kubernetes-apps/registry/templates/registry-proxy-psp.yml.j2
+++ b/roles/kubernetes-apps/registry/templates/registry-proxy-psp.yml.j2
@@ -1,0 +1,48 @@
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: registry-proxy
+  annotations:
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
+{% if apparmor_enabled %}
+    apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
+{% endif %}
+  labels:
+    kubernetes.io/cluster-service: 'true'
+    addonmanager.kubernetes.io/mode: Reconcile
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  requiredDropCapabilities:
+    - ALL
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    - 'persistentVolumeClaim'
+  hostNetwork: true
+  hostPorts:
+  - min: 5000
+    max: 5000
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false

--- a/roles/kubernetes-apps/registry/templates/registry-proxy-sa.yml.j2
+++ b/roles/kubernetes-apps/registry/templates/registry-proxy-sa.yml.j2
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: registry-proxy
+  namespace: {{ registry_namespace }}
+  labels:
+    kubernetes.io/cluster-service: "true"

--- a/roles/kubernetes-apps/registry/templates/registry-psp.yml.j2
+++ b/roles/kubernetes-apps/registry/templates/registry-psp.yml.j2
@@ -1,0 +1,45 @@
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: registry
+  annotations:
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
+{% if apparmor_enabled %}
+    apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
+{% endif %}
+  labels:
+    kubernetes.io/cluster-service: 'true'
+    addonmanager.kubernetes.io/mode: Reconcile
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  requiredDropCapabilities:
+    - ALL
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    - 'persistentVolumeClaim'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false

--- a/roles/kubernetes-apps/registry/templates/registry-rs.yml.j2
+++ b/roles/kubernetes-apps/registry/templates/registry-rs.yml.j2
@@ -22,9 +22,7 @@ spec:
         version: v{{ registry_image_tag }}
         kubernetes.io/cluster-service: "true"
     spec:
-{% if rbac_enabled %}
       serviceAccountName: registry
-{% endif %}
       containers:
         - name: registry
           image: {{ registry_image_repo }}:{{ registry_image_tag }}

--- a/roles/kubernetes-apps/registry/templates/registry-rs.yml.j2
+++ b/roles/kubernetes-apps/registry/templates/registry-rs.yml.j2
@@ -22,6 +22,9 @@ spec:
         version: v{{ registry_image_tag }}
         kubernetes.io/cluster-service: "true"
     spec:
+{% if rbac_enabled %}
+      serviceAccountName: registry
+{% endif %}
       containers:
         - name: registry
           image: {{ registry_image_repo }}:{{ registry_image_tag }}

--- a/roles/kubernetes-apps/registry/templates/registry-sa.yml.j2
+++ b/roles/kubernetes-apps/registry/templates/registry-sa.yml.j2
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: registry
+  namespace: {{ registry_namespace }}
+  labels:
+    kubernetes.io/cluster-service: "true"

--- a/roles/kubernetes/master/defaults/main.yml
+++ b/roles/kubernetes/master/defaults/main.yml
@@ -32,7 +32,7 @@ audit_log_path: /var/log/audit/kube-apiserver-audit.log
 audit_log_maxage: 30
 # the num of audit logs to retain
 audit_log_maxbackups: 1
- # the max size in MB to retain
+# the max size in MB to retain
 audit_log_maxsize: 100
 # policy file
 audit_policy_file: "{{ kube_config_dir }}/audit-policy/apiserver-audit-policy.yaml"

--- a/roles/kubernetes/master/tasks/main.yml
+++ b/roles/kubernetes/master/tasks/main.yml
@@ -52,6 +52,12 @@
     - kubectl
     - upgrade
 
+- name: Disable SecurityContextDeny admission-controller and enable PodSecurityPolicy
+  set_fact:
+    kube_apiserver_admission_control: "{{ kube_apiserver_admission_control | default([]) | difference(['SecurityContextDeny']) | union(['PodSecurityPolicy']) | unique }}"
+    kube_apiserver_enable_admission_plugins: "{{ kube_apiserver_enable_admission_plugins | difference(['SecurityContextDeny']) | union(['PodSecurityPolicy']) | unique }}"
+  when: podsecuritypolicy_enabled
+
 - name: Include kubeadm setup if enabled
   import_tasks: kubeadm-setup.yml
   when: kubeadm_enabled|bool|default(false)

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -363,3 +363,5 @@ etcd_events_peer_addresses: |-
   {% for item in groups['etcd'] -%}
     {{ "etcd"+loop.index|string }}-events=https://{{ hostvars[item].access_ip | default(hostvars[item].ip | default(hostvars[item].ansible_default_ipv4['address'])) }}:2382{% if not loop.last %},{% endif %}
   {%- endfor %}
+
+podsecuritypolicy_enabled: false

--- a/roles/network_plugin/canal/templates/canal-cr-calico.yml.j2
+++ b/roles/network_plugin/canal/templates/canal-cr-calico.yml.j2
@@ -78,3 +78,11 @@ rules:
     verbs:
       - get
       - list
+  - apiGroups:
+    - policy
+    resourceNames:
+    - privileged
+    resources:
+    - podsecuritypolicies
+    verbs:
+    - use

--- a/roles/network_plugin/canal/templates/canal-cr-flannel.yml.j2
+++ b/roles/network_plugin/canal/templates/canal-cr-flannel.yml.j2
@@ -24,3 +24,11 @@ rules:
       - nodes/status
     verbs:
       - patch
+  - apiGroups:
+    - policy
+    resourceNames:
+    - privileged
+    resources:
+    - podsecuritypolicies
+    verbs:
+    - use

--- a/roles/network_plugin/cilium/templates/cilium-cr.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium-cr.yml.j2
@@ -64,3 +64,11 @@ rules:
       - ciliumendpoints/status
     verbs:
       - "*"
+  - apiGroups:
+    - policy
+    resourceNames:
+    - privileged
+    resources:
+    - podsecuritypolicies
+    verbs:
+    - use

--- a/roles/network_plugin/contiv/templates/contiv-netmaster-clusterrole.yml.j2
+++ b/roles/network_plugin/contiv/templates/contiv-netmaster-clusterrole.yml.j2
@@ -16,3 +16,11 @@ rules:
       - watch
       - list
       - update
+  - apiGroups:
+    - policy
+    resourceNames:
+    - privileged
+    resources:
+    - podsecuritypolicies
+    verbs:
+    - use

--- a/roles/network_plugin/contiv/templates/contiv-netplugin-clusterrole.yml.j2
+++ b/roles/network_plugin/contiv/templates/contiv-netplugin-clusterrole.yml.j2
@@ -19,3 +19,11 @@ rules:
       - list
       - update
       - get
+  - apiGroups:
+    - policy
+    resourceNames:
+    - privileged
+    resources:
+    - podsecuritypolicies
+    verbs:
+    - use

--- a/roles/network_plugin/flannel/templates/cni-flannel-rbac.yml.j2
+++ b/roles/network_plugin/flannel/templates/cni-flannel-rbac.yml.j2
@@ -29,6 +29,14 @@ rules:
       - nodes/status
     verbs:
       - patch
+  - apiGroups:
+    - policy
+    resourceNames:
+    - privileged
+    resources:
+    - podsecuritypolicies
+    verbs:
+    - use
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/roles/network_plugin/weave/templates/weave-net.yml.j2
+++ b/roles/network_plugin/weave/templates/weave-net.yml.j2
@@ -41,6 +41,14 @@ items:
         verbs:
           - patch
           - update
+      - apiGroups:
+        - policy
+        resourceNames:
+        - privileged
+        resources:
+        - podsecuritypolicies
+        verbs:
+        - use
   - apiVersion: rbac.authorization.k8s.io/v1beta1
     kind: ClusterRoleBinding
     metadata:


### PR DESCRIPTION
What this PR is about:
- Pod security policies stuff installation (policies definitions, update of mainfests to use these policies, ...) is triggered when podsecuritypolicy_enabled is true
- Through the 2 main pod security policies (privileged and restricted) defined, kube-system scope is privileged, any other namespace is restricted
- Network plugins have been updated to use the privileged policy
- Netchecker has been updated: SA for hostnet agent w/ dedicated policy, securitycontext (i.e. netchecker_(server|agent)_user and netchecker_(server|agent)_group), CR and CRB
- SecurityContextDeny admission controller is disabled when PodSecurityPolicy is enabled
- Supersedes PR #3039 