### PR TITLE
Introducing credentials_dir variable in order to be able to override it

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -14,4 +14,4 @@ roles_path = roles:$VIRTUAL_ENV/usr/local/share/kubespray/roles:$VIRTUAL_ENV/usr
 deprecation_warnings=False
 inventory_ignore_extensions = ~, .orig, .bak, .ini, .cfg, .retry, .pyc, .pyo, .creds
 [inventory]
-ignore_patterns = artifacts
+ignore_patterns = artifacts, credentials

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -89,7 +89,7 @@ authentication. One could generate a kubeconfig based on one installed
 kube-master hosts (needs improvement) or connect with a username and password.
 By default, a user with admin rights is created, named `kube`.
 The password can be viewed after deployment by looking at the file
-`PATH_TO_KUBESPRAY/credentials/kube_user.creds`. This contains a randomly generated
+`{{ credentials_dir }}/kube_user.creds` (`credentials_dir` is set to `{{ inventory_dir }}/credentials` by default). This contains a randomly generated
 password. If you wish to set your own password, just precreate/modify this
 file yourself.
 

--- a/docs/vars.md
+++ b/docs/vars.md
@@ -145,6 +145,6 @@ The possible vars are:
 
 By default, a user with admin rights is created, named `kube`.
 The password can be viewed after deployment by looking at the file
-`PATH_TO_KUBESPRAY/credentials/kube_user.creds`. This contains a randomly generated
+`{{ credentials_dir }}/kube_user.creds` (`credentials_dir` is set to `{{ inventory_dir }}/credentials` by default). This contains a randomly generated
 password. If you wish to set your own password, just precreate/modify this
 file yourself or change `kube_api_pwd` var.

--- a/inventory/sample/group_vars/k8s-cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s-cluster/k8s-cluster.yml
@@ -34,9 +34,12 @@ kube_cert_group: kube-cert
 # Cluster Loglevel configuration
 kube_log_level: 2
 
+# Directory where credentials will be stored
+credentials_dir: "{{ inventory_dir }}/credentials"
+
 # Users to create for basic auth in Kubernetes API via HTTP
 # Optionally add groups for user
-kube_api_pwd: "{{ lookup('password', inventory_dir + '/credentials/kube_user.creds length=15 chars=ascii_letters,digits') }}"
+kube_api_pwd: "{{ lookup('password', credentials_dir + '/kube_user.creds length=15 chars=ascii_letters,digits') }}"
 kube_users:
   kube:
     pass: "{{kube_api_pwd}}"

--- a/roles/kubernetes/master/defaults/main.yml
+++ b/roles/kubernetes/master/defaults/main.yml
@@ -132,7 +132,7 @@ volume_cross_zone_attachment: false
 
 ## Encrypting Secret Data at Rest
 kube_encrypt_secret_data: false
-kube_encrypt_token: "{{ lookup('password', inventory_dir + '/credentials/kube_encrypt_token.creds length=32 chars=ascii_letters,digits') }}"
+kube_encrypt_token: "{{ lookup('password', credentials_dir + '/kube_encrypt_token.creds length=32 chars=ascii_letters,digits') }}"
 # Must be either: aescbc, secretbox or aesgcm
 kube_encryption_algorithm: "aescbc"
 

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -175,6 +175,9 @@ kubeconfig_localhost: false
 # Download kubectl onto the host that runs Ansible in {{ bin_dir }}
 kubectl_localhost: false
 
+# Define credentials_dir here so it can be overriden
+credentials_dir: "{{ inventory_dir }}/credentials"
+
 # K8s image pull policy (imagePullPolicy)
 k8s_image_pull_policy: IfNotPresent
 

--- a/roles/vault/defaults/main.yml
+++ b/roles/vault/defaults/main.yml
@@ -122,7 +122,7 @@ vault_pki_mounts:
     roles:
       - name: userpass
         group: userpass
-        password: "{{ lookup('password', inventory_dir + '/credentials/vault/userpass.creds length=15') }}"
+        password: "{{ lookup('password', credentials_dir + '/vault/userpass.creds length=15') }}"
         policy_rules: default
         role_options:
           allow_any_name: true
@@ -136,7 +136,7 @@ vault_pki_mounts:
     roles:
       - name: vault
         group: vault
-        password: "{{ lookup('password', inventory_dir + '/credentials/vault/vault.creds length=15') }}"
+        password: "{{ lookup('password', credentials_dir + '/vault/vault.creds length=15') }}"
         policy_rules: default
         role_options:
           allow_any_name: true
@@ -149,7 +149,7 @@ vault_pki_mounts:
     roles:
       - name: etcd
         group: etcd
-        password: "{{ lookup('password', inventory_dir + '/credentials/vault/etcd.creds length=15') }}"
+        password: "{{ lookup('password', credentials_dir + '/vault/etcd.creds length=15') }}"
         policy_rules: default
         role_options:
           allow_any_name: true
@@ -164,7 +164,7 @@ vault_pki_mounts:
     roles:
       - name: kube-master
         group: kube-master
-        password: "{{ lookup('password', inventory_dir + '/credentials/vault/kube-master.creds length=15') }}"
+        password: "{{ lookup('password', credentials_dir + '/vault/kube-master.creds length=15') }}"
         policy_rules: default
         role_options:
           allow_any_name: true
@@ -172,7 +172,7 @@ vault_pki_mounts:
           organization: "system:masters"
       - name: front-proxy-client
         group: kube-master
-        password: "{{ lookup('password', inventory_dir + '/credentials/vault/kube-proxy.creds length=15') }}"
+        password: "{{ lookup('password', credentials_dir + '/vault/kube-proxy.creds length=15') }}"
         policy_rules: default
         role_options:
           allow_any_name: true
@@ -180,7 +180,7 @@ vault_pki_mounts:
           organization: "system:front-proxy-client"
       - name: kube-node
         group: k8s-cluster
-        password: "{{ lookup('password', inventory_dir + '/credentials/vault/kube-node.creds length=15') }}"
+        password: "{{ lookup('password', credentials_dir + '/vault/kube-node.creds length=15') }}"
         policy_rules: default
         role_options:
           allow_any_name: true
@@ -188,7 +188,7 @@ vault_pki_mounts:
           organization: "system:nodes"
       - name: kube-proxy
         group: k8s-cluster
-        password: "{{ lookup('password', inventory_dir + '/credentials/vault/kube-proxy.creds length=15') }}"
+        password: "{{ lookup('password', credentials_dir + '/vault/kube-proxy.creds length=15') }}"
         policy_rules: default
         role_options:
           allow_any_name: true

--- a/tests/testcases/010_check-apiserver.yml
+++ b/tests/testcases/010_check-apiserver.yml
@@ -6,7 +6,7 @@
     uri:
       url: "https://{{ access_ip | default(ansible_default_ipv4.address) }}:{{ kube_apiserver_port }}/api/v1"
       user: kube
-      password: "{{ lookup('password', inventory_dir + '/credentials/kube_user.creds length=15 chars=ascii_letters,digits') }}"
+      password: "{{ lookup('password', credentials_dir + '/kube_user.creds length=15 chars=ascii_letters,digits') }}"
       validate_certs: no
       status_code: 200,401
     when: not kubeadm_enabled|default(false)


### PR DESCRIPTION
What this PR is about:
- `ignore_patterns` in the inventory section of ansible.cfg now contains "credentials" so that no warning is shown at playbook start
- The `credentials_dir` variable (default is "{{ inventory_dir }} + /credentials") could be overriden. In multiple sources inventories, the `inventory_dir` is set on a per host basis, when one of the sources is a script/binary - let's say - ~/bin, the credentials directory is created in ~/bin...