### PR TITLE
[bugfix] Use bin_dir to find kubectl in contrib/metallb

### DIFF
--- a/contrib/metallb/roles/provision/tasks/main.yml
+++ b/contrib/metallb/roles/provision/tasks/main.yml
@@ -10,6 +10,7 @@
   kube:
     name: "MetalLB"
     filename: "{{ kube_config_dir }}/metallb.yml"
+    kubectl: "{{bin_dir}}/kubectl"
     state: "{{ item.changed | ternary('latest','present') }}"
   with_items: "{{ rendering.results }}"
   when:

--- a/contrib/network-storage/heketi/roles/provision/tasks/storage.yml
+++ b/contrib/network-storage/heketi/roles/provision/tasks/storage.yml
@@ -7,5 +7,6 @@
 - name: "Kubernetes Apps | Install and configure Heketi Storage"
   kube:
     name: "GlusterFS"
+    kubectl: "{{bin_dir}}/kubectl"
     filename: "{{ kube_config_dir }}/heketi-storage.json"
     state: "{{ rendering.changed | ternary('latest', 'present') }}"


### PR DESCRIPTION
Hi,
I just noticed the metallb playbook does not work if executed as root on centos because I did not add the path to kubectl binary.

Also true for a task in the new heketi playbook.

Greetings, Sascha