### PR TITLE
remove /var/lib/cni directory in reset playbook

### DIFF
--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -156,6 +156,7 @@
     - "{{ bin_dir }}/calico-upgrade"
     - "{{ bin_dir }}/weave"
     - /var/lib/rkt
+    - /var/lib/cni
     - /etc/vault
     - /etc/contiv
     - /var/contiv


### PR DESCRIPTION
Remove the `/var/lib/cni` directory that the `kubernetes/node` role creates.

https://github.com/kubernetes-incubator/kubespray/blob/7fd87b95cf2bdeadb7b7e4cf89ff18a35752a47f/roles/kubernetes/node/tasks/main.yml#L10-L14