### PR TITLE
Precision on control machine mixed Ansible installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ To deploy the cluster you can use :
     # Deploy Kubespray with Ansible Playbook
     ansible-playbook -i inventory/mycluster/hosts.ini cluster.yml
 
+Note: When Ansible is already installed via system packages on the control machine, other python packages installed via `sudo pip install -r requirements.txt` will go to a different directory tree (e.g. `/usr/local/lib/python2.7/dist-packages` on Ubuntu) from Ansible's (e.g. `/usr/lib/python2.7/dist-packages/ansible` still on Ubuntu).
+As a consequence, `ansible-playbook` command will fail with:
+```
+ERROR! no action detected in task. This often indicates a misspelled module name, or incorrect module path.
+```
+probably pointing on a task depending on a module present in requirements.txt (i.e. "unseal vault").
+
+One way of solving this would be to uninstall the Ansible package and then, to install it via pip but it is not always possible.
+A workaround consists of setting `ANSIBLE_LIBRARY` and `ANSIBLE_MODULE_UTILS` environment variables respectively to the `ansible/modules` and `ansible/module_utils` subdirectories of pip packages installation location, which can be found in the Location field of the output of `pip show [package]` before executing `ansible-playbook`.
+
 ### Vagrant
 
 For Vagrant we need to install python dependencies for provisioning tasks.


### PR DESCRIPTION
This PR adds a note about Ansible installation troubleshooting on control machines mixing Ansible system package with pypi packages.

It includes a workaround tip that has been reported working on Ubuntu xenial control machines with ansible 2.4.4.0 (installed via apt).

I put it in the main README.md that describes how to get started but maybe the right place is docs/ansible.md (with a reference in README.md), if so let me know