### PR TITLE
weave: Upgrade to 2.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Supported Components
     -   [cilium](https://github.com/cilium/cilium) v1.2.0
     -   [contiv](https://github.com/contiv/install) v1.1.7
     -   [flanneld](https://github.com/coreos/flannel) v0.10.0
-    -   [weave](https://github.com/weaveworks/weave) v2.4.0
+    -   [weave](https://github.com/weaveworks/weave) v2.4.1
 -   Application
     -   [cephfs-provisioner](https://github.com/kubernetes-incubator/external-storage) v2.1.0-k8s1.11
     -   [cert-manager](https://github.com/jetstack/cert-manager) v0.4.1

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -46,7 +46,7 @@ flannel_version: "v0.10.0"
 flannel_cni_version: "v0.3.0"
 
 vault_version: 0.10.1
-weave_version: "2.4.0"
+weave_version: "2.4.1"
 pod_infra_version: 3.1
 contiv_version: 1.1.7
 cilium_version: "v1.2.0"
@@ -98,9 +98,9 @@ netcheck_agent_img_repo: "mirantis/k8s-netchecker-agent"
 netcheck_agent_tag: "{{ netcheck_version }}"
 netcheck_server_img_repo: "mirantis/k8s-netchecker-server"
 netcheck_server_tag: "{{ netcheck_version }}"
-weave_kube_image_repo: "weaveworks/weave-kube"
+weave_kube_image_repo: "docker.io/weaveworks/weave-kube"
 weave_kube_image_tag: "{{ weave_version }}"
-weave_npc_image_repo: "weaveworks/weave-npc"
+weave_npc_image_repo: "docker.io/weaveworks/weave-npc"
 weave_npc_image_tag: "{{ weave_version }}"
 contiv_image_repo: "contiv/netplugin"
 contiv_image_tag: "{{ contiv_version }}"

--- a/roles/network_plugin/weave/templates/weave-net.yml.j2
+++ b/roles/network_plugin/weave/templates/weave-net.yml.j2
@@ -42,13 +42,13 @@ items:
           - patch
           - update
       - apiGroups:
-        - policy
+          - policy
         resourceNames:
-        - privileged
+          - privileged
         resources:
-        - podsecuritypolicies
+          - podsecuritypolicies
         verbs:
-        - use
+          - use
   - apiVersion: rbac.authorization.k8s.io/v1beta1
     kind: ClusterRoleBinding
     metadata:


### PR DESCRIPTION
Upstream Changes:

-   weave 2.4.1 (https://github.com/weaveworks/weave/releases/tag/v2.4.1)

Our Changes:

-   Templates sync with upstream manifests