### PR TITLE
Fix wrong sa name in crb when psp is enabled

### DIFF
--- a/roles/kubernetes-apps/ansible/templates/netchecker-agent-hostnet-clusterrolebinding.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/netchecker-agent-hostnet-clusterrolebinding.yml.j2
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ netcheck_namespace }}
 subjects:
   - kind: ServiceAccount
-    name: netchecker-agent-hostnet
+    name: netchecker-agent
     namespace: {{ netcheck_namespace }}
 roleRef:
   kind: ClusterRole


### PR DESCRIPTION
Fix what could certainly be called a typo in PR#3102 as serviceAccount is netchecker-agent and not netchecker-agent-hostnet