### PR TITLE
Use delegate_to: localhost instead of local_action

### DIFF
--- a/roles/kubernetes/preinstall/tasks/pre_upgrade.yml
+++ b/roles/kubernetes/preinstall/tasks/pre_upgrade.yml
@@ -1,28 +1,23 @@
 ---
 - name: "Pre-upgrade | check if old credential dir exists"
-  local_action:
-    module: stat
+  stat:
     path: "{{ inventory_dir }}/../credentials"
-  vars:
-    ansible_python_interpreter: "/usr/bin/env python"
+  delegate_to: localhost
   register: old_credential_dir
   become: no
 
 - name: "Pre-upgrade | check if new credential dir exists"
-  local_action:
-    module: stat
+  stat:
     path: "{{ inventory_dir }}/credentials"
-  vars:
-    ansible_python_interpreter: "/usr/bin/env python"
+  delegate_to: localhost
   register: new_credential_dir
   become: no
   when: old_credential_dir.stat.exists
 
 - name: "Pre-upgrade | move data from old credential dir to new"
-  local_action: command mv {{ inventory_dir }}/../credentials {{ inventory_dir }}/credentials
+  command: mv {{ inventory_dir }}/../credentials {{ inventory_dir }}/credentials
   args:
     creates: "{{ inventory_dir }}/credentials"
-  vars:
-    ansible_python_interpreter: "/usr/bin/env python"
+  delegate_to: localhost
   become: no
   when: old_credential_dir.stat.exists and not new_credential_dir.stat.exists

--- a/roles/kubernetes/preinstall/tasks/pre_upgrade.yml
+++ b/roles/kubernetes/preinstall/tasks/pre_upgrade.yml
@@ -20,4 +20,6 @@
     creates: "{{ inventory_dir }}/credentials"
   delegate_to: localhost
   become: no
-  when: old_credential_dir.stat.exists and not new_credential_dir.stat.exists
+  when:
+    - old_credential_dir.stat.exists
+    - not new_credential_dir.stat.exists


### PR DESCRIPTION
Allow to use `ansible_become: true` (#2969).

I personally integrate `kubespray` as-is and don't make any modification to it:

```yaml
# My own playbook wraps kubespray
...
- import_playbook: kubespray_cluster.yml
# symlink to vendor/kubespray/cluster.yml
# allows to relocate the `playbook_dir` var
# so it can find my group_vars/host_vars
...
```

`import_playbook` doesn't support the `become` attribute, my workaround consists in  setting `ansible_become: true` for all hosts in the cluster via the `group_vars` and setting it to `false` for `localhost` in its `host_vars`.

More generally, it allows to configure the behaviors of the tasks run on `localhost` (e.g. `ansible_python_interpreter`, ...).

This is also consistent with the rest of `kubespray` which only uses `delegate to: localhost` (except a few test playbooks that I haven't touched)