### PR TITLE
Custom audit policy

### DIFF
--- a/roles/kubernetes/master/defaults/main.yml
+++ b/roles/kubernetes/master/defaults/main.yml
@@ -36,6 +36,12 @@ audit_log_maxbackups: 1
 audit_log_maxsize: 100
 # policy file
 audit_policy_file: "{{ kube_config_dir }}/audit-policy/apiserver-audit-policy.yaml"
+# custom audit policy rules (to replace the default ones)
+# audit_policy_custom_rules: >
+#   - level: None
+#     users: []
+#     verbs: []
+#     resources: []
 
 # audit log hostpath
 audit_log_name: audit-logs

--- a/roles/kubernetes/master/templates/apiserver-audit-policy.yaml.j2
+++ b/roles/kubernetes/master/templates/apiserver-audit-policy.yaml.j2
@@ -1,6 +1,9 @@
 apiVersion: audit.k8s.io/v1beta1
 kind: Policy
 rules:
+{% if audit_policy_custom_rules is defined and audit_policy_custom_rules != "" -%}
+{{ audit_policy_custom_rules | indent(2, true) }}
+{% else %}
   # The following requests were manually identified as high-volume and low-risk,
   # so drop them.
   - level: None
@@ -123,3 +126,4 @@ rules:
   - level: Metadata
     omitStages:
       - "RequestReceived"
+{% endif %}


### PR DESCRIPTION
When defining the `audit_policy_custom_rules` variable, it will be rendered as the `rules` field of the policy file instead of the default rules.
`audit_policy_custom_rules` must be a raw indented string as shown in the commented example.

Should fix #3127