### PR TITLE
Add volume mounts for audit

### DIFF
--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha1.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha1.yaml.j2
@@ -131,6 +131,18 @@ controllerManagerExtraVolumes:
   hostPath: "{{ kube_config_dir }}/openstack-cacert.pem"
   mountPath: "{{ kube_config_dir }}/openstack-cacert.pem"
 {% endif %}
+{% if kubernetes_audit %}
+apiServerExtraVolumes:
+- name: {{ audit_policy_name }}
+  hostPath: {{ audit_policy_hostpath }}
+  mountPath: {{ audit_policy_mountpath }}
+{% if audit_log_path != "-" %}
+- name: {{ audit_log_name }}
+  hostPath: {{ audit_log_hostpath }}
+  mountPath: {{ audit_log_mountpath }}
+  writable: true
+{% endif %}
+{% endif %}
 schedulerExtraArgs:
   profiling: "{{ kube_profiling }}"
 {% if kube_feature_gates %}


### PR DESCRIPTION
The v1alpha1 config for kubeadm does not do volume mounts for audit.