### PR TITLE
Fix k8s-dns-dnsmasq-nanny repo path

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -104,7 +104,7 @@ kubedns_image_tag: "{{ kubedns_version }}"
 coredns_version: 1.2.0
 coredns_image_repo: "docker.io/coredns/coredns"
 coredns_image_tag: "{{ coredns_version }}"
-dnsmasq_nanny_image_repo: "gcr.io/google_containers/k8s-dns-dnsmasq-nanny--{{ image_arch }}"
+dnsmasq_nanny_image_repo: "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-{{ image_arch }}"
 dnsmasq_nanny_image_tag: "{{ kubedns_version }}"
 dnsmasq_sidecar_image_repo: "gcr.io/google_containers/k8s-dns-sidecar-{{ image_arch }}"
 dnsmasq_sidecar_image_tag: "{{ kubedns_version }}"


### PR DESCRIPTION
Remove extra '-' from k8s-dns-dnsmasq-nanny repo path introduced in 1081f620.