### PR TITLE
Ability to define SSL certificates duration and SSL key size

### DIFF
--- a/roles/etcd/tasks/gen_certs_script.yml
+++ b/roles/etcd/tasks/gen_certs_script.yml
@@ -41,8 +41,8 @@
     - inventory_hostname == groups['etcd'][0]
 
 - name: Gen_certs | copy certs generation script
-  copy:
-    src: "make-ssl-etcd.sh"
+  template:
+    src: "make-ssl-etcd.sh.j2"
     dest: "{{ etcd_script_dir }}/make-ssl-etcd.sh"
     mode: 0700
   run_once: yes

--- a/roles/etcd/templates/make-ssl-etcd.sh.j2
+++ b/roles/etcd/templates/make-ssl-etcd.sh.j2
@@ -64,8 +64,8 @@ if [ -e "$SSLDIR/ca-key.pem" ]; then
     # Reuse existing CA
     cp $SSLDIR/{ca.pem,ca-key.pem} .
 else
-    openssl genrsa -out ca-key.pem 2048 > /dev/null 2>&1
-    openssl req -x509 -new -nodes -key ca-key.pem -days 36500 -out ca.pem -subj "/CN=etcd-ca" > /dev/null 2>&1
+    openssl genrsa -out ca-key.pem {{certificates_key_size}} > /dev/null 2>&1
+    openssl req -x509 -new -nodes -key ca-key.pem -days {{certificates_duration}} -out ca.pem -subj "/CN=etcd-ca" > /dev/null 2>&1
 fi
 
 # ETCD member
@@ -73,14 +73,14 @@ if [ -n "$MASTERS" ]; then
     for host in $MASTERS; do
         cn="${host%%.*}"
         # Member key
-        openssl genrsa -out member-${host}-key.pem 2048 > /dev/null 2>&1
+        openssl genrsa -out member-${host}-key.pem {{certificates_key_size}} > /dev/null 2>&1
         openssl req -new -key member-${host}-key.pem -out member-${host}.csr -subj "/CN=etcd-member-${cn}" -config ${CONFIG} > /dev/null 2>&1
-        openssl x509 -req -in member-${host}.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out member-${host}.pem -days 36500 -extensions ssl_client -extfile ${CONFIG} > /dev/null 2>&1
+        openssl x509 -req -in member-${host}.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out member-${host}.pem -days {{certificates_duration}} -extensions ssl_client -extfile ${CONFIG} > /dev/null 2>&1
 
         # Admin key
-        openssl genrsa -out admin-${host}-key.pem 2048 > /dev/null 2>&1
+        openssl genrsa -out admin-${host}-key.pem {{certificates_key_size}} > /dev/null 2>&1
         openssl req -new -key admin-${host}-key.pem -out admin-${host}.csr -subj "/CN=etcd-admin-${cn}" > /dev/null 2>&1
-        openssl x509 -req -in admin-${host}.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out admin-${host}.pem -days 36500 -extensions ssl_client  -extfile ${CONFIG} > /dev/null 2>&1
+        openssl x509 -req -in admin-${host}.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out admin-${host}.pem -days {{certificates_duration}} -extensions ssl_client  -extfile ${CONFIG} > /dev/null 2>&1
     done
 fi
 
@@ -88,9 +88,9 @@ fi
 if [ -n "$HOSTS" ]; then
     for host in $HOSTS; do
         cn="${host%%.*}"
-        openssl genrsa -out node-${host}-key.pem 2048 > /dev/null 2>&1
+        openssl genrsa -out node-${host}-key.pem {{certificates_key_size}} > /dev/null 2>&1
         openssl req -new -key node-${host}-key.pem -out node-${host}.csr -subj "/CN=etcd-node-${cn}" > /dev/null 2>&1
-        openssl x509 -req -in node-${host}.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out node-${host}.pem -days 36500 -extensions ssl_client  -extfile ${CONFIG} > /dev/null 2>&1
+        openssl x509 -req -in node-${host}.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out node-${host}.pem -days {{certificates_duration}} -extensions ssl_client  -extfile ${CONFIG} > /dev/null 2>&1
     done
 fi
 

--- a/roles/kubernetes-apps/helm/tasks/gen_helm_tiller_certs.yml
+++ b/roles/kubernetes-apps/helm/tasks/gen_helm_tiller_certs.yml
@@ -18,8 +18,8 @@
 - name: Gen_helm_tiller_certs | Copy certs generation script
   run_once: yes
   delegate_to: "{{groups['kube-master'][0]}}"
-  copy:
-    src: "helm-make-ssl.sh"
+  template:
+    src: "helm-make-ssl.sh.j2"
     dest: "{{ helm_script_dir }}/helm-make-ssl.sh"
     mode: 0700
 

--- a/roles/kubernetes-apps/helm/templates/helm-make-ssl.sh.j2
+++ b/roles/kubernetes-apps/helm/templates/helm-make-ssl.sh.j2
@@ -45,7 +45,7 @@ if [ -e "$SSLDIR/ca-key.pem" ]; then
     cp $SSLDIR/{ca.pem,ca-key.pem} .
 else
     openssl genrsa -out ca-key.pem 4096 > /dev/null 2>&1
-    openssl req -x509 -new -nodes -key ca-key.pem -days 36500 -out ca.pem -subj "/CN=tiller-ca" > /dev/null 2>&1
+    openssl req -x509 -new -nodes -key ca-key.pem -days {{certificates_duration}} -out ca.pem -subj "/CN=tiller-ca" > /dev/null 2>&1
 fi
 
 gen_key_and_cert() {
@@ -53,7 +53,7 @@ gen_key_and_cert() {
     local subject=$2
     openssl genrsa -out ${name}-key.pem 4096 > /dev/null 2>&1
     openssl req -new -key ${name}-key.pem -sha256 -out ${name}.csr -subj "${subject}" > /dev/null 2>&1
-    openssl x509 -req -in ${name}.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out ${name}.pem -days 36500 > /dev/null 2>&1
+    openssl x509 -req -in ${name}.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out ${name}.pem -days {{certificates_duration}} > /dev/null 2>&1
 }
 
 #Generate cert and key for Tiller if they don't exist

--- a/roles/kubernetes/secrets/tasks/gen_certs_script.yml
+++ b/roles/kubernetes/secrets/tasks/gen_certs_script.yml
@@ -37,8 +37,8 @@
   when: gen_certs|default(false)
 
 - name: Gen_certs | copy certs generation script
-  copy:
-    src: "make-ssl.sh"
+  template:
+    src: "make-ssl.sh.j2"
     dest: "{{ kube_script_dir }}/make-ssl.sh"
     mode: 0700
   run_once: yes

--- a/roles/kubernetes/secrets/templates/make-ssl.sh.j2
+++ b/roles/kubernetes/secrets/templates/make-ssl.sh.j2
@@ -68,8 +68,8 @@ if [ -e "$SSLDIR/ca-key.pem" ]; then
     # Reuse existing CA
     cp $SSLDIR/{ca.pem,ca-key.pem} .
 else
-    openssl genrsa -out ca-key.pem 2048 > /dev/null 2>&1
-    openssl req -x509 -new -nodes -key ca-key.pem -days 36500 -out ca.pem -subj "/CN=kube-ca" > /dev/null 2>&1
+    openssl genrsa -out ca-key.pem {{certificates_key_size}} > /dev/null 2>&1
+    openssl req -x509 -new -nodes -key ca-key.pem -days {{certificates_duration}} -out ca.pem -subj "/CN=kube-ca" > /dev/null 2>&1
 fi
 
 # Front proxy client CA
@@ -77,24 +77,24 @@ if [ -e "$SSLDIR/front-proxy-ca-key.pem" ]; then
     # Reuse existing front proxy CA
     cp $SSLDIR/{front-proxy-ca.pem,front-proxy-ca-key.pem} .
 else
-    openssl genrsa -out front-proxy-ca-key.pem 2048 > /dev/null 2>&1
-    openssl req -x509 -new -nodes -key front-proxy-ca-key.pem -days 36500 -out front-proxy-ca.pem -subj "/CN=front-proxy-ca" > /dev/null 2>&1
+    openssl genrsa -out front-proxy-ca-key.pem {{certificates_key_size}} > /dev/null 2>&1
+    openssl req -x509 -new -nodes -key front-proxy-ca-key.pem -days {{certificates_duration}} -out front-proxy-ca.pem -subj "/CN=front-proxy-ca" > /dev/null 2>&1
 fi
 
 gen_key_and_cert() {
     local name=$1
     local subject=$2
-    openssl genrsa -out ${name}-key.pem 2048 > /dev/null 2>&1
+    openssl genrsa -out ${name}-key.pem {{certificates_key_size}} > /dev/null 2>&1
     openssl req -new -key ${name}-key.pem -out ${name}.csr -subj "${subject}" -config ${CONFIG} > /dev/null 2>&1
-    openssl x509 -req -in ${name}.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out ${name}.pem -days 36500 -extensions v3_req -extfile ${CONFIG} > /dev/null 2>&1
+    openssl x509 -req -in ${name}.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out ${name}.pem -days {{certificates_duration}} -extensions v3_req -extfile ${CONFIG} > /dev/null 2>&1
 }
 
 gen_key_and_cert_front_proxy() {
     local name=$1
     local subject=$2
-    openssl genrsa -out ${name}-key.pem 2048 > /dev/null 2>&1
+    openssl genrsa -out ${name}-key.pem {{certificates_key_size}} > /dev/null 2>&1
     openssl req -new -key ${name}-key.pem -out ${name}.csr -subj "${subject}" -config ${CONFIG} > /dev/null 2>&1
-    openssl x509 -req -in ${name}.csr -CA front-proxy-ca.pem -CAkey front-proxy-ca-key.pem -CAcreateserial -out ${name}.pem -days 36500 -extensions v3_req -extfile ${CONFIG} > /dev/null 2>&1
+    openssl x509 -req -in ${name}.csr -CA front-proxy-ca.pem -CAkey front-proxy-ca-key.pem -CAcreateserial -out ${name}.pem -days {{certificates_duration}} -extensions v3_req -extfile ${CONFIG} > /dev/null 2>&1
 }
 
 # Admins
@@ -107,7 +107,7 @@ if [ -n "$MASTERS" ]; then
     fi
     # Generate dedicated service account signing key if one doesn't exist
     if ! [ -e "$SSLDIR/apiserver-key.pem" ] && ! [ -e "$SSLDIR/service-account-key.pem" ]; then
-        openssl genrsa -out service-account-key.pem 2048 > /dev/null 2>&1
+        openssl genrsa -out service-account-key.pem {{certificates_key_size}} > /dev/null 2>&1
     fi
 
     # kube-apiserver

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -439,3 +439,6 @@ podsecuritypolicy_enabled: false
 etcd_heartbeat_interval: "250"
 etcd_election_timeout: "5000"
 etcd_snapshot_count: "10000"
+
+certificates_key_size: 2048
+certificates_duration: 36500

--- a/roles/network_plugin/contiv/tasks/main.yml
+++ b/roles/network_plugin/contiv/tasks/main.yml
@@ -86,8 +86,19 @@
   register: contiv_manifests_results
   when: inventory_hostname in groups['kube-master']
 
+- name: Contiv | Copy certs generation script
+  template:
+    src: "generate-certificate.sh.j2"
+    dest: "/var/contiv/generate-certificate.sh"
+    mode: 0700
+  when:
+    - contiv_enable_api_proxy
+    - contiv_generate_certificate
+  delegate_to: "{{ groups['kube-master'][0] }}"
+  run_once: true
+
 - name: Contiv | Generate contiv-api-proxy certificates
-  script: generate-certificate.sh
+  script: /var/contiv/generate-certificate.sh
   args:
     creates: /var/contiv/auth_proxy_key.pem
   when:

--- a/roles/network_plugin/contiv/templates/generate-certificate.sh.j2
+++ b/roles/network_plugin/contiv/templates/generate-certificate.sh.j2
@@ -16,8 +16,8 @@ mkdir -p "$PREFIX"
 rm -f $KEY_PATH
 rm -f $CERT_PATH
 
-openssl genrsa -out $KEY_PATH 2048 >/dev/null 2>&1
-openssl req -new -x509 -sha256 -days 36500 \
+openssl genrsa -out $KEY_PATH {{certificates_key_size}} >/dev/null 2>&1
+openssl req -new -x509 -sha256 -days {{certificates_duration}} \
 	-key $KEY_PATH \
 	-out $CERT_PATH \
 	-subj "/C=US/ST=CA/L=San Jose/O=CPSG/OU=IT Department/CN=auth-local.cisco.com"


### PR DESCRIPTION
Instead of having hardcoded values (respectively 2048 and 36500), this PR introduces the ability to overwrite `certificates_key_size` and `certificates_duration` (which default respectively to 2048 and 36500)