### PR TITLE
cert-manager: Upgrade to 0.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Supported Components
     -   [weave](https://github.com/weaveworks/weave) v2.4.0
 -   Application
     -   [cephfs-provisioner](https://github.com/kubernetes-incubator/external-storage) v1.1.0-k8s1.10
-    -   [cert-manager](https://github.com/jetstack/cert-manager) v0.4.0
+    -   [cert-manager](https://github.com/jetstack/cert-manager) v0.4.1
     -   [ingress-nginx](https://github.com/kubernetes/ingress-nginx) v0.18.0
 
 Note: kubernetes doesn't support newer docker versions. Among other things kubelet currently breaks on docker's non-standard version numbering (it no longer uses semantic versioning). To ensure auto-updates don't break your cluster look into e.g. yum versionlock plugin or apt pin).

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -141,7 +141,7 @@ ingress_nginx_controller_image_repo: "quay.io/kubernetes-ingress-controller/ngin
 ingress_nginx_controller_image_tag: "0.18.0"
 ingress_nginx_default_backend_image_repo: "gcr.io/google_containers/defaultbackend"
 ingress_nginx_default_backend_image_tag: "1.4"
-cert_manager_version: "v0.4.0"
+cert_manager_version: "v0.4.1"
 cert_manager_controller_image_repo: "quay.io/jetstack/cert-manager-controller"
 cert_manager_controller_image_tag: "{{ cert_manager_version }}"
 

--- a/roles/kubernetes-apps/ingress_controller/cert_manager/defaults/main.yml
+++ b/roles/kubernetes-apps/ingress_controller/cert_manager/defaults/main.yml
@@ -1,6 +1,2 @@
 ---
 cert_manager_namespace: "cert-manager"
-cert_manager_cpu_requests: 10m
-cert_manager_cpu_limits: 30m
-cert_manager_memory_requests: 32Mi
-cert_manager_memory_limits: 200Mi

--- a/roles/kubernetes-apps/ingress_controller/cert_manager/templates/clusterrole-cert-manager.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/cert_manager/templates/clusterrole-cert-manager.yml.j2
@@ -5,7 +5,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0
+    chart: cert-manager-v0.4.1
     release: cert-manager
     heritage: Tiller
 rules:

--- a/roles/kubernetes-apps/ingress_controller/cert_manager/templates/clusterrolebinding-cert-manager.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/cert_manager/templates/clusterrolebinding-cert-manager.yml.j2
@@ -5,7 +5,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0
+    chart: cert-manager-v0.4.1
     release: cert-manager
     heritage: Tiller
 roleRef:

--- a/roles/kubernetes-apps/ingress_controller/cert_manager/templates/crd-certificate.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/cert_manager/templates/crd-certificate.yml.j2
@@ -5,7 +5,7 @@ metadata:
   name: certificates.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0
+    chart: cert-manager-v0.4.1
     release: cert-manager
     heritage: Tiller
 spec:

--- a/roles/kubernetes-apps/ingress_controller/cert_manager/templates/crd-clusterissuer.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/cert_manager/templates/crd-clusterissuer.yml.j2
@@ -5,7 +5,7 @@ metadata:
   name: clusterissuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0
+    chart: cert-manager-v0.4.1
     release: cert-manager
     heritage: Tiller
 spec:

--- a/roles/kubernetes-apps/ingress_controller/cert_manager/templates/crd-issuer.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/cert_manager/templates/crd-issuer.yml.j2
@@ -5,7 +5,7 @@ metadata:
   name: issuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0
+    chart: cert-manager-v0.4.1
     release: cert-manager
     heritage: Tiller
 spec:

--- a/roles/kubernetes-apps/ingress_controller/cert_manager/templates/deploy-cert-manager.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/cert_manager/templates/deploy-cert-manager.yml.j2
@@ -6,19 +6,19 @@ metadata:
   namespace: {{ cert_manager_namespace }}
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0
+    chart: cert-manager-v0.4.1
     release: cert-manager
     heritage: Tiller
 spec:
   replicas: 1
   selector:
     matchLabels:
-      k8s-app: cert-manager
+      app: cert-manager
       release: cert-manager
   template:
     metadata:
       labels:
-        k8s-app: cert-manager
+        app: cert-manager
         release: cert-manager
       annotations:
     spec:
@@ -37,8 +37,5 @@ spec:
                   fieldPath: metadata.namespace
           resources:
             requests:
-              cpu: {{ cert_manager_cpu_requests }}
-              memory: {{ cert_manager_memory_requests }}
-            limits:
-              cpu: {{ cert_manager_cpu_limits }}
-              memory: {{ cert_manager_memory_limits }}
+              cpu: 10m
+              memory: 32Mi

--- a/roles/kubernetes-apps/ingress_controller/cert_manager/templates/sa-cert-manager.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/cert_manager/templates/sa-cert-manager.yml.j2
@@ -6,6 +6,6 @@ metadata:
   namespace: {{ cert_manager_namespace }}
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0
+    chart: cert-manager-v0.4.1
     release: cert-manager
     heritage: Tiller


### PR DESCRIPTION
Upstream Changes:

-   cert-manager 0.4.1 (https://github.com/jetstack/cert-manager/releases/tag/v0.4.1)

Our Changes:

-   Better templates sync with upstream manifests
-   Remove fancy resources requests/limits customization