### PR TITLE
Change update strategy to RollingUpdate

### DIFF
--- a/roles/kubernetes-apps/policy_controller/calico/templates/calico-kube-controllers.yml.j2
+++ b/roles/kubernetes-apps/policy_controller/calico/templates/calico-kube-controllers.yml.j2
@@ -11,7 +11,7 @@ metadata:
 spec:
   replicas: 1
   strategy:
-    type: Recreate
+    type: RollingUpdate
   selector:
     matchLabels:
       kubernetes.io/cluster-service: "true"


### PR DESCRIPTION
When enable_network_policy is set to True with Calico 3 kubectl
apply fails with the error:

The Deployment "calico-kube-controllers" is invalid:
spec.strategy.rollingUpdate: Forbidden: may not be specified when
strategy type is 'Recreate'

See

https://github.com/kubernetes-incubator/kubespray/issues/3267

Changing the update strategy to RollingUpdate avoids this error.