### PR TITLE
Revert "Remove insecure-port and insecure-bind-address when possible"

### DIFF
--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha1.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha1.yaml.j2
@@ -45,12 +45,8 @@ authorizationModes:
 selfHosted: false
 apiServerExtraArgs:
   bind-address: {{ kube_apiserver_bind_address }}
-{% if kube_apiserver_insecure_port|string != "0" %}
   insecure-bind-address: {{ kube_apiserver_insecure_bind_address }}
-{% endif %}
-{% if kube_apiserver_insecure_port|string != "0" or kube_version | version_compare('v1.10', '<') %}
   insecure-port: "{{ kube_apiserver_insecure_port }}"
-{% endif %}
 {% if kube_version | version_compare('v1.10', '<') %}
   admission-control: {{ kube_apiserver_admission_control | join(',') }}
 {% else %}

--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha2.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha2.yaml.j2
@@ -37,12 +37,8 @@ authorizationModes:
 {% endfor %}
 apiServerExtraArgs:
   bind-address: {{ kube_apiserver_bind_address }}
-{% if kube_apiserver_insecure_port|string != "0" %}
   insecure-bind-address: {{ kube_apiserver_insecure_bind_address }}
-{% endif %}
-{% if kube_apiserver_insecure_port|string != "0" or kube_version | version_compare('v1.10', '<') %}
   insecure-port: "{{ kube_apiserver_insecure_port }}"
-{% endif %}
 {% if kube_version | version_compare('v1.10', '<') %}
   admission-control: {{ kube_apiserver_admission_control | join(',') }}
 {% else %}

--- a/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
@@ -46,9 +46,7 @@ spec:
     - --etcd-cafile={{ etcd_cert_dir }}/ca.pem
     - --etcd-certfile={{ etcd_cert_dir }}/node-{{ inventory_hostname }}.pem
     - --etcd-keyfile={{ etcd_cert_dir }}/node-{{ inventory_hostname }}-key.pem
-{% if kube_apiserver_insecure_port|string != "0" %}
     - --insecure-bind-address={{ kube_apiserver_insecure_bind_address }}
-{% endif %}
     - --bind-address={{ kube_apiserver_bind_address }}
     - --apiserver-count={{ kube_apiserver_count }}
 {% if kube_version | version_compare('v1.9', '>=') %}
@@ -102,9 +100,7 @@ spec:
 {%   endif %}
 {% endif %}
     - --secure-port={{ kube_apiserver_port }}
-{% if kube_apiserver_insecure_port|string != "0" or kube_version | version_compare('v1.10', '<') %}
     - --insecure-port={{ kube_apiserver_insecure_port }}
-{% endif %}
     - --storage-backend={{ kube_apiserver_storage_backend }}
 {% if kube_api_runtime_config is defined %}
 {%   for conf in kube_api_runtime_config %}


### PR DESCRIPTION
Reverts kubernetes-incubator/kubespray#3252

I have `kube_apiserver_insecure_port: 0` on k8s 1.11, but `--insecure-port` is not set inside the apiserver manifest

https://github.com/kubernetes/kubernetes/pull/59018#issuecomment-381245156 this sums up why it was premature to remove our usage of the flag

Once the flag is actually removed from kubernetes we can stop setting it, but right now removing the flag actually turns on the default of insescure-port = 8080, which is the opposite effect of setting it to 0