### PR TITLE
Remove insecure-port and insecure-bind-address when possible

### DIFF
--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha1.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha1.yaml.j2
@@ -45,8 +45,12 @@ authorizationModes:
 selfHosted: false
 apiServerExtraArgs:
   bind-address: {{ kube_apiserver_bind_address }}
+{% if kube_apiserver_insecure_port|string != "0" %}
   insecure-bind-address: {{ kube_apiserver_insecure_bind_address }}
+{% endif %}
+{% if kube_apiserver_insecure_port|string != "0" or kube_version | version_compare('v1.10', '<') %}
   insecure-port: "{{ kube_apiserver_insecure_port }}"
+{% endif %}
 {% if kube_version | version_compare('v1.10', '<') %}
   admission-control: {{ kube_apiserver_admission_control | join(',') }}
 {% else %}

--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha2.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha2.yaml.j2
@@ -37,8 +37,12 @@ authorizationModes:
 {% endfor %}
 apiServerExtraArgs:
   bind-address: {{ kube_apiserver_bind_address }}
+{% if kube_apiserver_insecure_port|string != "0" %}
   insecure-bind-address: {{ kube_apiserver_insecure_bind_address }}
+{% endif %}
+{% if kube_apiserver_insecure_port|string != "0" or kube_version | version_compare('v1.10', '<') %}
   insecure-port: "{{ kube_apiserver_insecure_port }}"
+{% endif %}
 {% if kube_version | version_compare('v1.10', '<') %}
   admission-control: {{ kube_apiserver_admission_control | join(',') }}
 {% else %}

--- a/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
@@ -46,7 +46,9 @@ spec:
     - --etcd-cafile={{ etcd_cert_dir }}/ca.pem
     - --etcd-certfile={{ etcd_cert_dir }}/node-{{ inventory_hostname }}.pem
     - --etcd-keyfile={{ etcd_cert_dir }}/node-{{ inventory_hostname }}-key.pem
+{% if kube_apiserver_insecure_port|string != "0" %}
     - --insecure-bind-address={{ kube_apiserver_insecure_bind_address }}
+{% endif %}
     - --bind-address={{ kube_apiserver_bind_address }}
     - --apiserver-count={{ kube_apiserver_count }}
 {% if kube_version | version_compare('v1.9', '>=') %}
@@ -100,7 +102,9 @@ spec:
 {%   endif %}
 {% endif %}
     - --secure-port={{ kube_apiserver_port }}
+{% if kube_apiserver_insecure_port|string != "0" or kube_version | version_compare('v1.10', '<') %}
     - --insecure-port={{ kube_apiserver_insecure_port }}
+{% endif %}
     - --storage-backend={{ kube_apiserver_storage_backend }}
 {% if kube_api_runtime_config is defined %}
 {%   for conf in kube_api_runtime_config %}


### PR DESCRIPTION
What this PR is about:
- When kube_version >=1.10 and `kube_apiserver_insecure_port`=0, remove the insecure-port and insecure-bind-address flags (Deprecated since 1.10 cf. https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.10.md)
- When kube_version <1.10 and `kube_apiserver_insecure_port`=0, remove the supernumerary insecure-bind-address flag (defaults to 127.0.0.1) that may make fail some security checks (item 1.1.5 in kube-bench for example)
- Otherwise, same behaviour as before