### PR TITLE
coredns: Upgrade to v1.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Supported Components
 -   Application
     -   [cephfs-provisioner](https://github.com/kubernetes-incubator/external-storage) v2.0.1-k8s1.11
     -   [cert-manager](https://github.com/jetstack/cert-manager) v0.4.1
+    -   [coredns](https://github.com/coredns/coredns) v1.2.2
     -   [ingress-nginx](https://github.com/kubernetes/ingress-nginx) v0.18.0
 
 Note: kubernetes doesn't support newer docker versions. Among other things kubelet currently breaks on docker's non-standard version numbering (it no longer uses semantic versioning). To ensure auto-updates don't break your cluster look into e.g. yum versionlock plugin or apt pin).

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -109,7 +109,7 @@ kubedns_version: 1.14.10
 kubedns_image_repo: "gcr.io/google_containers/k8s-dns-kube-dns-{{ image_arch }}"
 kubedns_image_tag: "{{ kubedns_version }}"
 
-coredns_version: "{%- if image_arch != 'amd64' -%}1.1.3{%- else -%}1.2.0{%- endif -%}"
+coredns_version: "{%- if image_arch != 'amd64' -%}1.1.3{%- else -%}1.2.2{%- endif -%}"
 coredns_image_repo: "gcr.io/google-containers/coredns"
 coredns_image_tag: "{{ coredns_version }}{%- if image_arch != 'amd64' -%}__{{ image_arch}}_linux{%- endif -%}"
 


### PR DESCRIPTION
Upstream Changes:

-   coredns v1.2.2 (https://github.com/coredns/coredns/releases/tag/v1.2.2)

NOTE:

-   coredns image for 1.2.0 and 1.2.1 had been removed from https://console.cloud.google.com/gcr/images/google-containers/GLOBAL/coredns