### PR TITLE
Fix localhost handling when /etc/hosts contains parenthesis

### DIFF
--- a/roles/kubernetes/preinstall/tasks/etchosts.yml
+++ b/roles/kubernetes/preinstall/tasks/etchosts.yml
@@ -30,12 +30,12 @@
 - name: Hosts | Extract existing entries for localhost from hosts file
   set_fact:
     etc_hosts_localhosts_dict: >-
-       {%- set splitted = (item | regex_replace('[ ]+', ' ')|regex_replace('#.+$')|trim).split( ' ') -%}
+       {%- set splitted = (item | regex_replace('[ \t]+', ' ')|regex_replace('#.*$')|trim).split( ' ') -%}
        {{ etc_hosts_localhosts_dict|default({}) | combine({splitted[0]: splitted[1::] }) }}
   with_items: "{{ (etc_hosts_content['content'] | b64decode).split('\n') }}"
   when:
     - etc_hosts_content.content is defined
-    - etc_hosts_localhost_entries.keys()|map('regex_replace', '(.*)', '^\\1 .*') | map('match', item) | list | length > 0
+    - (item|match('^::1 .*') or item|match('^127.0.0.1 .*'))
 
 - name: Hosts | Update target hosts file entries dict with required entries
   set_fact:


### PR DESCRIPTION
Fix wrong when condition that ends up with jinja error when the content of /etc/hosts contains parenthesis.
