### PR TITLE
Remove audit again from Kubeadm 1.10.x. Write mounts not supported un…

### DIFF
--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha1.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha1.yaml.j2
@@ -101,13 +101,6 @@ apiServerExtraArgs:
   runtime-config: {{ kube_api_runtime_config | join(',') }}
 {% endif %}
   allow-privileged: "true"
-{% if kubernetes_audit %}
-  audit-log-path: "{{ audit_log_path }}"
-  audit-log-maxage: "{{ audit_log_maxage }}"
-  audit-log-maxbackup: "{{ audit_log_maxbackups }}"
-  audit-log-maxsize: "{{ audit_log_maxsize }}"
-  audit-policy-file: {{ audit_policy_file }}
-{% endif %}
 {% for key in kube_kubeadm_apiserver_extra_args %}
   {{ key }}: "{{ kube_kubeadm_apiserver_extra_args[key] }}"
 {% endfor %}


### PR DESCRIPTION
…till 1.11