### PR TITLE
add ignore_patterns to ansible.cfg

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -13,3 +13,5 @@ callback_whitelist = profile_tasks
 roles_path = roles:$VIRTUAL_ENV/usr/local/share/kubespray/roles:$VIRTUAL_ENV/usr/local/share/ansible/roles:/usr/share/kubespray/roles
 deprecation_warnings=False
 inventory_ignore_extensions = ~, .orig, .bak, .ini, .cfg, .retry, .pyc, .pyo, .creds
+[inventory]
+ignore_patterns = artifacts


### PR DESCRIPTION
To avoid warning message when artifacts is generated within
the inventory directory

when verbose = "v"

expected behavior:

```
Using /Users/hoatle/k8s-dev/workspace/kubespray/ansible.cfg as config file
```

actual behavior:
```
Using /Users/hoatle/k8s-dev/workspace/kubespray/ansible.cfg as config file
 [WARNING]:  * Failed to parse /Users/hoatle/k8s-
dev/.vagrant/provisioners/ansible/inventory/artifacts/admin.conf with ini
plugin: /Users/hoatle/k8s-
dev/.vagrant/provisioners/ansible/inventory/artifacts/admin.conf:1: Expected
key=value host variable assignment, got: v1

 [WARNING]: Unable to parse /Users/hoatle/k8s-
dev/.vagrant/provisioners/ansible/inventory/artifacts/admin.conf as an
inventory source

 [WARNING]: Unable to parse /Users/hoatle/k8s-
dev/.vagrant/provisioners/ansible/inventory/artifacts as an inventory source
```

