### PR TITLE
Update CoreDNS templates to newest version and fix kubedns-autoscaler

### DIFF
--- a/roles/kubernetes-apps/ansible/templates/coredns-clusterrole.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-clusterrole.yml.j2
@@ -4,7 +4,6 @@ kind: ClusterRole
 metadata:
   labels:
     kubernetes.io/bootstrapping: rbac-defaults
-    addonmanager.kubernetes.io/mode: Reconcile
   name: system:coredns
 rules:
 - apiGroups:

--- a/roles/kubernetes-apps/ansible/templates/coredns-clusterrolebinding.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-clusterrolebinding.yml.j2
@@ -6,7 +6,6 @@ metadata:
     rbac.authorization.kubernetes.io/autoupdate: "true"
   labels:
     kubernetes.io/bootstrapping: rbac-defaults
-    addonmanager.kubernetes.io/mode: EnsureExists
   name: system:coredns
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
@@ -4,8 +4,6 @@ kind: ConfigMap
 metadata:
   name: coredns
   namespace: kube-system
-  labels:
-    addonmanager.kubernetes.io/mode: EnsureExists
 data:
   Corefile: |
     .:53 {
@@ -27,4 +25,7 @@ data:
         proxy . /etc/resolv.conf
 {% endif %}
         cache 30
+        loop
+        reload
+        loadbalance
     }

--- a/roles/kubernetes-apps/ansible/templates/coredns-deployment.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-deployment.yml.j2
@@ -6,9 +6,7 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: coredns{{ coredns_ordinal_suffix | default('') }}
-    kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: Reconcile
-    kubernetes.io/name: "CoreDNS"
+    kubernetes.io/name: "coredns{{ coredns_ordinal_suffix | default('') }}"
 spec:
   replicas: {{ coredns_replicas }}
   strategy:
@@ -79,6 +77,14 @@ spec:
         - containerPort: 9153
           name: metrics
           protocol: TCP
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - NET_BIND_SERVICE
+            drop:
+            - all
+          readOnlyRootFilesystem: true
         livenessProbe:
           httpGet:
             path: /health

--- a/roles/kubernetes-apps/ansible/templates/coredns-sa.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-sa.yml.j2
@@ -4,6 +4,3 @@ kind: ServiceAccount
 metadata:
   name: coredns
   namespace: kube-system
-  labels:
-    kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: Reconcile

--- a/roles/kubernetes-apps/ansible/templates/coredns-svc.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-svc.yml.j2
@@ -7,8 +7,7 @@ metadata:
   labels:
     k8s-app: coredns{{ coredns_ordinal_suffix | default('') }}
     kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: Reconcile
-    kubernetes.io/name: "CoreDNS"
+    kubernetes.io/name: "coredns{{ coredns_ordinal_suffix | default('') }}"
   annotations:
     prometheus.io/path: /metrics
     prometheus.io/port: "9153"

--- a/roles/kubernetes-apps/ansible/templates/kubedns-autoscaler-clusterrole.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/kubedns-autoscaler-clusterrole.yml.j2
@@ -21,7 +21,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["nodes"]
-    verbs: ["list"]
+    verbs: ["list", "watch"]
   - apiGroups: [""]
     resources: ["replicationcontrollers/scale"]
     verbs: ["get", "update"]


### PR DESCRIPTION
Synchronize our CoreDNS templates with https://github.com/coredns/deployment/blob/master/kubernetes/coredns.yaml.sed

Also fixes #3460 for kubedns-autoscaler