### PR TITLE
Moves port from controlPlaneEndpoint to bindPort

### DIFF
--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha1.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha1.yaml.j2
@@ -2,7 +2,8 @@ apiVersion: kubeadm.k8s.io/v1alpha1
 kind: MasterConfiguration
 api:
 {% if groups['kube-master'] | length > 1 and kubeadm_config_api_fqdn is defined %}
-  controlPlaneEndpoint: {{ kubeadm_config_api_fqdn }}:{{ loadbalancer_apiserver.port | default(kube_apiserver_port) }}
+  controlPlaneEndpoint: {{ kubeadm_config_api_fqdn }}
+  bindPort: {{ loadbalancer_apiserver.port | default(kube_apiserver_port) }}
 {% else %}
   advertiseAddress: {{ ip | default(ansible_default_ipv4.address) }}
   bindPort: {{ kube_apiserver_port }}

--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha2.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha2.yaml.j2
@@ -2,7 +2,8 @@ apiVersion: kubeadm.k8s.io/v1alpha2
 kind: MasterConfiguration
 api:
 {% if groups['kube-master'] | length > 1 and kubeadm_config_api_fqdn is defined %}
-  controlPlaneEndpoint: {{ kubeadm_config_api_fqdn }}:{{ loadbalancer_apiserver.port | default(kube_apiserver_port) }}
+  controlPlaneEndpoint: {{ kubeadm_config_api_fqdn }}
+  bindPort: {{ loadbalancer_apiserver.port | default(kube_apiserver_port) }}
 {% else %}
   advertiseAddress: {{ ip | default(ansible_default_ipv4.address) }}
   bindPort: {{ kube_apiserver_port }}


### PR DESCRIPTION
Hi! When using an external loadBalancer, using `{{ fqdn }}:{{ port }}` breaks regex filter in newer versions of kubeadm. this patch moves the port into the `bindPort` parameter.

