### PR TITLE
Fix configure calico network pool for ipipMode = CrossSubnet

### DIFF
--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -97,7 +97,7 @@
         },
         "spec": {
           "cidr": "{{ kube_pods_subnet }}",
-          "ipipMode": "{{ ipip_mode|capitalize }}",
+          "ipipMode": "{{ ipip_mode }}",
           "natOutgoing": {{ nat_outgoing|default(false) and not peer_with_router|default(false) }} }} " | {{ bin_dir }}/calicoctl create -f -
   run_once: true
   delegate_to: "{{ groups['kube-master'][0] }}"


### PR DESCRIPTION
When you set calico ipip mode to `CrossSubnet`, deployment fails because filter `capitalize` remove the uppercase in "Subnet", so `CrossSubnet` gets converted to `Crosssubnet` which breakes the task **_Calico | Configure calico network pool_**