### PR TITLE
Mount /root/.kube to helm container

### DIFF
--- a/roles/kubernetes-apps/helm/templates/helm-container.j2
+++ b/roles/kubernetes-apps/helm/templates/helm-container.j2
@@ -2,6 +2,7 @@
 {{ docker_bin_dir }}/docker run --rm \
   --net=host \
   --name=helm \
+  -v /root/.kube:/root/.kube:ro \
   -v /etc/ssl:/etc/ssl:ro \
   -v {{ helm_home_dir }}:{{ helm_home_dir }}:rw \
   {% for dir in ssl_ca_dirs -%}


### PR DESCRIPTION
When `helm_deployment` is set to `docker` and `kube_apiserver_insecure_port` is set to `0`, `helm init` fails as it can't read /root/.kube/config (like when `helm_deployment` is set to `host` ) and falls back to connecting to localhost:8080 (i.e. API server insecure interface).
In order to make it work, /root/.kube must be mounted (it will also make helm docker deployment closer to helm host deployment)