### PR TITLE
Calico: serviceaccounts is required in resources list of cluster role

### DIFF
--- a/roles/kubernetes-apps/policy_controller/calico/templates/calico-kube-cr.yml.j2
+++ b/roles/kubernetes-apps/policy_controller/calico/templates/calico-kube-cr.yml.j2
@@ -13,6 +13,7 @@ rules:
       - namespaces
       - networkpolicies
       - nodes
+      - serviceaccounts
     verbs:
       - watch
       - list


### PR DESCRIPTION
calico-kube-controllers pod logs the following error otherwise:
```
E1004 15:59:38.563990       1 reflector.go:205] github.com/projectcalico/kube-controllers/pkg/controllers/serviceaccount/serviceaaccount_controller.go:153: Failed to list *v1.ServiceAccount: serviceaccounts is forbidden: User "system:serviceaccount:kube-system:calico-kube-controllers" cannot list serviceaccounts at the cluster scope
```