### PR TITLE
Move network_plugin specific reset tasks to its role directory 

### DIFF
--- a/roles/network_plugin/cilium/tasks/reset.yml
+++ b/roles/network_plugin/cilium/tasks/reset.yml
@@ -1,0 +1,9 @@
+---
+- name: reset | check and remove devices if still present
+  include_tasks: reset_iface.yml
+  vars:
+    iface: "{{ item }}"
+  with_items:
+    - cilium_host
+    - cilium_net
+    - cilium_vxlan

--- a/roles/network_plugin/cilium/tasks/reset_iface.yml
+++ b/roles/network_plugin/cilium/tasks/reset_iface.yml
@@ -1,0 +1,9 @@
+---
+- name: "reset | check if network device {{ iface }} is present"
+  stat:
+    path: "/sys/class/net/{{ iface }}"
+  register: device_remains
+
+- name: "reset | remove network device {{ iface }}"
+  command: "ip link del {{ iface }}"
+  when: device_remains.stat.exists

--- a/roles/network_plugin/flannel/tasks/reset.yml
+++ b/roles/network_plugin/flannel/tasks/reset.yml
@@ -1,0 +1,18 @@
+---
+- name: reset | check cni network device
+  stat:
+    path: /sys/class/net/cni0
+  register: cni
+
+- name: reset | remove the network device created by the flannel
+  command: ip link del cni0
+  when: cni.stat.exists
+
+- name: reset | check flannel network device
+  stat:
+    path: /sys/class/net/flannel.1
+  register: flannel
+
+- name: reset | remove the network device created by the flannel
+  command: ip link del flannel.1
+  when: flannel.stat.exists

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -169,7 +169,8 @@
 
 - name: reset | include file with reset tasks specific to the network_plugin if exists
   include_tasks: "{{ (role_path + '/../network_plugin/' + kube_network_plugin + '/tasks/reset.yml') | realpath  }}"
-  when: kube_network_plugin in ['flannel', 'cilium']
+  when:
+    - kube_network_plugin in ['flannel', 'cilium']
   tags:
     - network
 

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -167,33 +167,11 @@
     - files
     - dns
 
-- name: reset | check cni network device
-  stat:
-    path: /sys/class/net/cni0
-  register: cni
-  when: kube_network_plugin == 'flannel'
+- name: reset | include file with reset tasks specific to the network_plugin if exists
+  include_tasks: "{{ (role_path + '/../network_plugin/' + kube_network_plugin + '/tasks/reset.yml') | realpath  }}"
+  when: kube_network_plugin in ['flannel', 'cilium']
   tags:
-    - flannel
-
-- name: reset | remove the network device created by the flannel
-  command: ip link del cni0
-  when: kube_network_plugin == 'flannel' and cni.stat.exists
-  tags:
-    - flannel
-
-- name: reset | check flannel network device
-  stat:
-    path: /sys/class/net/flannel.1
-  register: flannel
-  when: kube_network_plugin == 'flannel'
-  tags:
-    - flannel
-
-- name: reset | remove the network device created by the flannel
-  command: ip link del flannel.1
-  when: kube_network_plugin == 'flannel' and flannel.stat.exists
-  tags:
-    - flannel
+    - network
 
 - name: reset | Restart network
   service:


### PR DESCRIPTION
Initially, I wanted to remove cilium devices at reset time (which I added to this PR) but I thought it could be cleaner to include specific tasks if a file exists instead of using a when in roles/reset/tasks/reset.yml