### PR TITLE
Fix for #3168.

### DIFF
--- a/roles/kubernetes/node/tasks/main.yml
+++ b/roles/kubernetes/node/tasks/main.yml
@@ -43,7 +43,7 @@
     - kubelet
     - kubeadm
 
-- name: write the kubecfg (auth) file for kubelet
+- name: Write the kubecfg (auth) file for kubelet
   template:
     src: "{{ item }}-kubeconfig.yaml.j2"
     dest: "{{ kube_config_dir }}/{{ item }}-kubeconfig.yaml"
@@ -53,6 +53,15 @@
     - kube-proxy
   when: not kubeadm_enabled
   notify: restart kubelet
+  tags:
+    - kubelet
+
+- name: Ensure kubelet.conf exists
+  file:
+    src: "{{ kube_config_dir }}/node-kubeconfig.yaml"
+    dest: "{{ kube_config_dir }}/kubelet.conf"
+    state: link
+  when: not kubeadm_enabled
   tags:
     - kubelet
 

--- a/roles/network_plugin/calico/templates/cni-calico.conflist.j2
+++ b/roles/network_plugin/calico/templates/cni-calico.conflist.j2
@@ -28,11 +28,7 @@
       "mtu": {{ calico_mtu }},
     {%- endif %}
       "kubernetes": {
-    {% if kubeadm_enabled %}
         "kubeconfig": "{{ kube_config_dir }}/kubelet.conf"
-    {% else %}
-        "kubeconfig": "{{ kube_config_dir }}/node-kubeconfig.yaml"
-    {%- endif %}
       }
     },
     {

--- a/roles/network_plugin/calico/templates/cni-calico.conflist.j2
+++ b/roles/network_plugin/calico/templates/cni-calico.conflist.j2
@@ -28,7 +28,11 @@
       "mtu": {{ calico_mtu }},
     {%- endif %}
       "kubernetes": {
+    {% if kubeadm_enabled %}
+        "kubeconfig": "{{ kube_config_dir }}/kubelet.conf"
+    {% else %}
         "kubeconfig": "{{ kube_config_dir }}/node-kubeconfig.yaml"
+    {%- endif %}
       }
     },
     {

--- a/roles/network_plugin/canal/templates/cni-canal.conflist.j2
+++ b/roles/network_plugin/canal/templates/cni-canal.conflist.j2
@@ -15,7 +15,11 @@
           "type": "k8s"
         },
         "kubernetes": {
+        {% if kubeadm_enabled %}
+          "kubeconfig": "{{ kube_config_dir }}/kubelet.conf"
+        {% else %}
           "kubeconfig": "{{ kube_config_dir }}/node-kubeconfig.yaml"
+        {%- endif %}
         }
       }
     },

--- a/roles/network_plugin/canal/templates/cni-canal.conflist.j2
+++ b/roles/network_plugin/canal/templates/cni-canal.conflist.j2
@@ -15,11 +15,7 @@
           "type": "k8s"
         },
         "kubernetes": {
-        {% if kubeadm_enabled %}
           "kubeconfig": "{{ kube_config_dir }}/kubelet.conf"
-        {% else %}
-          "kubeconfig": "{{ kube_config_dir }}/node-kubeconfig.yaml"
-        {%- endif %}
         }
       }
     },


### PR DESCRIPTION
Fixes #3168, pointing the calico and canal CNI configuration to the correct kubelet kubeconfig based on kubeadm or standard install mode.