### PR TITLE
Extra options for upgrade mode

### DIFF
--- a/roles/upgrade/pre-upgrade/defaults/main.yml
+++ b/roles/upgrade/pre-upgrade/defaults/main.yml
@@ -1,3 +1,5 @@
 ---
 drain_grace_period: 300
 drain_timeout: 360s
+drain_label_selector: ""
+drain_nodes: true

--- a/roles/upgrade/pre-upgrade/tasks/main.yml
+++ b/roles/upgrade/pre-upgrade/tasks/main.yml
@@ -35,10 +35,13 @@
 - name: Drain node
   command: >-
     {{ bin_dir }}/kubectl drain
-      --force
-      --ignore-daemonsets
-      --grace-period {{ drain_grace_period }}
-      --timeout {{ drain_timeout }}
-      --delete-local-data {{ inventory_hostname }}
+    --force
+    --ignore-daemonsets
+    --grace-period {{ drain_grace_period }}
+    --timeout {{ drain_timeout }}
+    --delete-local-data {{ inventory_hostname }}
+    {% if drain_label_selector != "" %}--selector '{{ drain_label_selector }}'{% endif %}
   delegate_to: "{{ groups['kube-master'][0] }}"
-  when: needs_cordoning
+  when:
+    - drain_nodes
+    - needs_cordoning


### PR DESCRIPTION
Optionally do not drain nodes by setting drain_nodes to false
Optionally set a labelselector to target which pods should be drained.