### PR TITLE
Check `openstack_cacert` for empty string

### DIFF
--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha1.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha1.yaml.j2
@@ -118,7 +118,7 @@ controllerManagerExtraArgs:
 {% for key in kube_kubeadm_controller_extra_args %}
   {{ key }}: "{{ kube_kubeadm_controller_extra_args[key] }}"
 {% endfor %}
-{% if cloud_provider is defined and cloud_provider in ["openstack"] and openstack_cacert is defined %}
+{% if cloud_provider is defined and cloud_provider in ["openstack"] and openstack_cacert is defined and openstack_cacert != "" %}
 controllerManagerExtraVolumes:
 - name: openstackcacert
   hostPath: "{{ kube_config_dir }}/openstack-cacert.pem"

--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha2.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha2.yaml.j2
@@ -117,7 +117,7 @@ controllerManagerExtraArgs:
 {% for key in kube_kubeadm_controller_extra_args %}
   {{ key }}: "{{ kube_kubeadm_controller_extra_args[key] }}"
 {% endfor %}
-{% if cloud_provider is defined and cloud_provider in ["openstack"] and openstack_cacert is defined %}
+{% if cloud_provider is defined and cloud_provider in ["openstack"] and openstack_cacert is defined and openstack_cacert != "" %}
 controllerManagerExtraVolumes:
 - name: openstackcacert
   hostPath: "{{ kube_config_dir }}/openstack-cacert.pem"

--- a/roles/kubernetes/master/templates/manifests/kube-controller-manager.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-controller-manager.manifest.j2
@@ -97,7 +97,7 @@ spec:
       name: cloudconfig
       readOnly: true
 {% endif %}
-{% if cloud_provider is defined and cloud_provider in ["openstack"] and openstack_cacert is defined %}
+{% if cloud_provider is defined and cloud_provider in ["openstack"] and openstack_cacert is defined and openstack_cacert != "" %}
     - mountPath: "{{ kube_config_dir }}/openstack-cacert.pem"
       name: openstackcacert
       readOnly: true
@@ -122,7 +122,7 @@ spec:
       path: "{{ kube_config_dir }}/cloud_config"
     name: cloudconfig
 {% endif %}
-{% if cloud_provider is defined and cloud_provider in ["openstack"] and openstack_cacert is defined %}
+{% if cloud_provider is defined and cloud_provider in ["openstack"] and openstack_cacert is defined and openstack_cacert != "" %}
   - hostPath:
       path: "{{ kube_config_dir }}/openstack-cacert.pem"
     name: openstackcacert

--- a/roles/kubernetes/node/tasks/main.yml
+++ b/roles/kubernetes/node/tasks/main.yml
@@ -177,6 +177,7 @@
     - cloud_provider is defined
     - cloud_provider == 'openstack'
     - openstack_cacert is defined
+    - openstack_cacert != ""
   tags:
     - cloud-provider
 


### PR DESCRIPTION
Fixes https://github.com/kubernetes-incubator/kubespray/issues/3268

The `openstack_cacert` is always defined for kubernetes/node role
https://github.com/kubernetes-incubator/kubespray/blob/0a720b35afac6966acac350bd3eca0be2a7b1a5c/roles/kubernetes/node/defaults/main.yml#L122

The only place it is correctly verified if `openstack_cacert` is defined with a meaningful value is
https://github.com/kubernetes-incubator/kubespray/blob/0a720b35afac6966acac350bd3eca0be2a7b1a5c/roles/kubernetes/node/templates/openstack-cloud-config.j2#L15

This PR applies the same logic on other uses of `openstack_cacert` in both kubernetes/node and kubernetes/master roles