### PR TITLE
Ansible var should be quoted

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s-cluster/k8s-cluster.yml
@@ -59,7 +59,7 @@ kube_users:
 # kube_oidc_url: https:// ...
 # kube_oidc_client_id: kubernetes
 ## Optional settings for OIDC
-# kube_oidc_ca_file: {{ kube_cert_dir }}/ca.pem
+# kube_oidc_ca_file: "{{ kube_cert_dir }}/ca.pem"
 # kube_oidc_username_claim: sub
 # kube_oidc_username_prefix: oidc:
 # kube_oidc_groups_claim: groups


### PR DESCRIPTION
to fix the follow problem in case quote is not used:

PLAY [k8s-cluster:etcd:calico-rr] **********************************************
ERROR! Syntax Error while loading YAML.
  expected <block end>, but found '<scalar>'

The error appears to have been in '/tmp/vagrant-ansible/inventory/group_vars/k8s-cluster.yml': line 59, column 39, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

kube_oidc_ca_file: {{ kube_cert_dir }}/openid-ca.pem
                                      ^ here
We could be wrong, but this one looks like it might be an issue with
missing quotes.  Always quote template expression brackets when they
start a value. For instance:

    with_items:
      - {{ foo }}

Should be written as:

    with_items:
      - "{{ foo }}"

Ansible failed to complete successfully. Any error output should be
visible above. Please fix these errors and try again.