### PR TITLE
Add check that kube-master, kube-node and etcd groups are not empty.

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -5,6 +5,15 @@
       - ansible_version.full|version_compare('2.3.0', '>=')
   run_once: yes
 
+- name: Stop if either kube-master, kube-node or etcd is empty
+  assert:
+    that: groups.get('{{ item }}')
+  with_items:
+    - kube-master
+    - kube-node
+    - etcd
+  run_once: true
+
 - name: Stop if non systemd OS type
   assert:
     that: ansible_service_mgr == "systemd"


### PR DESCRIPTION
This can save a lot of time debugging silly mistakes.