### PR TITLE
fix the output of router_id with the right id

### DIFF
--- a/contrib/terraform/openstack/modules/network/outputs.tf
+++ b/contrib/terraform/openstack/modules/network/outputs.tf
@@ -1,4 +1,8 @@
 output "router_id" {
+  value = "${openstack_networking_router_v2.k8s.id}"
+}
+
+output "router_internal_port_id" {
   value = "${openstack_networking_router_interface_v2.k8s.id}"
 }
 


### PR DESCRIPTION
router_id doesn't match the ID of the router. Instead it matches the internal port's ID.
This is confusing and, imo, wrong.

Let's have a router_id output with the correct router's id and another output with the router's internal port's ID.