### PR TITLE
Fix some addons when PodSecurityPolicy is enabled

### DIFF
--- a/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/tasks/main.yml
+++ b/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/tasks/main.yml
@@ -35,7 +35,7 @@
 
 - name: Local Volume Provisioner | Insert extra templates to Local Volume Provisioner templates list for PodSecurityPolicy
   set_fact:
-    local_volume_provisioner_templates: "{{ local_volume_provisioner_templates[:2] + local_volume_provisioner_templates_for_psp_not_system_ns + local_volume_provisioner_templates[3:] }}"
+    local_volume_provisioner_templates: "{{ local_volume_provisioner_templates[:2] + local_volume_provisioner_templates_for_psp_not_system_ns + local_volume_provisioner_templates[2:] }}"
   when:
     - podsecuritypolicy_enabled
     - local_volume_provisioner_namespace != "kube-system"

--- a/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-psp-role.yml.j2
+++ b/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-psp-role.yml.j2
@@ -1,0 +1,15 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: psp:local-volume-provisioner
+  namespace: {{ local_volume_provisioner_namespace }}
+rules:
+  - apiGroups:
+    - policy
+    resourceNames:
+    - local-volume-provisioner
+    resources:
+    - podsecuritypolicies
+    verbs:
+    - use

--- a/roles/kubernetes-apps/registry/tasks/main.yml
+++ b/roles/kubernetes-apps/registry/tasks/main.yml
@@ -27,7 +27,7 @@
 
 - name: Registry | Append extra templates to Registry Templates list for PodSecurityPolicy
   set_fact:
-    registry_templates: "{{ registry_templates[:3] + registry_templates_for_psp + registry_templates[4:] }}"
+    registry_templates: "{{ registry_templates[:3] + registry_templates_for_psp + registry_templates[3:] }}"
   when:
     - podsecuritypolicy_enabled
     - registry_namespace != "kube-system"


### PR DESCRIPTION
What this PR is about:
- Add a missing template for local-volume-provisioner-role when podsecuritypolicy_enabled=true (Fix #3188 )
- Fix wrong jinja syntax for sub list extraction when podsecuritypolicy_enabled (local-volume-provisioner and registry)