### PR TITLE
Fix CI issue (Fedora task introduce new lookup plugin)

### DIFF
--- a/roles/bootstrap-os/tasks/bootstrap-fedora.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-fedora.yml
@@ -10,9 +10,8 @@
   tags: facts
 
 - name: Install python on fedora
-  raw: "dnf install --assumeyes --quiet {{ item['item'] }}"
-  when: item['rc'] != 0
-  loop: "{{ need_bootstrap['results'] }}"
+  raw: "dnf install --assumeyes --quiet python"
+  when: "{{ need_bootstrap.results | map(attribute='rc') | sort | last | bool }}"
 
 - name: Install required python packages
   dnf:


### PR DESCRIPTION
Fixes issue with CI:

```
FAILED! => {"msg": "Unexpected failure in finding the lookup named '{{ need_bootstrap['results'] }}' in the available lookup plugins"}
```