### PR TITLE
add support for openstack trust to cloud provider config

### DIFF
--- a/roles/kubernetes/node/tasks/openstack-credential-check.yml
+++ b/roles/kubernetes/node/tasks/openstack-credential-check.yml
@@ -21,5 +21,12 @@
 
 - name: check openstack_tenant_id value
   fail:
-    msg: "openstack_tenant_id is missing"
-  when: openstack_tenant_id is not defined or openstack_tenant_id == ""
+    msg: "one of openstack_tenant_id or openstack_trust_id must be specified"
+  when: (openstack_tenant_id is not defined or openstack_tenant_id == "") and
+        openstack_trust_id is not defined
+
+- name: check openstack_trust_id value
+  fail:
+    msg: "one of openstack_tenant_id or openstack_trust_id must be specified"
+  when: (openstack_trust_id is not defined or openstack_trust_id == "") and
+        openstack_tenant_id is not defined

--- a/roles/kubernetes/node/templates/openstack-cloud-config.j2
+++ b/roles/kubernetes/node/templates/openstack-cloud-config.j2
@@ -3,7 +3,11 @@ auth-url="{{ openstack_auth_url }}"
 username="{{ openstack_username }}"
 password="{{ openstack_password }}"
 region="{{ openstack_region }}"
+{% if openstack_trust_id is defined and openstack_trust_id != "" %}
+trust-id="{{ openstack_trust_id }}"
+{% else %}
 tenant-id="{{ openstack_tenant_id }}"
+{% endif %}
 {% if openstack_tenant_name is defined and openstack_tenant_name != "" %}
 tenant-name="{{ openstack_tenant_name }}"
 {% endif %}


### PR DESCRIPTION
This allows you to create an account with no permissions for use by the openstack cloud provider through the use of a trust relationship.  This implements the feature request made in issue #3124.