### PR TITLE
Fix createhome directory for adduser role

### DIFF
--- a/roles/adduser/tasks/main.yml
+++ b/roles/adduser/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: User | Create User
   user:
     comment: "{{user.comment|default(omit)}}"
-    createhome: "{{user.create_home|default(omit)}}"
+    createhome: "{{user.createhome|default(omit)}}"
     group: "{{user.group|default(user.name)}}"
     home: "{{user.home|default(omit)}}"
     shell: "{{user.shell|default(omit)}}"


### PR DESCRIPTION
A typo in the adduser role prevents the createhome
variable to be taken into account.

Fix #3164