### PR TITLE
Fix node labels at Python 3

### DIFF
--- a/roles/kubernetes/node/templates/kubelet.standard.env.j2
+++ b/roles/kubernetes/node/templates/kubelet.standard.env.j2
@@ -96,7 +96,7 @@ KUBELET_HOSTNAME="--hostname-override={{ kube_override_hostname }}"
 {% endif %}
 {% set inventory_node_labels = [] %}
 {% if node_labels is defined %}
-{%   for labelname, labelvalue in node_labels.iteritems() %}
+{%   for labelname, labelvalue in node_labels.items() %}
 {%     set dummy = inventory_node_labels.append('%s=%s'|format(labelname, labelvalue)) %}
 {%   endfor %}
 {% endif %}


### PR DESCRIPTION
Fixes the apply of custom labels on cluster nodes if Python 3 is used (#2843).
https://github.com/kubernetes-incubator/kubespray/issues/2843#issuecomment-395572952
