### PR TITLE
kubeadm join take return code 1

### DIFF
--- a/roles/kubernetes/kubeadm/tasks/main.yml
+++ b/roles/kubernetes/kubeadm/tasks/main.yml
@@ -56,7 +56,11 @@
     --config {{ kube_config_dir}}/kubeadm-client.{{ kubeadmConfig_api_version }}.conf
     --ignore-preflight-errors=all
   register: kubeadm_join
-  when: not is_kube_master and (not kubelet_conf.stat.exists)
+  when:
+    - not is_kube_master
+    - not kubelet_conf.stat.exists
+  failed_when:
+    - kubeadm_join.rc not in [0,1]
 
 - name: Wait for kubelet bootstrap to create config
   wait_for:


### PR DESCRIPTION
 * When 'kubeadm join' has return code 1, node is joined correctly and allow rc 1 not to fail

Fix #3216

Note: I always have a error due to return code is 1 and I send this pull request.