### PR TITLE
Fix kubeadm-config for audit-log-path and feature-gates

### DIFF
--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha2.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha2.yaml.j2
@@ -82,11 +82,14 @@ apiServerExtraArgs:
 {% endif %}
   allow-privileged: "true"
 {% if kubernetes_audit %}
-  audit-log-path: {{ audit_log_path }}
+  audit-log-path: "{{ audit_log_path }}"
   audit-log-maxage: "{{ audit_log_maxage }}"
   audit-log-maxbackup: "{{ audit_log_maxbackups }}"
   audit-log-maxsize: "{{ audit_log_maxsize }}"
   audit-policy-file: {{ audit_policy_file }}
+{% endif %}
+{% if kube_feature_gates %}
+  feature-gates: {{ kube_feature_gates|join(',') }}
 {% endif %}
 {% for key in kube_kubeadm_apiserver_extra_args %}
   {{ key }}: "{{ kube_kubeadm_apiserver_extra_args[key] }}"
@@ -112,9 +115,6 @@ apiServerExtraVolumes:
   mountPath: {{ audit_log_mountpath }}
   writable: true
 {% endif %}
-{% endif %}
-{% if kube_feature_gates %}
-  feature-gates: {{ kube_feature_gates|join(',') }}
 {% endif %}
 {% for key in kube_kubeadm_controller_extra_args %}
   {{ key }}: "{{ kube_kubeadm_controller_extra_args[key] }}"


### PR DESCRIPTION
What this PR is about:
- It adds quotes to the value of `audit-log-path` (prevent the error `unable to decode config from bytes: couldn't unmarshal YAML: yaml: line 42: block sequence entries are not allowed in this context` from happening at `kubeadm init`)
- It moves the `feature-gates` field to the `apiServerExtraArgs` section as it should be