### PR TITLE
Audit support improvement

### DIFF
--- a/roles/kubernetes/master/defaults/main.yml
+++ b/roles/kubernetes/master/defaults/main.yml
@@ -26,6 +26,7 @@ force_etcd3: false
 
 # audit support
 kubernetes_audit: false
+# audit_log_path must not be set to "-" with kubeadm as it only handles a logfile named audit.log
 audit_log_path: /var/log/audit/kube-apiserver-audit.log
 # num days
 audit_log_maxage: 30
@@ -39,12 +40,11 @@ audit_policy_file: "{{ kube_config_dir }}/audit-policy/apiserver-audit-policy.ya
 # audit log hostpath
 audit_log_name: audit-logs
 audit_log_hostpath: /var/log/kubernetes/audit
-audit_log_mountpath: /var/log/audit
-audit_log_writable: true
+audit_log_mountpath: "{{ audit_log_path | dirname }}"
 
 # audit policy hostpath
 audit_policy_name: audit-policy
-audit_policy_hostpath: /etc/kubernetes/audit-policy
+audit_policy_hostpath: "{{ audit_policy_file | dirname }}"
 audit_policy_mountpath: "{{ audit_policy_hostpath }}"
 
 # Limits for kube components

--- a/roles/kubernetes/master/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-setup.yml
@@ -66,13 +66,15 @@
   changed_when: false
 
 - name: Create audit-policy directory
-  file: path={{ kube_config_dir }}/audit-policy state=directory
+  file:
+    path: "{{ audit_policy_file | dirname }}"
+    state: directory
   when: kubernetes_audit|default(false)
 
 - name: Write api audit policy yaml
   template:
     src: apiserver-audit-policy.yaml.j2
-    dest: "{{ kube_config_dir }}/audit-policy/apiserver-audit-policy.yaml"
+    dest: "{{ audit_policy_file }}"
   when: kubernetes_audit|default(false)
 
 - name: gets the kubeadm version

--- a/roles/kubernetes/master/tasks/static-pod-setup.yml
+++ b/roles/kubernetes/master/tasks/static-pod-setup.yml
@@ -1,6 +1,8 @@
 ---
 - name: Create audit-policy directory
-  file: path={{ kube_config_dir }}/audit-policy state=directory
+  file:
+    path: "{{ audit_policy_file | dirname }}"
+    state: directory
   tags:
     - kube-apiserver
   when: kubernetes_audit|default(false)
@@ -8,7 +10,7 @@
 - name: Write api audit policy yaml
   template:
     src: apiserver-audit-policy.yaml.j2
-    dest: "{{ kube_config_dir }}/audit-policy/apiserver-audit-policy.yaml"
+    dest: "{{ audit_policy_file }}"
   notify: Master | Restart apiserver
   tags:
     - kube-apiserver

--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha2.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha2.yaml.j2
@@ -14,7 +14,7 @@ etcd:
       keyFile: {{ kube_config_dir }}/ssl/etcd/node-{{ inventory_hostname }}-key.pem
 {% if kubernetes_audit %}
 auditPolicy:
-  logDir: {{ audit_log_path }}
+  logDir: {{ audit_log_mountpath }}
   logMaxAge: {{ audit_log_maxage }}
   path: {{ audit_policy_file }}
 {% endif %}
@@ -93,6 +93,9 @@ apiServerExtraVolumes:
 - name: {{ audit_policy_name }}
   hostPath: {{ audit_policy_hostpath }}
   mountPath: {{ audit_policy_mountpath }}
+- name: {{ audit_log_name }}
+  hostPath: {{ audit_log_hostpath }}
+  mountPath: {{ audit_log_mountpath }}
 {% endif %}
 {% if cloud_provider is defined and cloud_provider in ["openstack"] and openstack_cacert is defined %}
 controllerManagerExtraVolumes:

--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha2.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha2.yaml.j2
@@ -14,7 +14,7 @@ etcd:
       keyFile: {{ kube_config_dir }}/ssl/etcd/node-{{ inventory_hostname }}-key.pem
 {% if kubernetes_audit %}
 auditPolicy:
-  logDir: {{ audit_log_mountpath }}
+  logDir: {{ audit_log_hostpath }}
   logMaxAge: {{ audit_log_maxage }}
   path: {{ audit_policy_file }}
 {% endif %}
@@ -88,15 +88,6 @@ controllerManagerExtraArgs:
   node-monitor-grace-period: {{ kube_controller_node_monitor_grace_period }}
   node-monitor-period: {{ kube_controller_node_monitor_period }}
   pod-eviction-timeout: {{ kube_controller_pod_eviction_timeout }}
-{% if kubernetes_audit %}
-apiServerExtraVolumes:
-- name: {{ audit_policy_name }}
-  hostPath: {{ audit_policy_hostpath }}
-  mountPath: {{ audit_policy_mountpath }}
-- name: {{ audit_log_name }}
-  hostPath: {{ audit_log_hostpath }}
-  mountPath: {{ audit_log_mountpath }}
-{% endif %}
 {% if cloud_provider is defined and cloud_provider in ["openstack"] and openstack_cacert is defined %}
 controllerManagerExtraVolumes:
 - name: openstackcacert

--- a/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
@@ -193,12 +193,13 @@ spec:
       readOnly: true
 {% endif %}
 {% if kubernetes_audit %}
+{% if audit_log_path != "-" %}
     - mountPath: {{ audit_log_mountpath }}
       name: {{ audit_log_name }}
       Writable: true
+{% endif %}
     - mountPath: {{ audit_policy_mountpath }}
       name: {{ audit_policy_name }}
-      Writable: true
 {% endif %}
   volumes:
   - hostPath:
@@ -221,9 +222,11 @@ spec:
     name: rhel-ca-bundle
 {% endif %}
 {% if kubernetes_audit %}
+{% if audit_log_path != "-" %}
   - hostPath:
       path: {{ audit_log_hostpath }}
     name: {{ audit_log_name }}
+{% endif %}
   - hostPath:
       path: {{ audit_policy_hostpath }}
     name: {{ audit_policy_name }}


### PR DESCRIPTION
What this PR is about:
- Minor variable reuses instead of redefinitions
- Do not mount when audit_log_path is set to stdout ("-")
- Do not mount when kubeadm is used (as it mounts itself from the host cf. https://github.com/kubernetes/kubernetes/blob/32dc6cc08aa0349d44aa3109f0a718cbb51fb101/cmd/kubeadm/app/phases/controlplane/volumes.go)
- Makes policy volume not writeable

Caveat: Setting audit_log_path to "-" when using kubeadm would certainly end up with failures. kubeadm only supports log files. NB: the destination file seems to be hardcoded to "audit.log" (https://github.com/kubernetes/kubernetes/blob/master/cmd/kubeadm/app/phases/controlplane/manifests.go)

Follow-up to PR #3113