### PR TITLE
new cilium stable version: 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Supported Components
 -   Network Plugin
     -   [calico](https://github.com/projectcalico/calico) v2.6.8
     -   [canal](https://github.com/projectcalico/canal) (given calico/flannel versions)
-    -   [cilium](https://github.com/cilium/cilium) v1.1.2
+    -   [cilium](https://github.com/cilium/cilium) v1.2.0
     -   [contiv](https://github.com/contiv/install) v1.1.7
     -   [flanneld](https://github.com/coreos/flannel) v0.10.0
     -   [weave](https://github.com/weaveworks/weave) v2.4.0

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -43,7 +43,7 @@ vault_version: 0.10.1
 weave_version: "2.4.0"
 pod_infra_version: 3.0
 contiv_version: 1.1.7
-cilium_version: "v1.1.2"
+cilium_version: "v1.2.0"
 
 # Download URLs
 kubeadm_download_url: "https://storage.googleapis.com/kubernetes-release/release/{{ kubeadm_version }}/bin/linux/{{ image_arch }}/kubeadm"


### PR DESCRIPTION
From Cilium:

Cilium *1.2.0* has been released! :tada:

*Major Features:*
o DNS/FQDN based security policies
o AWS EKS support (guide: http://cilium.io/eks)
o Integrated etcd operator
o BGP support via kube-router integration
o Pod networking & security across Kubernetes clusters (ClusterMesh)

For more details, examples and guides, see the release blog:
https://cilium.io/blog/2018/08/21/cilium-12

*Release:*
Binaries: https://github.com/cilium/cilium/releases/tag/v1.2.0
Container image: `cilium/cilium:v1.2.0`