### PR TITLE
Remove --insecure-bind-address when insecure-port=0

### DIFF
--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha1.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha1.yaml.j2
@@ -45,7 +45,9 @@ authorizationModes:
 selfHosted: false
 apiServerExtraArgs:
   bind-address: {{ kube_apiserver_bind_address }}
+{% if kube_apiserver_insecure_port|string != "0" %}
   insecure-bind-address: {{ kube_apiserver_insecure_bind_address }}
+{% endif %}
   insecure-port: "{{ kube_apiserver_insecure_port }}"
 {% if kube_version | version_compare('v1.10', '<') %}
   admission-control: {{ kube_apiserver_admission_control | join(',') }}

--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha2.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha2.yaml.j2
@@ -37,7 +37,9 @@ authorizationModes:
 {% endfor %}
 apiServerExtraArgs:
   bind-address: {{ kube_apiserver_bind_address }}
+{% if kube_apiserver_insecure_port|string != "0" %}
   insecure-bind-address: {{ kube_apiserver_insecure_bind_address }}
+{% endif %}
   insecure-port: "{{ kube_apiserver_insecure_port }}"
 {% if kube_version | version_compare('v1.10', '<') %}
   admission-control: {{ kube_apiserver_admission_control | join(',') }}

--- a/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
@@ -46,7 +46,9 @@ spec:
     - --etcd-cafile={{ etcd_cert_dir }}/ca.pem
     - --etcd-certfile={{ etcd_cert_dir }}/node-{{ inventory_hostname }}.pem
     - --etcd-keyfile={{ etcd_cert_dir }}/node-{{ inventory_hostname }}-key.pem
+{% if kube_apiserver_insecure_port|string != "0" %}
     - --insecure-bind-address={{ kube_apiserver_insecure_bind_address }}
+{% endif %}
     - --bind-address={{ kube_apiserver_bind_address }}
     - --apiserver-count={{ kube_apiserver_count }}
 {% if kube_version | version_compare('v1.9', '>=') %}


### PR DESCRIPTION
`insecure-bind-address` is not needed when `insecure-port` is set to 0 and it makes kube-bench fail (item 1.1.5)