### PR TITLE
Upgrade pause image to 3.1

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -44,7 +44,7 @@ flannel_version: "v0.10.0"
 flannel_cni_version: "v0.3.0"
 vault_version: 0.10.1
 weave_version: "2.4.0"
-pod_infra_version: 3.0
+pod_infra_version: 3.1
 contiv_version: 1.1.7
 cilium_version: "v1.2.0"
 


### PR DESCRIPTION
[root@node1 kubespray]# kubeadm  config images list
k8s.gcr.io/kube-apiserver-amd64:v1.11.2
k8s.gcr.io/kube-controller-manager-amd64:v1.11.2
k8s.gcr.io/kube-scheduler-amd64:v1.11.2
k8s.gcr.io/kube-proxy-amd64:v1.11.2
k8s.gcr.io/pause:3.1
k8s.gcr.io/etcd-amd64:3.2.18
k8s.gcr.io/coredns:1.1.3
