### PR TITLE
Calico: Ability to define the asNumber on a per node basis 

### DIFF
--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -159,6 +159,52 @@
     - calico_version | version_compare('v3.0.0', '<')
     - nodeToMeshEnabled|default(True)
 
+- name: Calico | Configure node asNumber for per node peering
+  shell: >
+   echo '{
+   "apiVersion": "projectcalico.org/v3",
+   "kind": "Node",
+   "metadata": {
+      "name": "{{ inventory_hostname }}"
+   },
+   "spec": {
+      "bgp": {
+        "asNumber": "{{ local_as }}"
+      },
+      "orchRefs":[{"nodeName":"{{ inventory_hostname }}","orchestrator":"k8s"}]
+   }}' | {{ bin_dir }}/calicoctl create --skip-exists -f -
+  retries: 4
+  delay: "{{ retry_stagger | random + 3 }}"
+  when:
+    - calico_version | version_compare('v3.0.0', '>=')
+    - peer_with_router|default(false)
+    - inventory_hostname in groups['k8s-cluster']
+    - local_as is defined
+    - groups['calico-rr'] | default([]) | length == 0
+
+- name: Calico | Configure node asNumber for per node peering (legacy)
+  shell: >
+   echo '{
+   "apiVersion": "v1",
+   "kind": "node",
+   "metadata": {
+      "name": "{{ inventory_hostname }}"
+   },
+   "spec": {
+      "bgp": {
+        "asNumber": "{{ local_as }}"
+      },
+      "orchRefs":[{"nodeName":"{{ inventory_hostname }}","orchestrator":"k8s"}]
+   }}' | {{ bin_dir }}/calicoctl create --skip-exists -f -
+  retries: 4
+  delay: "{{ retry_stagger | random + 3 }}"
+  when:
+    - calico_version | version_compare('v3.0.0', '<')
+    - peer_with_router|default(false)
+    - inventory_hostname in groups['k8s-cluster']
+    - local_as is defined
+    - groups['calico-rr'] | default([]) | length == 0
+
 - name: Calico | Configure peering with router(s)
   shell: >
    echo '{


### PR DESCRIPTION
With this, it is possible for nodes  to peer directly with routers (by defining peers accordingly also).
A condition has been set in order for that to only happen when route reflectors are not used (`calico-rr` empty), I guess both cases are mutually exclusive...