### PR TITLE
Fix calico health checks

### DIFF
--- a/roles/kubernetes-apps/helm/tasks/main.yml
+++ b/roles/kubernetes-apps/helm/tasks/main.yml
@@ -39,7 +39,7 @@
   register: install_helm
   changed_when: false
 
-#FIXME: https://github.com/helm/helm/issues/4063
+# FIXME: https://github.com/helm/helm/issues/4063
 - name: Helm | Force apply tiller overrides if necessary
   shell: >
     {{ bin_dir }}/helm init --upgrade --tiller-image={{ tiller_image_repo }}:{{ tiller_image_tag }} --tiller-namespace={{ tiller_namespace }}

--- a/roles/kubernetes/preinstall/tasks/0050-create_directories.yml
+++ b/roles/kubernetes/preinstall/tasks/0050-create_directories.yml
@@ -1,3 +1,4 @@
+---
 - name: Create kubernetes directories
   file:
     path: "{{ item }}"

--- a/roles/kubernetes/preinstall/tasks/0070-system-packages.yml
+++ b/roles/kubernetes/preinstall/tasks/0070-system-packages.yml
@@ -1,3 +1,4 @@
+---
 - name: Update package management cache (YUM)
   yum:
     update_cache: yes

--- a/roles/kubernetes/preinstall/tasks/0080-system-configurations.yml
+++ b/roles/kubernetes/preinstall/tasks/0080-system-configurations.yml
@@ -1,3 +1,4 @@
+---
 # Todo : selinux configuration
 - name: Confirm selinux deployed
   stat:

--- a/roles/network_plugin/calico/defaults/main.yml
+++ b/roles/network_plugin/calico/defaults/main.yml
@@ -2,7 +2,7 @@
 # Enables Internet connectivity from containers
 nat_outgoing: true
 
-#add default ippool name
+# add default ippool name
 calico_pool_name: "default-pool"
 
 # Use IP-over-IP encapsulation across hosts

--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -164,10 +164,10 @@
   delay: "{{ retry_stagger | random + 3 }}"
   with_items: "{{ peers|default([]) }}"
   when:
-   - calico_version_on_server.stdout|version_compare('v3.0.0', '<')
-   - not calico_upgrade_enabled
-   - peer_with_router|default(false)
-   - inventory_hostname in groups['k8s-cluster']
+    - calico_version_on_server.stdout|version_compare('v3.0.0', '<')
+    - not calico_upgrade_enabled
+    - peer_with_router|default(false)
+    - inventory_hostname in groups['k8s-cluster']
 
 - name: Calico | Configure peering with route reflectors
   shell: >
@@ -208,10 +208,10 @@
   delay: "{{ retry_stagger | random + 3 }}"
   with_items: "{{ groups['calico-rr'] | default([]) }}"
   when:
-   - calico_version_on_server.stdout|version_compare('v3.0.0', '<')
-   - not calico_upgrade_enabled
-   - peer_with_calico_rr|default(false)
-   - hostvars[item]['cluster_id'] == cluster_id
+    - calico_version_on_server.stdout|version_compare('v3.0.0', '<')
+    - not calico_upgrade_enabled
+    - peer_with_calico_rr|default(false)
+    - hostvars[item]['cluster_id'] == cluster_id
 
 
 - name: Calico | Create calico manifests

--- a/roles/network_plugin/calico/templates/calico-node.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-node.yml.j2
@@ -136,6 +136,7 @@ spec:
               memory: {{ calico_node_memory_requests }}
           livenessProbe:
             httpGet:
+              host: 127.0.0.1
               path: /liveness
               port: 9099
             periodSeconds: 10
@@ -143,6 +144,7 @@ spec:
             failureThreshold: 6
           readinessProbe:
             httpGet:
+              host: 127.0.0.1
               path: /readiness
               port: 9099
             periodSeconds: 10


### PR DESCRIPTION
Probably after updating to calico v 3.2.0, calico pods are listening on localhost 

![image](https://user-images.githubusercontent.com/2006610/45162245-d1cc6900-b1ed-11e8-9630-389d96c8fb37.png)

and healthchecks are failing

![image](https://user-images.githubusercontent.com/2006610/45162430-4d2e1a80-b1ee-11e8-96ba-d22e1c40a489.png)

So we need to make healthcheck on localhost, according to this documentaiton

![image](https://user-images.githubusercontent.com/2006610/45162552-8cf50200-b1ee-11e8-8fc0-57b276227f3c.png)

And after that everything started working.