### PR TITLE
Configurable kibana_base_url to fix #3322.

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -136,13 +136,13 @@ kubednsautoscaler_image_repo: "gcr.io/google_containers/cluster-proportional-aut
 kubednsautoscaler_image_tag: "{{ kubednsautoscaler_version }}"
 test_image_repo: busybox
 test_image_tag: latest
-elasticsearch_version: "v5.6.4"
-elasticsearch_image_repo: "k8s.gcr.io/elasticsearch"
+elasticsearch_version: "6.4.0"
+elasticsearch_image_repo: "docker.elastic.co/elasticsearch/elasticsearch"
 elasticsearch_image_tag: "{{ elasticsearch_version }}"
-fluentd_version: "v2.0.4"
+fluentd_version: "v2.2.0"
 fluentd_image_repo: "k8s.gcr.io/fluentd-elasticsearch"
 fluentd_image_tag: "{{ fluentd_version }}"
-kibana_version: "5.6.4"
+kibana_version: "6.4.0"
 kibana_image_repo: "docker.elastic.co/kibana/kibana"
 kibana_image_tag: "{{ kibana_version }}"
 helm_version: "v2.9.1"

--- a/roles/kubernetes-apps/efk/kibana/templates/kibana-deployment.yml.j2
+++ b/roles/kubernetes-apps/efk/kibana/templates/kibana-deployment.yml.j2
@@ -36,8 +36,10 @@ spec:
         env:
           - name: "ELASTICSEARCH_URL"
             value: "http://elasticsearch-logging:{{ elasticsearch_service_port }}"
+{% if kibana_base_url %}
           - name: "SERVER_BASEPATH"
             value: "{{ kibana_base_url }}"
+{% endif %}
           - name: XPACK_MONITORING_ENABLED
             value: "false"
           - name: XPACK_SECURITY_ENABLED


### PR DESCRIPTION
Kibana's SERVER_BASEPATH does not work for me.
It should be changed to disable to fix the problem.

I still keep default SERVER_BASEPATH though it doesn't work for me.

After apply this PR, you can disable SERVER_BASEPATH by following inventory variable in addons.yml.

```
kibana_base_url: false
```