### PR TITLE
Enable kubeadm test

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -358,6 +358,17 @@ gce_centos7-flannel-addons:
   except: ['triggers']
   only: [/^pr-.*$/]
 
+gce_centos-weave-kubeadm:
+  stage: deploy-part2
+  <<: *job
+  <<: *gce
+  variables:
+    <<: *gce_variables
+    <<: *centos_weave_kubeadm_variables
+  when: on_success
+  except: ['triggers']
+  only: [/^pr-.*$/]
+
 gce_ubuntu-weave-sep:
   stage: deploy-part2
   <<: *job
@@ -453,17 +464,6 @@ gce_ubuntu-canal-kubeadm-triggers:
     <<: *ubuntu_canal_kubeadm_variables
   when: on_success
   only: ['triggers']
-
-gce_centos-weave-kubeadm:
-  stage: deploy-part2
-  <<: *job
-  <<: *gce
-  variables:
-    <<: *gce_variables
-    <<: *centos_weave_kubeadm_variables
-  when: manual
-  except: ['triggers']
-  only: ['master', /^pr-.*$/]
 
 gce_centos-weave-kubeadm-triggers:
   stage: deploy-part2


### PR DESCRIPTION
Need to test the kubeadm deployment cluster, most of the functional changes, will involve kubeadm.