### PR TITLE
Add documentation about having HA for etcd

### DIFF
--- a/docs/ha-mode.md
+++ b/docs/ha-mode.md
@@ -11,12 +11,32 @@ achieve the same goal.
 Etcd
 ----
 
-The `etcd_access_endpoint` fact provides an access pattern for clients. And the
-`etcd_multiaccess` (defaults to `True`) group var controls that behavior.
-It makes deployed components to access the etcd cluster members
-directly: `http://ip1:2379, http://ip2:2379,...`. This mode assumes the clients
-do a loadbalancing and handle HA for connections.
+In order to use an external loadbalancing (L4/TCP or L7 w/ SSL Passthrough VIP), the following variables need to be overriden in group_vars
+* `etcd_access_addresses`
+* `etcd_client_url`
+* `etcd_cert_alt_names`
+* `etcd_cert_alt_ips`
 
+### Example of a VIP w/ FQDN
+```yaml
+etcd_access_addresses: https://etcd.example.com:2379
+etcd_client_url: https://etcd.example.com:2379
+etcd_cert_alt_names:
+  - "etcd.kube-system.svc.{{ dns_domain }}"
+  - "etcd.kube-system.svc"
+  - "etcd.kube-system"
+  - "etcd"
+  - "etcd.example.com" # This one needs to be added to the default etcd_cert_alt_names
+```
+
+### Example of a VIP w/o FQDN (IP only)
+
+```yaml
+etcd_access_addresses: https://2.3.7.9:2379
+etcd_client_url: https://2.3.7.9:2379
+etcd_cert_alt_ips:
+  - "2.3.7.9"
+```
 
 Kube-apiserver
 --------------

--- a/inventory/sample/group_vars/all.yml
+++ b/inventory/sample/group_vars/all.yml
@@ -14,12 +14,6 @@ bin_dir: /usr/local/bin
 ## but don't know about that address themselves.
 #access_ip: 1.1.1.1
 
-### LOADBALANCING AND ACCESS MODES
-## Enable multiaccess to configure etcd clients to access all of the etcd members directly
-## as the "http://hostX:port, http://hostY:port, ..." and ignore the proxy loadbalancers.
-## This may be the case if clients support and loadbalance multiple etcd servers natively.
-#etcd_multiaccess: true
-
 ### ETCD: disable peer client cert authentication.
 # This affects ETCD_PEER_CLIENT_CERT_AUTH variable
 #etcd_peer_client_auth: true

--- a/roles/etcd/defaults/main.yml
+++ b/roles/etcd/defaults/main.yml
@@ -20,6 +20,7 @@ etcd_cert_alt_names:
   - "etcd.kube-system.svc"
   - "etcd.kube-system"
   - "etcd"
+etcd_cert_alt_ips: []
 
 etcd_script_dir: "{{ bin_dir }}/etcd-scripts"
 

--- a/roles/etcd/tasks/gen_certs_vault.yml
+++ b/roles/etcd/tasks/gen_certs_vault.yml
@@ -26,6 +26,9 @@
         "{{ hostvars[host]['ip'] }}",
         {%- endif -%}
         {%- endfor -%}
+        {%- for cert_alt_ip in etcd_cert_alt_ips -%}
+        "{{ cert_alt_ip }}",
+        {%- endfor -%}
         "127.0.0.1","::1"
         ]
     issue_cert_path: "{{ item }}"

--- a/roles/etcd/templates/openssl.conf.j2
+++ b/roles/etcd/templates/openssl.conf.j2
@@ -39,4 +39,7 @@ IP.{{ counter["ip"] }} = {{ hostvars[host]['access_ip'] }}{{ increment(counter, 
 {% endif %}
 IP.{{ counter["ip"] }} = {{ hostvars[host]['ip'] | default(hostvars[host]['ansible_default_ipv4']['address']) }}{{ increment(counter, 'ip') }}
 {% endfor %}
+{% for cert_alt_ip in etcd_cert_alt_ips %}
+IP.{{ counter["ip"] }} = {{ cert_alt_ip }}{{ increment(counter, 'ip') }}
+{% endfor %}
 IP.{{ counter["ip"] }} = 127.0.0.1


### PR DESCRIPTION
This is the current setup I use (w/ FQDN), the playbook completes (I'm not an etcd expert and further tests will show it is not a good idea...).

BTW, I removed references to `etcd_multiaccess` and `etcd_access_endpoint` as they are not used anywhere anymore