### PR TITLE
add until option for etcd backup commands

### DIFF
--- a/roles/etcd/handlers/backup.yml
+++ b/roles/etcd/handlers/backup.yml
@@ -39,6 +39,8 @@
   environment:
     ETCDCTL_API: 2
   retries: 3
+  register: backup_v2_command
+  until: backup_v2_command.rc == 0
   delay: "{{ retry_stagger | random + 3 }}"
 
 - name: Backup etcd v3 data
@@ -51,4 +53,6 @@
     ETCDCTL_CERT: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}.pem"
     ETCDCTL_KEY: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}-key.pem"
   retries: 3
+  register: etcd_backup_v3_command
+  until: etcd_backup_v3_command.rc == 0
   delay: "{{ retry_stagger | random + 3 }}"


### PR DESCRIPTION
In order to use the `retries` option, `until` must be set. https://docs.ansible.com/ansible/2.5/user_guide/playbooks_loops.html#do-until-loops:
`If the until parameter isn’t defined, the value for the retries parameter is forced to 1.`

This PR adds until option for the ETCD commands backup