### PR TITLE
Fixes Calico 3.x BGPPeer resources

### DIFF
--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -165,7 +165,7 @@
    "apiVersion": "projectcalico.org/v3",
    "kind": "BGPPeer",
    "metadata": {
-      "name": "{{ inventory_hostname }}-bgp"
+      "name": "{{ inventory_hostname }}-{{ item.router_id }}"
    },
    "spec": {
       "asNumber": "{{ item.as }}",
@@ -204,7 +204,7 @@
    "apiVersion": "projectcalico.org/v3",
    "kind": "BGPPeer",
    "metadata": {
-      "name": "{{ inventory_hostname }}"
+      "name": "{{ inventory_hostname }}-{{ hostvars[item]["calico_rr_ip"]|default(hostvars[item]["ip"])|default(hostvars[item]["ansible_default_ipv4"]["address"]) }}"
    },
    "spec": {
       "asNumber": "{{ local_as | default(global_as_num)}}",

--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -163,14 +163,13 @@
   shell: >
    echo '{
    "apiVersion": "projectcalico.org/v3",
-   "kind": "bgpPeer",
+   "kind": "BGPPeer",
    "metadata": {
       "name": "{{ inventory_hostname }}-bgp"
    },
    "spec": {
       "asNumber": "{{ item.as }}",
       "node": "{{ inventory_hostname }}",
-      "scope": "node",
       "peerIP": "{{ item.router_id }}"
    }}' | {{ bin_dir }}/calicoctl create --skip-exists -f -
   retries: 4
@@ -203,13 +202,12 @@
   shell: >
    echo '{
    "apiVersion": "projectcalico.org/v3",
-   "kind": "bgpPeer",
+   "kind": "BGPPeer",
    "metadata": {
       "name": "{{ inventory_hostname }}"
    },
    "spec": {
       "asNumber": "{{ local_as | default(global_as_num)}}",
-      "scope": "node",
       "node": "{{ inventory_hostname }}",
       "peerIP": "{{ hostvars[item]["calico_rr_ip"]|default(hostvars[item]["ip"])|default(hostvars[item]["ansible_default_ipv4"]["address"]) }}"
    }}' | {{ bin_dir }}/calicoctl create --skip-exists -f -


### PR DESCRIPTION
This fixes several issues with the Calico 3.x `BGPPeer` resources:
  * Ensures `BGPPeer.kind` is the correct case
  * Ensures `BGPPeer.metadata.name` is unique
  * Removes `BGPPeer.spec.scope` since it's no longer a valid field

Fixes #3330

