### PR TITLE
resolve issues with new cacert feature

### DIFF
--- a/roles/kubernetes/node/tasks/main.yml
+++ b/roles/kubernetes/node/tasks/main.yml
@@ -157,6 +157,20 @@
     - cloud-provider
     - facts
 
+- name: Write cacert file
+  copy:
+    src: "{{ openstack_cacert }}"
+    dest: "{{ kube_config_dir }}/openstack-cacert.pem"
+    group: "{{ kube_cert_group }}"
+    mode: 0640
+  when:
+    - inventory_hostname in groups['k8s-cluster']
+    - cloud_provider is defined
+    - cloud_provider in [ 'openstack', 'azure', 'vsphere' ]
+    - openstack_cacert is defined
+  tags:
+    - cloud-provider
+
 - name: Write cloud-config
   template:
     src: "{{ cloud_provider }}-cloud-config.j2"

--- a/roles/kubernetes/preinstall/tasks/main.yml
+++ b/roles/kubernetes/preinstall/tasks/main.yml
@@ -311,17 +311,3 @@
     - ansible_distribution in ["CentOS","RedHat"]
   tags:
     - bootstrap-os
-
-- name: Write cacert file
-  copy:
-    content: "{{ openstack_cacert }}"
-    dest: "{{ kube_config_dir }}/openstack-cacert.pem"
-    group: "{{ kube_cert_group }}"
-    mode: 0640
-  when:
-    - inventory_hostname in groups['k8s-cluster']
-    - cloud_provider is defined
-    - cloud_provider in [ 'openstack', 'azure', 'vsphere' ]
-    - openstack_cacert is defined
-  tags:
-    - cloud-provider


### PR DESCRIPTION
- Moved cacert copy clause from kubernetes/pre-install to kubernetes/node role
- Replaced content option with src option as the OS_CACERT points to a file