### PR TITLE
Fix target hosts generation when /etc/hosts does not contain 127.0.0.1 or ::1

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0090-etchosts.yml
+++ b/roles/kubernetes/preinstall/tasks/0090-etchosts.yml
@@ -40,7 +40,7 @@
 - name: Hosts | Update target hosts file entries dict with required entries
   set_fact:
     etc_hosts_localhosts_dict_target: >-
-      {%- set target_entries = etc_hosts_localhosts_dict.get(item.key, []) | difference(item.value.get('unexpected' ,[])) -%}
+      {%- set target_entries = (etc_hosts_localhosts_dict|default({})).get(item.key, []) | difference(item.value.get('unexpected' ,[])) -%}
       {{ etc_hosts_localhosts_dict_target|default({}) | combine({item.key: (target_entries + item.value.expected)|unique}) }}
   with_dict: "{{ etc_hosts_localhost_entries }}"
 


### PR DESCRIPTION
Fix #3206 