### PR TITLE
Add Pod IP to Flannel manifest.

### DIFF
--- a/roles/network_plugin/flannel/templates/cni-flannel.yml.j2
+++ b/roles/network_plugin/flannel/templates/cni-flannel.yml.j2
@@ -79,6 +79,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         volumeMounts:
         - name: run
           mountPath: /run


### PR DESCRIPTION
Issue: #3380 

This adds the current Pod IP to the flannel manifest; this allows then using the Pod IP in the command definition (for instance, as `--iface $(POD_IP)` by specifying `flannel_interface: "$(POD_IP)"
` in the cluster variables).

This fixes an issue preventing binding flannel to the private IP, when the private and public IP of a node is bound to the same interface. As-is, it is impossible to prefer the private over the public if it is the secondary address (`eth0:1` vs `eth0.1`). I encountered this arrangement on Linode using Debian 9.