### PR TITLE
[bugfix] heketi storageclass privilege

### DIFF
--- a/contrib/network-storage/heketi/roles/provision/templates/storageclass.yml.j2
+++ b/contrib/network-storage/heketi/roles/provision/templates/storageclass.yml.j2
@@ -8,5 +8,5 @@ metadata:
 provisioner: kubernetes.io/glusterfs
 parameters:
   resturl: "http://{{ endpoint_address }}:8080"
-  restuser: "user"
-  restuserkey: "{{ heketi_user_key }}"
+  restuser: "admin"
+  restuserkey: "{{ heketi_admin_key }}"


### PR DESCRIPTION
Hi,

I just discovered that the storageclass in contrib/network-storage/heketi is using the unprivileged user instead of the privileged one. This leads to a very "funny" behaviour. (somehow volumes are created until there is no more space left but they wont be assigned to anything)

Greetings, Sascha