### PR TITLE
Revert "Fix docker role for ubuntu bionic that points to xenial"

### DIFF
--- a/roles/docker/vars/ubuntu-bionic.yml
+++ b/roles/docker/vars/ubuntu-bionic.yml
@@ -28,5 +28,5 @@ docker_repo_info:
   repos:
     - >
        deb [arch=amd64] {{ docker_ubuntu_repo_base_url }}
-       bionic
+       xenial
        stable


### PR DESCRIPTION
Reverts kubernetes-incubator/kubespray#3395

17.03 doesn't exist in Bionic. 

Until upgrade to 18.06 this must be reverted