### PR TITLE
Calico version verification before cluster upgrade begin.

### DIFF
--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -18,11 +18,6 @@ versions. Here are all version vars for each component:
 * flannel_version
 * kubedns_version
 
-Please remember that some components upgrade depends on minimum installed version.
-In example **calico version 2.6.5 upgrade to 3.1.1 is upgrading etcd store to etcdv3**.
-The kubespray stack upgrade would failed when calico version is below 2.6.5. Please check
-components' documentation and always upgrade test environment first.
-
 #### Unsafe upgrade example
 
 If you wanted to upgrade just kube_version from v1.4.3 to v1.4.6, you could
@@ -40,7 +35,7 @@ ansible-playbook cluster.yml -i inventory/sample/hosts.ini -e kube_version=v1.4.
 
 #### Graceful upgrade
 
-Kubespray also supports cordon, drain and uncordoning of nodes when performing 
+Kubespray also supports cordon, drain and uncordoning of nodes when performing
 a cluster upgrade. There is a separate playbook used for this purpose. It is
 important to note that upgrade-cluster.yml can only be used for upgrading an
 existing cluster. That means there must be at least 1 kube-master already

--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -18,6 +18,11 @@ versions. Here are all version vars for each component:
 * flannel_version
 * kubedns_version
 
+Please remember that some components upgrade depends on minimum installed version.
+In example **calico version 2.6.5 upgrade to 3.1.1 is upgrading etcd store to etcdv3**.
+The kubespray stack upgrade would failed when calico version is below 2.6.5. Please check
+components' documentation and always upgrade test environment first.
+
 #### Unsafe upgrade example
 
 If you wanted to upgrade just kube_version from v1.4.3 to v1.4.6, you could
@@ -86,7 +91,7 @@ for impact to user deployed pods.
 
 A deployer may want to upgrade specific components in order to minimize risk
 or save time. This strategy is not covered by CI as of this writing, so it is
-not guaranteed to work. 
+not guaranteed to work.
 
 These commands are useful only for upgrading fully-deployed, healthy, existing
 hosts. This will definitely not work for undeployed or partially deployed

--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -127,3 +127,21 @@
   tags:
     - cloud-provider
     - facts
+
+- name: "Get current version of calico cluster version"
+  shell: "{{ bin_dir }}/calicoctl version  | grep 'Cluster Version' | awk '{ print $3}'"
+  register: calico_version_on_server
+  run_once: yes
+  delegate_to: "{{ groups['kube-master'][0] }}"
+
+
+- name: "Check that calico version is enought for upgrade"
+  assert:
+    that:
+      - calico_version_on_server.stdout|version_compare('v2.6.5', '>=')
+    msg: "Your version of calico is not fresh enough for upgrade. Minimum version v2.6.5"
+  when:
+    - 'calico_version_on_server.stdout is defined'
+    - 'calico_version_on_server.stdout != ""'
+    - inventory_hostname == groups['kube-master'][0]
+  run_once: yes


### PR DESCRIPTION
Add a small warning to the [upgrades.md](docs/upgrades.md). Unfortunately currently kubespray playbook check components compatibility during component upgrade not before stack upgrade. Sometimes 50% of your stack was upgraded and playbook failed on some components which is problematic. 