### PR TITLE
Fix DNS loop when resolvconf_mode is set to host_resolvconf

### DIFF
--- a/docs/vars.md
+++ b/docs/vars.md
@@ -53,7 +53,7 @@ Kubernetes needs some parameters in order to get deployed. These are the
 following default cluster paramters:
 
 * *cluster_name* - Name of cluster (default is cluster.local)
-* *domain_name* - Name of cluster DNS domain (default is cluster.local)
+* *dns_domain* - Name of cluster DNS domain (default is cluster.local)
 * *kube_network_plugin* - Plugin to use for container networking
 * *kube_service_addresses* - Subnet for cluster IPs (default is
   10.233.0.0/18). Must not overlap with kube_pods_subnet

--- a/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
@@ -13,10 +13,18 @@ data:
         health
         kubernetes {{ dns_domain }} in-addr.arpa ip6.arpa {
           pods insecure
+{% if resolvconf_mode == 'host_resolvconf' and upstream_dns_servers is defined %}
+          upstream {{ upstream_dns_servers|join(' ') }}
+{% else %}
           upstream /etc/resolv.conf
+{% endif %}
           fallthrough in-addr.arpa ip6.arpa
         }
         prometheus :9153
+{% if resolvconf_mode == 'host_resolvconf' and upstream_dns_servers is defined %}
+        proxy . {{ upstream_dns_servers|join(' ') }}
+{% else %}
         proxy . /etc/resolv.conf
+{% endif %}
         cache 30
     }

--- a/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
@@ -13,7 +13,7 @@ data:
         health
         kubernetes {{ dns_domain }} in-addr.arpa ip6.arpa {
           pods insecure
-{% if resolvconf_mode == 'host_resolvconf' and upstream_dns_servers is defined %}
+{% if resolvconf_mode == 'host_resolvconf' and upstream_dns_servers is defined and upstream_dns_servers|length > 0 %}
           upstream {{ upstream_dns_servers|join(' ') }}
 {% else %}
           upstream /etc/resolv.conf
@@ -21,7 +21,7 @@ data:
           fallthrough in-addr.arpa ip6.arpa
         }
         prometheus :9153
-{% if resolvconf_mode == 'host_resolvconf' and upstream_dns_servers is defined %}
+{% if resolvconf_mode == 'host_resolvconf' and upstream_dns_servers is defined and upstream_dns_servers|length > 0 %}
         proxy . {{ upstream_dns_servers|join(' ') }}
 {% else %}
         proxy . /etc/resolv.conf

--- a/roles/kubernetes-apps/ansible/templates/kubedns-deploy.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/kubedns-deploy.yml.j2
@@ -94,7 +94,7 @@ spec:
         - --dns-port=10053
         - --config-dir=/kube-dns-config
         - --v={{ kube_log_level }}
-{% if resolvconf_mode == 'host_resolvconf' and upstream_dns_servers is defined %}
+{% if resolvconf_mode == 'host_resolvconf' and upstream_dns_servers is defined and upstream_dns_servers|length > 0 %}
         - --nameservers={{ upstream_dns_servers|join(',') }}
 {% endif %}
         env:

--- a/roles/kubernetes-apps/ansible/templates/kubedns-deploy.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/kubedns-deploy.yml.j2
@@ -94,6 +94,9 @@ spec:
         - --dns-port=10053
         - --config-dir=/kube-dns-config
         - --v={{ kube_log_level }}
+{% if resolvconf_mode == 'host_resolvconf' and upstream_dns_servers is defined %}
+        - --nameservers={{ upstream_dns_servers|join(',') }}
+{% endif %}
         env:
         - name: PROMETHEUS_PORT
           value: "10055"

--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -153,12 +153,3 @@
     - 'calico_version_on_server.stdout != ""'
     - inventory_hostname == groups['kube-master'][0]
   run_once: yes
-
-- name: "Check that upstream_dns_servers is defined for resolvconf_mode == 'host_resolvconf'"
-  assert:
-    that:
-      - upstream_dns_servers|length > 0
-    msg: "You need to define a list of dns servers in upstream_dns_servers when you use resolvconf_mode == 'host_resolvconf'"
-  when:
-    - resolvconf_mode == 'host_resolvconf'
-  run_once: yes

--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -153,3 +153,12 @@
     - 'calico_version_on_server.stdout != ""'
     - inventory_hostname == groups['kube-master'][0]
   run_once: yes
+
+- name: "Check that upstream_dns_servers is defined for resolvconf_mode == 'host_resolvconf'"
+  assert:
+    that:
+      - upstream_dns_servers|length > 0
+    msg: "You need to define a list of dns servers in upstream_dns_servers when you use resolvconf_mode == 'host_resolvconf'"
+  when:
+    - resolvconf_mode == 'host_resolvconf'
+  run_once: yes


### PR DESCRIPTION
When `resolvconf_mode` is set to `host_resolvconf`, CoreDNS has a DNS loop.

The following settings are set:

```
kube_service_addresses: 10.3.0.0/21

upstream_dns_servers:
  - 8.8.8.8
  - 9.9.9.9
```

Kubernetes nodes will contain the following contant in `/etc/resolv.conf`:

```
# cat /etc/resolv.conf
domain cluster.local
search default.svc.cluster.local svc.cluster.local
nameserver 10.3.0.3
nameserver 10.3.0.4
nameserver 8.8.8.8
nameserver 9.9.9.9
options ndots:2
options timeout:2
options attempts:2
```

Since CoreDNS config is set to proxy all it's queries that are non-kubernetes to the resolvers in `/etc/resolv.conf` the DNS loop is created (as CoreDNS is the two first entries).

```
.:53 {
        errors
        health
        kubernetes {{ dns_domain }} in-addr.arpa ip6.arpa {
          pods insecure
          upstream /etc/resolv.conf
          fallthrough in-addr.arpa ip6.arpa
        }
        prometheus :9153
        proxy . /etc/resolv.conf
        cache 30
    }
```

So when you resolve `google.com` from within a Pod. CoreDNS will try to resolve the domain two times on itself before it uses the upstream servers.

The following PR will set the `upstream_dns_servers` directly in the CoreDNS config when `resolvconf_mode` is set to `host_resolvconf` to prevent this DNS loop.