### PR TITLE
Add cloud provider config to kubeadm deployments

### DIFF
--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha1.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha1.yaml.j2
@@ -20,8 +20,11 @@ networking:
   serviceSubnet: {{ kube_service_addresses }}
   podSubnet: {{ kube_pods_subnet }}
 kubernetesVersion: {{ kube_version }}
-{% if cloud_provider is defined and cloud_provider not in ["gce", "oci"] %}
-cloudProvider: {{ cloud_provider }}
+{% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere"] %}
+  cloudProvider: {{cloud_provider}}
+  cloudConfig: {{ kube_config_dir }}/cloud_config
+{% elif cloud_provider is defined and cloud_provider in ["aws", "external"] %}
+  cloudProvider: {{cloud_provider}}
 {% endif %}
 {% if kube_proxy_mode == 'ipvs' %}
 kubeProxy:

--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha1.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha1.yaml.j2
@@ -111,6 +111,9 @@ apiServerExtraArgs:
 {% if kube_feature_gates %}
   feature-gates: {{ kube_feature_gates|join(',') }}
 {% endif %}
+{% if kube_network_plugin is defined and kube_network_plugin == 'cloud' %}
+  configure-cloud-routes: "true"
+{% endif %}
 controllerManagerExtraArgs:
   node-monitor-grace-period: {{ kube_controller_node_monitor_grace_period }}
   node-monitor-period: {{ kube_controller_node_monitor_period }}
@@ -123,11 +126,18 @@ controllerManagerExtraArgs:
 {% for key in kube_kubeadm_controller_extra_args %}
   {{ key }}: "{{ kube_kubeadm_controller_extra_args[key] }}"
 {% endfor %}
-{% if cloud_provider is defined and cloud_provider in ["openstack"] and openstack_cacert is defined and openstack_cacert != "" %}
+{% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere"] %}
 controllerManagerExtraVolumes:
+{% if cloud_provider is defined and cloud_provider in ["openstack"] and openstack_cacert is defined and openstack_cacert != "" %}
 - name: openstackcacert
   hostPath: "{{ kube_config_dir }}/openstack-cacert.pem"
   mountPath: "{{ kube_config_dir }}/openstack-cacert.pem"
+{% endif %}
+{% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere"] %}
+  - name: cloud-config
+    hostPath: {{ kube_config_dir }}/cloud_config
+    mountPath: {{ kube_config_dir }}/cloud_config
+{% endif %}
 {% endif %}
 schedulerExtraArgs:
   profiling: "{{ kube_profiling }}"
@@ -141,6 +151,11 @@ schedulerExtraArgs:
 {% endif %}
 {% if kube_basic_auth|default(true) or kube_token_auth|default(true) %}
 apiServerExtraVolumes:
+{% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere"] %}
+- name: cloud-config
+  hostPath: {{ kube_config_dir }}/cloud_config
+  mountPath: {{ kube_config_dir }}/cloud_config
+{% endif %}
 {% if kube_basic_auth|default(true) %}
 - name: basic-auth-config
   hostPath: {{ kube_users_dir }}
@@ -151,6 +166,12 @@ apiServerExtraVolumes:
   hostPath: {{ kube_token_dir }}
   mountPath: {{ kube_token_dir }}
 {% endif %}
+{% endif %}
+{% if (cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere"]) or volume_cross_zone_attachment %}
+schedulerExtraVolumes:
+- name: cloud-config
+  hostPath: {{ kube_config_dir }}/cloud_config
+  mountPath: {{ kube_config_dir }}/cloud_config
 {% endif %}
 apiServerCertSANs:
 {% for san in  apiserver_sans.split(' ') | unique %}

--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha1.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha1.yaml.j2
@@ -126,14 +126,14 @@ controllerManagerExtraArgs:
 {% for key in kube_kubeadm_controller_extra_args %}
   {{ key }}: "{{ kube_kubeadm_controller_extra_args[key] }}"
 {% endfor %}
-{% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere"] %}
+{% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere", "aws"] %}
 controllerManagerExtraVolumes:
 {% if cloud_provider is defined and cloud_provider in ["openstack"] and openstack_cacert is defined and openstack_cacert != "" %}
 - name: openstackcacert
   hostPath: "{{ kube_config_dir }}/openstack-cacert.pem"
   mountPath: "{{ kube_config_dir }}/openstack-cacert.pem"
 {% endif %}
-{% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere"] %}
+{% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere", "aws"] %}
   - name: cloud-config
     hostPath: {{ kube_config_dir }}/cloud_config
     mountPath: {{ kube_config_dir }}/cloud_config
@@ -151,7 +151,7 @@ schedulerExtraArgs:
 {% endif %}
 {% if kube_basic_auth|default(true) or kube_token_auth|default(true) %}
 apiServerExtraVolumes:
-{% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere"] %}
+{% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere", "aws"] %}
 - name: cloud-config
   hostPath: {{ kube_config_dir }}/cloud_config
   mountPath: {{ kube_config_dir }}/cloud_config

--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha1.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha1.yaml.j2
@@ -21,10 +21,10 @@ networking:
   podSubnet: {{ kube_pods_subnet }}
 kubernetesVersion: {{ kube_version }}
 {% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere", "aws"] %}
-  cloudProvider: {{cloud_provider}}
-  cloudConfig: {{ kube_config_dir }}/cloud_config
+cloudProvider: {{cloud_provider}}
+cloudConfig: {{ kube_config_dir }}/cloud_config
 {% elif cloud_provider is defined and cloud_provider in ["external"] %}
-  cloudProvider: {{cloud_provider}}
+cloudProvider: {{cloud_provider}}
 {% endif %}
 {% if kube_proxy_mode == 'ipvs' %}
 kubeProxy:

--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha1.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha1.yaml.j2
@@ -20,10 +20,10 @@ networking:
   serviceSubnet: {{ kube_service_addresses }}
   podSubnet: {{ kube_pods_subnet }}
 kubernetesVersion: {{ kube_version }}
-{% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere"] %}
+{% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere", "aws"] %}
   cloudProvider: {{cloud_provider}}
   cloudConfig: {{ kube_config_dir }}/cloud_config
-{% elif cloud_provider is defined and cloud_provider in ["aws", "external"] %}
+{% elif cloud_provider is defined and cloud_provider in ["external"] %}
   cloudProvider: {{cloud_provider}}
 {% endif %}
 {% if kube_proxy_mode == 'ipvs' %}
@@ -166,12 +166,6 @@ apiServerExtraVolumes:
   hostPath: {{ kube_token_dir }}
   mountPath: {{ kube_token_dir }}
 {% endif %}
-{% endif %}
-{% if (cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere"]) or volume_cross_zone_attachment %}
-schedulerExtraVolumes:
-- name: cloud-config
-  hostPath: {{ kube_config_dir }}/cloud_config
-  mountPath: {{ kube_config_dir }}/cloud_config
 {% endif %}
 apiServerCertSANs:
 {% for san in  apiserver_sans.split(' ') | unique %}

--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha2.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha2.yaml.j2
@@ -21,9 +21,6 @@ networking:
   serviceSubnet: {{ kube_service_addresses }}
   podSubnet: {{ kube_pods_subnet }}
 kubernetesVersion: {{ kube_version }}
-{% if cloud_provider is defined and cloud_provider != "gce" %}
-cloudProvider: {{ cloud_provider }}
-{% endif %}
 kubeProxy:
   config:
     mode: {{ kube_proxy_mode }}
@@ -107,6 +104,15 @@ apiServerExtraArgs:
 {% if kube_feature_gates %}
   feature-gates: {{ kube_feature_gates|join(',') }}
 {% endif %}
+{% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere"] %}
+  cloud-provider: {{cloud_provider}}
+  cloud-config: {{ kube_config_dir }}/cloud_config
+{% elif cloud_provider is defined and cloud_provider in ["aws", "external"] %}
+  cloud-provider: {{cloud_provider}}
+{% endif %}
+{% if kube_network_plugin is defined and kube_network_plugin == 'cloud' %}
+  configure-cloud-routes: "true"
+{% endif %}
 controllerManagerExtraArgs:
   node-monitor-grace-period: {{ kube_controller_node_monitor_grace_period }}
   node-monitor-period: {{ kube_controller_node_monitor_period }}
@@ -119,14 +125,30 @@ controllerManagerExtraArgs:
 {% for key in kube_kubeadm_controller_extra_args %}
   {{ key }}: "{{ kube_kubeadm_controller_extra_args[key] }}"
 {% endfor %}
+{% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere"] %}
+  cloud-provider: {{cloud_provider}}
+  cloud-config: {{ kube_config_dir }}/cloud_config
+{% elif cloud_provider is defined and cloud_provider in ["aws", "external"] %}
+  cloud-provider: {{cloud_provider}}
+{% endif %}
 {% if cloud_provider is defined and cloud_provider in ["openstack"] and openstack_cacert is defined and openstack_cacert != "" %}
 controllerManagerExtraVolumes:
 - name: openstackcacert
   hostPath: "{{ kube_config_dir }}/openstack-cacert.pem"
   mountPath: "{{ kube_config_dir }}/openstack-cacert.pem"
 {% endif %}
-{% if kubernetes_audit or kube_basic_auth|default(true) or kube_token_auth|default(true) %}
+{% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere"] %}
+  - name: cloud-config
+    hostPath: {{ kube_config_dir }}/cloud_config
+    mountPath: {{ kube_config_dir }}/cloud_config
+{% endif %}
+{% if kubernetes_audit or kube_basic_auth|default(true) or kube_token_auth|default(true) or ( cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere"] ) %}
 apiServerExtraVolumes:
+{% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere"] %}
+  - name: cloud-config
+    hostPath: {{ kube_config_dir }}/cloud_config
+    mountPath: {{ kube_config_dir }}/cloud_config
+{% endif %}
 {% if kube_basic_auth|default(true) %}
 - name: basic-auth-config
   hostPath: {{ kube_users_dir }}
@@ -151,6 +173,9 @@ apiServerExtraVolumes:
 {% endif %}
 schedulerExtraArgs:
   profiling: "{{ kube_profiling }}"
+{% if volume_cross_zone_attachment %}
+  policy-config-file: {{ kube_config_dir }}/kube-scheduler-policy.yaml
+{% endif %}
 {% if kube_feature_gates %}
   feature-gates: {{ kube_feature_gates|join(',') }}
 {% endif %}
@@ -158,6 +183,18 @@ schedulerExtraArgs:
 {% for key in kube_kubeadm_scheduler_extra_args %}
   {{ key }}: "{{ kube_kubeadm_scheduler_extra_args[key] }}"
 {% endfor %}
+{% endif %}
+{% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere"] %}
+  cloud-provider: {{cloud_provider}}
+  cloud-config: {{ kube_config_dir }}/cloud_config
+{% elif cloud_provider is defined and cloud_provider in ["aws", "external"] %}
+  cloud-provider: {{cloud_provider}}
+{% endif %}
+{% if (cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere"]) or volume_cross_zone_attachment %}
+schedulerExtraVolumes:
+  - name: cloud-config
+    hostPath: {{ kube_config_dir }}/cloud_config
+    mountPath: {{ kube_config_dir }}/cloud_config
 {% endif %}
 apiServerCertSANs:
 {% for san in  apiserver_sans.split(' ') | unique %}

--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha2.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha2.yaml.j2
@@ -104,7 +104,7 @@ apiServerExtraArgs:
 {% if kube_feature_gates %}
   feature-gates: {{ kube_feature_gates|join(',') }}
 {% endif %}
-{% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere"] %}
+{% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere", "aws"] %}
   cloud-provider: {{cloud_provider}}
   cloud-config: {{ kube_config_dir }}/cloud_config
 {% elif cloud_provider is defined and cloud_provider in ["aws", "external"] %}
@@ -125,13 +125,13 @@ controllerManagerExtraArgs:
 {% for key in kube_kubeadm_controller_extra_args %}
   {{ key }}: "{{ kube_kubeadm_controller_extra_args[key] }}"
 {% endfor %}
-{% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere"] %}
+{% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere", "aws"] %}
   cloud-provider: {{cloud_provider}}
   cloud-config: {{ kube_config_dir }}/cloud_config
 {% elif cloud_provider is defined and cloud_provider in ["aws", "external"] %}
   cloud-provider: {{cloud_provider}}
 {% endif %}
-{% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere"] %}
+{% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere", "aws"] %}
 controllerManagerExtraVolumes:
 {% if cloud_provider is defined and cloud_provider in ["openstack"] and openstack_cacert is defined and openstack_cacert != "" %}
 - name: openstackcacert
@@ -144,9 +144,9 @@ controllerManagerExtraVolumes:
   mountPath: {{ kube_config_dir }}/cloud_config
 {% endif %}
 {% endif %}
-{% if kubernetes_audit or kube_basic_auth|default(true) or kube_token_auth|default(true) or ( cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere"] ) %}
+{% if kubernetes_audit or kube_basic_auth|default(true) or kube_token_auth|default(true) or ( cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere", "aws"] ) %}
 apiServerExtraVolumes:
-{% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere"] %}
+{% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere", "aws"] %}
 - name: cloud-config
   hostPath: {{ kube_config_dir }}/cloud_config
   mountPath: {{ kube_config_dir }}/cloud_config
@@ -185,12 +185,6 @@ schedulerExtraArgs:
 {% for key in kube_kubeadm_scheduler_extra_args %}
   {{ key }}: "{{ kube_kubeadm_scheduler_extra_args[key] }}"
 {% endfor %}
-{% endif %}
-{% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere", "aws"] %}
-  cloud-provider: {{cloud_provider}}
-  cloud-config: {{ kube_config_dir }}/cloud_config
-{% elif cloud_provider is defined and cloud_provider in ["external"] %}
-  cloud-provider: {{cloud_provider}}
 {% endif %}
 apiServerCertSANs:
 {% for san in  apiserver_sans.split(' ') | unique %}

--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha2.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha2.yaml.j2
@@ -131,8 +131,9 @@ controllerManagerExtraArgs:
 {% elif cloud_provider is defined and cloud_provider in ["aws", "external"] %}
   cloud-provider: {{cloud_provider}}
 {% endif %}
-{% if cloud_provider is defined and cloud_provider in ["openstack"] and openstack_cacert is defined and openstack_cacert != "" %}
+{% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere"] %}
 controllerManagerExtraVolumes:
+{% if cloud_provider is defined and cloud_provider in ["openstack"] and openstack_cacert is defined and openstack_cacert != "" %}
 - name: openstackcacert
   hostPath: "{{ kube_config_dir }}/openstack-cacert.pem"
   mountPath: "{{ kube_config_dir }}/openstack-cacert.pem"
@@ -141,6 +142,7 @@ controllerManagerExtraVolumes:
   - name: cloud-config
     hostPath: {{ kube_config_dir }}/cloud_config
     mountPath: {{ kube_config_dir }}/cloud_config
+{% endif %}
 {% endif %}
 {% if kubernetes_audit or kube_basic_auth|default(true) or kube_token_auth|default(true) or ( cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere"] ) %}
 apiServerExtraVolumes:

--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha2.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha2.yaml.j2
@@ -139,17 +139,17 @@ controllerManagerExtraVolumes:
   mountPath: "{{ kube_config_dir }}/openstack-cacert.pem"
 {% endif %}
 {% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere"] %}
-  - name: cloud-config
-    hostPath: {{ kube_config_dir }}/cloud_config
-    mountPath: {{ kube_config_dir }}/cloud_config
+- name: cloud-config
+  hostPath: {{ kube_config_dir }}/cloud_config
+  mountPath: {{ kube_config_dir }}/cloud_config
 {% endif %}
 {% endif %}
 {% if kubernetes_audit or kube_basic_auth|default(true) or kube_token_auth|default(true) or ( cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere"] ) %}
 apiServerExtraVolumes:
 {% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere"] %}
-  - name: cloud-config
-    hostPath: {{ kube_config_dir }}/cloud_config
-    mountPath: {{ kube_config_dir }}/cloud_config
+- name: cloud-config
+  hostPath: {{ kube_config_dir }}/cloud_config
+  mountPath: {{ kube_config_dir }}/cloud_config
 {% endif %}
 {% if kube_basic_auth|default(true) %}
 - name: basic-auth-config
@@ -194,9 +194,9 @@ schedulerExtraArgs:
 {% endif %}
 {% if (cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere"]) or volume_cross_zone_attachment %}
 schedulerExtraVolumes:
-  - name: cloud-config
-    hostPath: {{ kube_config_dir }}/cloud_config
-    mountPath: {{ kube_config_dir }}/cloud_config
+- name: cloud-config
+  hostPath: {{ kube_config_dir }}/cloud_config
+  mountPath: {{ kube_config_dir }}/cloud_config
 {% endif %}
 apiServerCertSANs:
 {% for san in  apiserver_sans.split(' ') | unique %}

--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha2.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha2.yaml.j2
@@ -186,17 +186,11 @@ schedulerExtraArgs:
   {{ key }}: "{{ kube_kubeadm_scheduler_extra_args[key] }}"
 {% endfor %}
 {% endif %}
-{% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere"] %}
+{% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere", "aws"] %}
   cloud-provider: {{cloud_provider}}
   cloud-config: {{ kube_config_dir }}/cloud_config
-{% elif cloud_provider is defined and cloud_provider in ["aws", "external"] %}
+{% elif cloud_provider is defined and cloud_provider in ["external"] %}
   cloud-provider: {{cloud_provider}}
-{% endif %}
-{% if (cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere"]) or volume_cross_zone_attachment %}
-schedulerExtraVolumes:
-- name: cloud-config
-  hostPath: {{ kube_config_dir }}/cloud_config
-  mountPath: {{ kube_config_dir }}/cloud_config
 {% endif %}
 apiServerCertSANs:
 {% for san in  apiserver_sans.split(' ') | unique %}

--- a/roles/kubernetes/node/templates/kubelet.kubeadm.env.j2
+++ b/roles/kubernetes/node/templates/kubelet.kubeadm.env.j2
@@ -102,8 +102,11 @@ KUBELET_NETWORK_PLUGIN="--hairpin-mode=promiscuous-bridge --network-plugin=kuben
 {% endif %}
 # Should this cluster be allowed to run privileged docker containers
 KUBE_ALLOW_PRIV="--allow-privileged=true"
-{% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere", "aws"] %}
+
+{% if cloud_provider is defined and cloud_provider in ["openstack", "vsphere", "aws"] %}
 KUBELET_CLOUDPROVIDER="--cloud-provider={{ cloud_provider }} --cloud-config={{ kube_config_dir }}/cloud_config"
+{% elif cloud_provider is defined and cloud_provider in ["azure"] %}
+KUBELET_CLOUDPROVIDER="--cloud-provider={{ cloud_provider }} --cloud-config={{ kube_config_dir }}/cloud_config --azure-container-registry-config={{ kube_config_dir }}/cloud_config"
 {% elif cloud_provider is defined and cloud_provider in ["oci", "external"] %}
 KUBELET_CLOUDPROVIDER="--cloud-provider=external"
 {% else %}


### PR DESCRIPTION
Add cloud provider to kubeadm deployments.

According to https://github.com/kubernetes/kubeadm/issues/1018#issuecomment-407721598 the cloud provider config should be in the extra args of each control plane.