### PR TITLE
Untaint master when it has node role

### DIFF
--- a/roles/kubernetes/master/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-setup.yml
@@ -210,3 +210,8 @@
 - name: kubeadm | cleanup old certs if necessary
   import_tasks: kubeadm-cleanup-old-certs.yml
   when: old_apiserver_cert.stat.exists
+
+- name: kubeadm | Remove taint for master with node role
+  command: "{{ bin_dir }}/kubectl taint node {{ inventory_hostname }} node-role.kubernetes.io/master:NoSchedule-"
+  delegate_to: "{{groups['kube-master']|first}}"
+  when: inventory_hostname in groups['kube-node']


### PR DESCRIPTION
For kubeadm, master node is tainted by default.
If node includes master role and node role, it should be schedulable, IMO.

This PR remove taint when master node have node role.

Node:
This PR is related to #3319, #3317.