### PR TITLE
canal should mount xtables.lock to share the lock with other processe…

### DIFF
--- a/roles/network_plugin/canal/templates/canal-node.yaml.j2
+++ b/roles/network_plugin/canal/templates/canal-node.yaml.j2
@@ -51,6 +51,10 @@ spec:
         - name: "canal-certs"
           hostPath:
             path: "{{ canal_cert_dir }}"
+        - name: xtables-lock
+          hostPath:
+            path: /run/xtables.lock
+            type: FileOrCreate
       containers:
         # Runs the flannel daemon to enable vxlan networking between
         # container hosts.
@@ -128,6 +132,9 @@ spec:
             - name: "canal-certs"
               mountPath: "{{ canal_cert_dir }}"
               readOnly: true
+            - name: xtables-lock
+              mountPath: /run/xtables.lock
+              readOnly: false
         # Runs calico/node container on each Kubernetes node.  This
         # container programs network policy and local routes on each
         # host.


### PR DESCRIPTION
This fixes https://github.com/kubernetes-incubator/kubespray/issues/3192 by making canal-node's flannel container to mount xtables.lock  from host as it should be a shared lock. Ow, when there're a high number of pods, there are chances that will make iptables commands fail when both kube-proxy and flannel run at the same time. 