### PR TITLE
scaling: issue etcd certs for new nodes

### DIFF
--- a/scale.yml
+++ b/scale.yml
@@ -22,6 +22,13 @@
     ansible_ssh_pipelining: true
   gather_facts: true
 
+##We need to genereate the etcd certificates beforhand
+- hosts: etcd
+  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  roles:
+  - { role: kubespray-defaults}
+  - { role: etcd, tags: etcd, etcd_cluster_setup: false }
+
 ##Target only workers to get kubelet installed and checking in on any new nodes
 - hosts: kube-node
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"


### PR DESCRIPTION
we need to generate new etcd certs for the new kube-nodes.

related to: #2867 #2883 and merge request #2820

honors the change from @woopstar for  gen_cert.

mark