### PR TITLE
Fix docker role for ubuntu bionic that points to xenial

### DIFF
--- a/roles/docker/vars/ubuntu-bionic.yml
+++ b/roles/docker/vars/ubuntu-bionic.yml
@@ -28,5 +28,5 @@ docker_repo_info:
   repos:
     - >
        deb [arch=amd64] {{ docker_ubuntu_repo_base_url }}
-       xenial
+       bionic
        stable


### PR DESCRIPTION
This pr fixes issue #3387.