### PR TITLE
Calico: Ability to define global peerings 

### DIFF
--- a/docs/calico.md
+++ b/docs/calico.md
@@ -79,6 +79,13 @@ you'll need to edit the inventory and add a hostvar `local_as` by node.
 node1 ansible_ssh_host=95.54.0.12 local_as=xxxxxx
 ```
 
+##### Optional : Defining BGP peers
+
+Peers can be defined using the `peers` variable (see docs/calico_peer_example examples).
+In order to define global peers, the `peers` variable can be defined in group_vars with the "scope" attribute of each global peer set to "global".
+In order to define peers on a per node basis, the `peers` variable must be defined in hostvars.
+NB: Ansible's `hash_behaviour` is by default set to "replace", thus defining both global and per node peers would end up with having only per node peers. If having both global and per node peers defined was meant to happen, global peers would have to be defined in hostvars for each host (as well as per node peers)
+
 ##### Optional : Define global AS number
 
 Optional parameter `global_as_num` defines Calico global AS number (`/calico/bgp/v1/global/as_num` etcd key).

--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -205,7 +205,7 @@
     - local_as is defined
     - groups['calico-rr'] | default([]) | length == 0
 
-- name: Calico | Configure peering with router(s)
+- name: Calico | Configure peering with router(s) at node scope
   shell: >
    echo '{
    "apiVersion": "projectcalico.org/v3",
@@ -221,13 +221,13 @@
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
   with_items:
-    - "{{ peers|default([]) }}"
+    - "{{ peers|rejectattr('scope','equalto', 'global')|default([]) }}"
   when:
     - calico_version | version_compare('v3.0.0', '>=')
     - peer_with_router|default(false)
     - inventory_hostname in groups['k8s-cluster']
 
-- name: Calico | Configure peering with router(s) (legacy)
+- name: Calico | Configure peering with router(s) at node scope (legacy)
   shell: >
    echo '{
    "kind": "bgpPeer",
@@ -238,7 +238,47 @@
    | {{ bin_dir }}/calicoctl create --skip-exists -f -
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
-  with_items: "{{ peers|default([]) }}"
+  with_items: "{{ peers|rejectattr('scope','equalto', 'global')|default([]) }}"
+  when:
+    - calico_version | version_compare('v3.0.0', '<')
+    - peer_with_router|default(false)
+    - inventory_hostname in groups['k8s-cluster']
+
+- name: Calico | Configure peering with router(s) at global scope
+  shell: >
+   echo '{
+   "apiVersion": "projectcalico.org/v3",
+   "kind": "BGPPeer",
+   "metadata": {
+      "name": "global-{{ item.router_id }}"
+   },
+   "spec": {
+      "asNumber": "{{ item.as }}",
+      "peerIP": "{{ item.router_id }}"
+   }}' | {{ bin_dir }}/calicoctl create --skip-exists -f -
+  retries: 4
+  delay: "{{ retry_stagger | random + 3 }}"
+  with_items:
+    - "{{ peers|selectattr('scope','equalto', 'global')|default([]) }}"
+  run_once: true
+  when:
+    - calico_version | version_compare('v3.0.0', '>=')
+    - peer_with_router|default(false)
+    - inventory_hostname in groups['k8s-cluster']
+
+- name: Calico | Configure peering with router(s) at global scope (legacy)
+  shell: >
+   echo '{
+   "kind": "bgpPeer",
+   "spec": {"asNumber": "{{ item.as }}"},
+   "apiVersion": "v1",
+   "metadata": {"scope": "global", "peerIP": "{{ item.router_id }}"}
+   }'
+   | {{ bin_dir }}/calicoctl create --skip-exists -f -
+  retries: 4
+  delay: "{{ retry_stagger | random + 3 }}"
+  with_items: "{{ peers|selectattr('scope','equalto', 'global')|default([]) }}"
+  run_once: true
   when:
     - calico_version | version_compare('v3.0.0', '<')
     - peer_with_router|default(false)


### PR DESCRIPTION
With this, it is possible to define global peers by setting the scope attribute in each peer definition:
```
peers:
  -router_id: "10.99.0.2"
    as: "65xxx"
    scope: global
```

When the scope attribute is not set, the BGPPeer resource is considered at node scope and the current behaviour remains