### PR TITLE
Make Felix healthhost configurable

### DIFF
--- a/docs/calico.md
+++ b/docs/calico.md
@@ -164,6 +164,15 @@ To re-define default action please set the following variable in your inventory:
 calico_endpoint_to_host_action: "ACCEPT"
 ```
 
+##### Optional : Define address on which Felix will respond to health requests
+
+Since Calico 3.2.0, HealthCheck default behavior changed from listening on all interfaces to just listening on localhost.
+
+To re-define health host please set the following variable in your inventory:
+```
+calico_healthhost: "0.0.0.0"
+```
+
 Cloud providers configuration
 =============================
 

--- a/roles/network_plugin/calico/defaults/main.yml
+++ b/roles/network_plugin/calico/defaults/main.yml
@@ -48,6 +48,9 @@ calico_upgrade_version: v1.0.5
 # see https://github.com/projectcalico/felix/blob/ab8799eaea66627e5db7717e62fca61fd9c08646/python/calico/felix/config.py#L198
 calico_node_ignorelooserpf: false
 
+# Define address on which Felix will respond to health requests
+calico_healthhost: "localhost"
+
 # If you want to use non default IP_AUTODETECTION_METHOD for calico node set this option to one of:
 # * can-reach=DESTINATION
 # * interface=INTERFACE-REGEX

--- a/roles/network_plugin/calico/templates/calico-node.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-node.yml.j2
@@ -65,6 +65,8 @@ spec:
             # Set Felix endpoint to host default action to ACCEPT.
             - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
               value: "{{ calico_endpoint_to_host_action|default('RETURN') }}"
+            - name: FELIX_HEALTHHOST
+              value: "{{ calico_healthhost }}"
 # should be set in etcd before deployment
 #            # Configure the IP Pool from which Pod IPs will be chosen.
 #            - name: CALICO_IPV4POOL_CIDR


### PR DESCRIPTION
Hi,

Regarding https://docs.projectcalico.org/v3.2/releases/,
HealthCheck default behavior changed from listening on all interfaces to just listening on localhost. This behavior can be controlled by the new HealthHost parameter. felix #1782 (@ozdanborne)

I think, it's ok to make this parameter configurable.