### PR TITLE
Fix netcheck agent/server image/tag variable names

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -128,10 +128,10 @@ pod_infra_image_tag: "{{ pod_infra_version }}"
 install_socat_image_repo: "xueshanf/install-socat"
 install_socat_image_tag: "latest"
 netcheck_version: "v1.2.2"
-netcheck_agent_img_repo: "mirantis/k8s-netchecker-agent"
-netcheck_agent_tag: "{{ netcheck_version }}"
-netcheck_server_img_repo: "mirantis/k8s-netchecker-server"
-netcheck_server_tag: "{{ netcheck_version }}"
+netcheck_agent_image_repo: "mirantis/k8s-netchecker-agent"
+netcheck_agent_image_tag: "{{ netcheck_version }}"
+netcheck_server_image_repo: "mirantis/k8s-netchecker-server"
+netcheck_server_image_tag: "{{ netcheck_version }}"
 weave_kube_image_repo: "docker.io/weaveworks/weave-kube"
 weave_kube_image_tag: "{{ weave_version }}"
 weave_npc_image_repo: "docker.io/weaveworks/weave-npc"
@@ -201,8 +201,8 @@ downloads:
   netcheck_server:
     enabled: "{{ deploy_netchecker }}"
     container: true
-    repo: "{{ netcheck_server_img_repo }}"
-    tag: "{{ netcheck_server_tag }}"
+    repo: "{{ netcheck_server_image_repo }}"
+    tag: "{{ netcheck_server_image_tag }}"
     sha256: "{{ netcheck_server_digest_checksum|default(None) }}"
     groups:
       - k8s-cluster
@@ -210,8 +210,8 @@ downloads:
   netcheck_agent:
     enabled: "{{ deploy_netchecker }}"
     container: true
-    repo: "{{ netcheck_agent_img_repo }}"
-    tag: "{{ netcheck_agent_tag }}"
+    repo: "{{ netcheck_agent_image_repo }}"
+    tag: "{{ netcheck_agent_image_tag }}"
     sha256: "{{ netcheck_agent_digest_checksum|default(None) }}"
     groups:
       - k8s-cluster

--- a/roles/kubernetes-apps/ansible/defaults/main.yml
+++ b/roles/kubernetes-apps/ansible/defaults/main.yml
@@ -30,8 +30,8 @@ deploy_netchecker: false
 netchecker_port: 31081
 agent_report_interval: 15
 netcheck_namespace: default
-agent_img: "{{ netcheck_agent_img_repo }}:{{ netcheck_agent_tag }}"
-server_img: "{{ netcheck_server_img_repo }}:{{ netcheck_server_tag }}"
+agent_img: "{{ netcheck_agent_image_repo }}:{{ netcheck_agent_image_tag }}"
+server_img: "{{ netcheck_server_image_repo }}:{{ netcheck_server_image_tag }}"
 
 # Limits for netchecker apps
 netchecker_agent_cpu_limit: 30m


### PR DESCRIPTION
According to the [documentation](https://github.com/kubernetes-incubator/kubespray/blob/master/docs/downloads.md), container images are described by vars like `foo_image_repo` and `foo_image_tag`.

The variables netcheck_{agent,server}_{img_repo,tag} do not follow that convention.

This PR aims at fixing this as we rely on this name scheme to update our local registry.