### PR TITLE
Docker 18.06 for ubuntu versions before bionic

### DIFF
--- a/roles/docker/vars/ubuntu-amd64.yml
+++ b/roles/docker/vars/ubuntu-amd64.yml
@@ -9,6 +9,8 @@ docker_versioned_pkg:
   '1.13': docker-engine=1.13.1-0~ubuntu-{{ ansible_distribution_release|lower }}
   '17.03': docker-ce=17.03.2~ce-0~ubuntu-{{ ansible_distribution_release|lower }}
   '17.09': docker-ce=17.09.0~ce-0~ubuntu-{{ ansible_distribution_release|lower }}
+  '17.12': docker-ce=17.12.1~ce-0~ubuntu-{{ ansible_distribution_release|lower }}
+  '18.06': docker-ce=18.06.1~ce~3-0~ubuntu
   'stable': docker-ce=17.03.2~ce-0~ubuntu-{{ ansible_distribution_release|lower }}
   'edge': docker-ce=17.12.1~ce-0~ubuntu-{{ ansible_distribution_release|lower }}
 

--- a/roles/docker/vars/ubuntu-amd64.yml
+++ b/roles/docker/vars/ubuntu-amd64.yml
@@ -12,7 +12,7 @@ docker_versioned_pkg:
   '17.12': docker-ce=17.12.1~ce-0~ubuntu-{{ ansible_distribution_release|lower }}
   '18.06': docker-ce=18.06.1~ce~3-0~ubuntu
   'stable': docker-ce=17.03.2~ce-0~ubuntu-{{ ansible_distribution_release|lower }}
-  'edge': docker-ce=17.12.1~ce-0~ubuntu-{{ ansible_distribution_release|lower }}
+  'edge': docker-ce=18.06.1~ce~3-0~ubuntu
 
 docker_package_info:
   pkg_mgr: apt


### PR DESCRIPTION
What this PR is about:
- Addition in `docker_versioned_pkg` of an entry for 18.06 (which is also available in trusty, xenial)
- Moving "edge" to 18.06 pkg version (I was not sure if it was the intended behaviour so I added this in a separate commit)