### PR TITLE
Add bad hostname preflight check

### DIFF
--- a/roles/kubernetes/preinstall/tasks/verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/verify-settings.yml
@@ -103,3 +103,9 @@
     that: ansible_kernel.split('-')[0]|version_compare('4.8', '>=')
   when: kube_network_plugin == 'cilium'
   ignore_errors: "{{ ignore_assert_errors }}"
+
+- name: Stop if bad hostname
+  assert:
+    that: inventory_hostname | match("[a-z0-9]([-a-z0-9]*[a-z0-9])?$")
+    msg: "Hostname must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character"
+  ignore_errors: "{{ ignore_assert_errors }}"


### PR DESCRIPTION
Hostname must be a valid DNS name, which is checked as https://github.com/kubernetes/apimachinery/blob/master/pkg/util/validation/validation.go#L115

The situation I have encountered is that my hostname contained underscore which is disallowed and apiserver refused to start.