### PR TITLE
allow '.' in hostnames for verify bad hostnames

### DIFF
--- a/roles/kubernetes/preinstall/tasks/verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/verify-settings.yml
@@ -106,6 +106,6 @@
 
 - name: Stop if bad hostname
   assert:
-    that: inventory_hostname | match("[a-z0-9]([-a-z0-9]*[a-z0-9])?$")
-    msg: "Hostname must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character"
+    that: inventory_hostname | match("[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$")
+    msg: "Hostname must consist of lower case alphanumeric characters, '.' or '-', and must start and end with an alphanumeric character"
   ignore_errors: "{{ ignore_assert_errors }}"


### PR DESCRIPTION
we use FQDN as inventory_hostname, without `.` we get errros

Mark