### PR TITLE
Replaces nonexisting system_namespace variable

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster/addons.yml
+++ b/inventory/sample/group_vars/k8s-cluster/addons.yml
@@ -7,13 +7,13 @@ helm_enabled: false
 
 # Registry deployment
 registry_enabled: false
-# registry_namespace: "{{ system_namespace }}"
+# registry_namespace: kube-system
 # registry_storage_class: ""
 # registry_disk_size: "10Gi"
 
 # Local volume provisioner deployment
 local_volume_provisioner_enabled: false
-# local_volume_provisioner_namespace: "{{ system_namespace }}"
+# local_volume_provisioner_namespace: kube-system
 # local_volume_provisioner_base_dir: /mnt/disks
 # local_volume_provisioner_mount_dir: /mnt/disks
 # local_volume_provisioner_storage_class: local-storage


### PR DESCRIPTION
As the `system_namespace` is removed since sometime but was still present in the commented `registry_namespace` and `local_volume_provisioner_namespace`

I could not find a suitable replacement variable so replaced it with a hardcoded kube-system.  
If there is a suitable variable which I overlooked, let me know!