### PR TITLE
Resolve issues associated with Calico deployment in policy-only mode.

### DIFF
--- a/roles/network_plugin/calico/templates/calico-config.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-config.yml.j2
@@ -10,10 +10,11 @@ data:
   etcd_key: "/calico-secrets/key.pem"
 {% if calico_network_backend is defined and calico_network_backend == 'none' %}
   cluster_type: "kubespray"
-{%- else %}
+  calico_backend: "none"
+{% else %}
   cluster_type: "kubespray,bgp"
-{% endif %}
   calico_backend: "bird"
+{% endif %}
 {% if inventory_hostname in groups['k8s-cluster'] and peer_with_router|default(false) %}
   as: "{{ local_as|default(global_as_num) }}"
 {% endif -%}


### PR DESCRIPTION
Currently, deploying Calico in policy-only mode by setting `calico_network_backend` to none results in a couple of issues. 

First, the configMap is for calico-node is not properly templated/rendered. When `calico_network_backend` is set to none, the configMap renders as the following (note the last line):

```
name: calico-config
  namespace: kube-system
data:
  etcd_endpoints: "https://172.17.8.101:2379,https://172.17.8.102:2379,https://172.17.8.103:2379,https://172.17.8.104:2379,https://172.17.8.105:2379"
  etcd_ca: "/calico-secrets/ca_cert.crt"
  etcd_cert: "/calico-secrets/cert.crt"
  etcd_key: "/calico-secrets/key.pem"
  cluster_type: "kubespray"  calico_backend: "bird"
```

Additionally, examples from Calico documentation show cluster_type and calico_backend being set specifically for policy-only mode. Currently, `cluster_type` is only affected when  `calico_network_backend` is set to none. See [here](https://github.com/projectcalico/calico/blob/master/v3.1/getting-started/kubernetes/installation/hosted/kubernetes-datastore/policy-only/1.7/calico.yaml).

This PR addresses both of these issues. 