### PR TITLE
Heketi: Fix `ready` to not to be an AnsibleUnsafeText

### DIFF
--- a/contrib/network-storage/heketi/roles/provision/tasks/glusterfs.yml
+++ b/contrib/network-storage/heketi/roles/provision/tasks/glusterfs.yml
@@ -22,7 +22,7 @@
     daemonset_state: { stdout: "{}" }
     ready: "{{ daemonset_state.stdout|from_json|json_query(\"status.numberReady\") }}"
     desired: "{{ daemonset_state.stdout|from_json|json_query(\"status.desiredNumberScheduled\") }}"
-  until: "ready >= 3"
+  until: "ready | int >= 3"
   retries: 60
   delay: 5
 


### PR DESCRIPTION
A short change to fix following error.

Before, the comparison between `ready` and `3` has failed while running playbook `heketi.yml`
```text
TASK [provision : Kubernetes Apps | Wait for daemonset to become available.] *****************************************************
Thursday 27 September 2018  14:57:16 +0000 (0:00:00.134)       0:00:13.316 ****
fatal: [node1]: FAILED! => {"msg": "The conditional check 'ready >= 3' failed. The error was: Unexpected templating type error occurred on ({% if ready >= 3 %} True {% else %} False {% endif %}): '>=' not supported between instances of 'AnsibleUnsafeText' and 'int'"}
```

with following Ansible and Python version.
```text
ansible 2.6.4
  config file = /home/geap/geap-kubespray/ansible.cfg
  configured module search path = ['/home/geap/geap-kubespray/library']
  ansible python module location = /usr/local/lib/python3.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.7.0 (default, Sep 18 2018, 02:27:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```

This change makes the code work as intended.
I hope @torvitas can review this short change.