### PR TITLE
--nodeport-addresses added on kube-proxy.manifest.j2 and on k8s-cluster.yml

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s-cluster.yml
@@ -110,6 +110,11 @@ kube_apiserver_insecure_port: 8080 # (http)
 # Can be ipvs, iptables
 kube_proxy_mode: iptables
 
+# Kube-proxy nodeport address.
+# cidr to bind nodeport services. Flag --nodeport-addresses on kube-proxy manifest
+kube_proxy_nodeport_addresses: false
+# kube_proxy_nodeport_addresses_cidr: 10.0.1.0/24
+
 ## Encrypting Secret Data at Rest (experimental)
 kube_encrypt_secret_data: false
 

--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha1.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha1.yaml.j2
@@ -27,6 +27,9 @@ kubeProxy:
   config:
     featureGates: SupportIPVSProxyMode=true
     mode: ipvs
+{% if kube_proxy_nodeport_addresses %}
+    nodePortAddresses: [{{ kube_proxy_nodeport_addresses_cidr }}]
+{% endif %}
 {% endif %}
 authorizationModes:
 {% for mode in authorization_modes %}

--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha1.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha1.yaml.j2
@@ -22,14 +22,14 @@ kubernetesVersion: {{ kube_version }}
 {% if cloud_provider is defined and cloud_provider != "gce" %}
 cloudProvider: {{ cloud_provider }}
 {% endif %}
-{% if kube_proxy_mode == 'ipvs' and kube_version | version_compare('v1.10', '<') %}
 kubeProxy:
   config:
+{% if kube_proxy_mode == 'ipvs' and kube_version | version_compare('v1.10', '<') %}
     featureGates: SupportIPVSProxyMode=true
     mode: ipvs
+{% endif %}
 {% if kube_proxy_nodeport_addresses %}
     nodePortAddresses: [{{ kube_proxy_nodeport_addresses_cidr }}]
-{% endif %}
 {% endif %}
 authorizationModes:
 {% for mode in authorization_modes %}

--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha2.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha2.yaml.j2
@@ -27,6 +27,9 @@ kubeProxy:
   config:
     mode: {{ kube_proxy_mode }}
     hostnameOverride: {{ inventory_hostname }}
+{% if kube_proxy_nodeport_addresses %}
+    nodePortAddresses: [{{ kube_proxy_nodeport_addresses_cidr }}]
+{% endif %}
 authorizationModes:
 {% for mode in authorization_modes %}
 - {{ mode }}

--- a/roles/kubernetes/node/templates/manifests/kube-proxy.manifest.j2
+++ b/roles/kubernetes/node/templates/manifests/kube-proxy.manifest.j2
@@ -43,6 +43,9 @@ spec:
     - --proxy-mode={{ kube_proxy_mode }}
     - --oom-score-adj=-998
     - --healthz-bind-address={{ kube_proxy_healthz_bind_address }}
+{% if kube_proxy_nodeport_addresses %}
+    - --nodeport-addresses={{ kube_proxy_nodeport_addresses_cidr }}
+{% endif %}
 {% if kube_proxy_masquerade_all and kube_proxy_mode == "iptables" %}
     - --masquerade-all
 {% elif kube_proxy_mode == 'ipvs' %}


### PR DESCRIPTION
Hi, i'm using kubespray to provision a cluster on hetzner cloud, and using internal vpn addresses i needed kube-proxy to use that cidr for nodeports instead of all interfaces. 

I added two variables on `k8s-cluster.yml` and a condition on `kube-proxy.manifest.j2`

Info about `--nodeport-addresses` flag: 
* https://kubernetes.io/docs/concepts/services-networking/service/
* https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy/

Tested on hetzner cloud with terraform

![schermata 2018-08-22 alle 15 20 22](https://user-images.githubusercontent.com/25492971/44465818-f1289b00-a61e-11e8-93fd-1a91dfe8fea1.png)
