### PR TITLE
Add support for OracleLinux

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -93,14 +93,14 @@
   template:
     src: "rh_docker.repo.j2"
     dest: "{{ yum_repo_dir }}/docker.repo"
-  when: ansible_distribution in ["CentOS","RedHat"] and not is_atomic
+  when: ansible_distribution in ["CentOS","RedHat","OracleLinux"] and not is_atomic
 
 - name: Copy yum.conf for editing
   copy:
     src: "{{ yum_conf }}"
     dest: "{{ docker_yum_conf }}"
     remote_src: yes
-  when: ansible_distribution in ["CentOS","RedHat"] and not is_atomic
+  when: ansible_distribution in ["CentOS","RedHat","OracleLinux"] and not is_atomic
 
 - name: Edit copy of yum.conf to set obsoletes=0
   lineinfile:
@@ -108,7 +108,7 @@
     state: present
     regexp: '^obsoletes='
     line: 'obsoletes=0'
-  when: ansible_distribution in ["CentOS","RedHat"] and not is_atomic
+  when: ansible_distribution in ["CentOS","RedHat","OracleLinux"] and not is_atomic
 
 
 - name: ensure docker packages are installed

--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -12,7 +12,7 @@
 
 - name: Stop if unknown OS
   assert:
-    that: ansible_distribution in ['RedHat', 'CentOS', 'Fedora', 'Ubuntu', 'Debian', 'CoreOS', 'Container Linux by CoreOS', 'openSUSE Leap', 'openSUSE Tumbleweed']
+    that: ansible_distribution in ['RedHat', 'CentOS', 'Fedora', 'Ubuntu', 'Debian', 'CoreOS', 'Container Linux by CoreOS', 'openSUSE Leap', 'openSUSE Tumbleweed', 'OracleLinux']
   ignore_errors: "{{ ignore_assert_errors }}"
 
 - name: Stop if unknown network plugin

--- a/roles/kubernetes/preinstall/tasks/0070-system-packages.yml
+++ b/roles/kubernetes/preinstall/tasks/0070-system-packages.yml
@@ -74,7 +74,7 @@
     name: epel-release
     state: present
   when:
-    - ansible_distribution in ["CentOS","RedHat"]
+    - ansible_distribution in ["CentOS","RedHat","OracleLinux"]
     - not is_atomic
     - epel_enabled|bool
   tags:


### PR DESCRIPTION
OracleLinux is similar to RedHat and CentOS, we can just add its name to the list.
I have successfully installed kubernetes on my virtual machines which run OracleLinux.
However, I did notice a minor difference: OracleLinux does not provide `epel-release` package, so if `epel_enabled` is set to true, you'll get errors. In my tests, I installed epel on all servers before running kubespray playbook.