### PR TITLE
fix kube-controller-manager config with openstack-cacert

### DIFF
--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -122,7 +122,6 @@ openstack_tenant_id: "{{ lookup('env','OS_TENANT_ID')| default(lookup('env','OS_
 openstack_tenant_name: "{{ lookup('env','OS_TENANT_NAME') }}"
 openstack_domain_name: "{{ lookup('env','OS_USER_DOMAIN_NAME') }}"
 openstack_domain_id: "{{ lookup('env','OS_USER_DOMAIN_ID') }}"
-openstack_cacert: "{{ lookup('env','OS_CACERT') }}"
 
 # For the vsphere integration, kubelet will need credentials to access
 # vsphere apis

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -263,6 +263,7 @@ openstack_lbaas_create_monitor: "yes"
 openstack_lbaas_monitor_delay: "1m"
 openstack_lbaas_monitor_timeout: "30s"
 openstack_lbaas_monitor_max_retries: "3"
+openstack_cacert: "{{ lookup('env','OS_CACERT') }}"
 
 ## List of authorization modes that must be configured for
 ## the k8s cluster. Only 'AlwaysAllow', 'AlwaysDeny', 'Node' and


### PR DESCRIPTION
The openstack_cacert flag is not defined for the kubernetes master because it is not initialized in the default values.

This PR fixes the issue https://github.com/kubernetes-incubator/kubespray/issues/3423