### PR TITLE
Uses etcdv3 for calico 3 rr_v4 resources

### DIFF
--- a/roles/network_plugin/calico/rr/tasks/main.yml
+++ b/roles/network_plugin/calico/rr/tasks/main.yml
@@ -50,8 +50,6 @@
   command: |-
     {{ bin_dir }}/etcdctl \
     --endpoints={{ etcd_access_addresses }} \
-    --cert={{ etcd_cert_dir }}/admin-{{ groups['etcd'][0] }}.pem \
-    --key={{ etcd_cert_dir }}/admin-{{ groups['etcd'][0] }}-key.pem \
     put /calico/bgp/v1/rr_v4/{{ rr_ip }} \
     '{
        "ip": "{{ rr_ip }}",
@@ -59,6 +57,8 @@
      }'
   environment:
     ETCDCTL_API: 3
+    ETCDCTL_CERT: "{{ etcd_cert_dir }}/admin-{{ groups['etcd'][0] }}.pem"
+    ETCDCTL_KEY: "{{ etcd_cert_dir }}/admin-{{ groups['etcd'][0] }}-key.pem"
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
   delegate_to: "{{groups['etcd'][0]}}"
@@ -69,13 +69,14 @@
   command: |-
     {{ bin_dir }}/etcdctl \
     --peers={{ etcd_access_addresses }} \
-    --cert-file {{ etcd_cert_dir }}/admin-{{ groups['etcd'][0] }}.pem \
-    --key-file {{ etcd_cert_dir }}/admin-{{ groups['etcd'][0] }}-key.pem \
     set /calico/bgp/v1/rr_v4/{{ rr_ip }} \
     '{
        "ip": "{{ rr_ip }}",
        "cluster_id": "{{ cluster_id }}"
      }'
+  environment:
+    ETCDCTL_CERT_FILE: "{{ etcd_cert_dir }}/admin-{{ groups['etcd'][0] }}.pem"
+    ETCDCTL_KEY_FILE: "{{ etcd_cert_dir }}/admin-{{ groups['etcd'][0] }}-key.pem"
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
   delegate_to: "{{groups['etcd'][0]}}"

--- a/roles/network_plugin/calico/rr/tasks/main.yml
+++ b/roles/network_plugin/calico/rr/tasks/main.yml
@@ -49,6 +49,25 @@
 - name: Calico-rr | Configure route reflector
   command: |-
     {{ bin_dir }}/etcdctl \
+    --endpoints={{ etcd_access_addresses }} \
+    --cert={{ etcd_cert_dir }}/admin-{{ groups['etcd'][0] }}.pem \
+    --key={{ etcd_cert_dir }}/admin-{{ groups['etcd'][0] }}-key.pem \
+    put /calico/bgp/v1/rr_v4/{{ rr_ip }} \
+    '{
+       "ip": "{{ rr_ip }}",
+       "cluster_id": "{{ cluster_id }}"
+     }'
+  environment:
+    ETCDCTL_API: 3
+  retries: 4
+  delay: "{{ retry_stagger | random + 3 }}"
+  delegate_to: "{{groups['etcd'][0]}}"
+  when:
+    - calico_version | version_compare("v3.0.0", ">=")
+
+- name: Calico-rr | Configure route reflector (legacy)
+  command: |-
+    {{ bin_dir }}/etcdctl \
     --peers={{ etcd_access_addresses }} \
     --cert-file {{ etcd_cert_dir }}/admin-{{ groups['etcd'][0] }}.pem \
     --key-file {{ etcd_cert_dir }}/admin-{{ groups['etcd'][0] }}-key.pem \
@@ -60,6 +79,8 @@
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
   delegate_to: "{{groups['etcd'][0]}}"
+  when:
+    - calico_version | version_compare("v3.0.0", "<")
 
 - meta: flush_handlers
 


### PR DESCRIPTION
Given that Calico 3 is using etcdv3, this ensures that `rr_v4` resources are added via the etcdv3 api

For example:
```
$ ETCDCTL_API=3 etcdctl --endpoints=https://localhost:2379 --cacert=/etc/ssl/etcd/ssl/ca.pem --cert=/etc/ssl/etcd/ssl/admin-etcd01.pem --key=/etc/ssl/etcd/ssl/admin-etcd01-key.pem get --prefix /calico/ --keys-only

/calico/bgp/v1/rr_v4/10.0.0.10

/calico/bgp/v1/rr_v4/10.0.0.11

/calico/ipam/v2/assignment/ipv4/block/10.1.0.128-26
...
```