### PR TITLE
etcd v3.2.18 not available, bump to v3.2.24

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -37,7 +37,7 @@ image_arch: "{{host_architecture | default('amd64')}}"
 # Versions
 kube_version: v1.11.3
 kubeadm_version: "{{ kube_version }}"
-etcd_version: v3.2.18
+etcd_version: v3.2.24
 
 # TODO(mattymo): Move calico versions to roles/network_plugins/calico/defaults
 # after migration to container download


### PR DESCRIPTION
Error: fatal: [node1]: FAILED! => {"attempts": 4, "changed": false, "cmd": "/usr/bin/docker pull quay.io/coreos/etcd:v3.2.18", "msg": "[Errno 2] No such file or directory", "rc": 2}

https://quay.io/repository/coreos/etcd?tag=&tab=tags v3.2.18 tag not available. 