### PR TITLE
Fix ansible syntax to avoid ansible warnings

### DIFF
--- a/roles/bootstrap-os/tasks/bootstrap-fedora.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-fedora.yml
@@ -11,7 +11,7 @@
 
 - name: Install python on fedora
   raw: "dnf install --assumeyes --quiet python"
-  when: "{{ need_bootstrap.results | map(attribute='rc') | sort | last | bool }}"
+  when: need_bootstrap.results | map(attribute='rc') | sort | last | bool
 
 - name: Install required python packages
   dnf:

--- a/roles/download/tasks/main.yml
+++ b/roles/download/tasks/main.yml
@@ -21,6 +21,6 @@
   when:
     - not skip_downloads|default(false)
     - item.value.enabled
-    - "{{ item.value.container | default(False) }}"
+    - item.value.container | default(false)
     - download_run_once
     - group_names | intersect(download.groups) | length

--- a/roles/kubernetes-apps/network_plugin/weave/tasks/main.yml
+++ b/roles/kubernetes-apps/network_plugin/weave/tasks/main.yml
@@ -17,5 +17,5 @@
   register: weave_status
   retries: 180
   delay: 5
-  until: "{{ weave_status.status == 200 and 'Status: ready' in weave_status.content }}"
+  until: "weave_status.status == 200 and 'Status: ready' in weave_status.content"
   when: inventory_hostname == groups['kube-master'][0]

--- a/roles/kubernetes/secrets/tasks/gen_certs_script.yml
+++ b/roles/kubernetes/secrets/tasks/gen_certs_script.yml
@@ -123,7 +123,7 @@
   when: inventory_hostname in groups['kube-master'] and
         inventory_hostname != groups['kube-master'][0] and
         (not item in kubecert_node.files | map(attribute='path') | map("basename") | list or
-        kubecert_node.files | selectattr("path", "equalto", "{{ kube_cert_dir }}/{{ item }}") | map(attribute="checksum")|first|default('') != kubecert_master.files | selectattr("path", "equalto", "{{ kube_cert_dir }}/{{ item }}") | map(attribute="checksum")|first|default(''))
+        kubecert_node.files | selectattr("path", "equalto", '%s/%s'|format(kube_cert_dir, item)) | map(attribute="checksum")|first|default('') != kubecert_master.files | selectattr("path", "equalto", '%s/%s'|format(kube_cert_dir, item)) | map(attribute="checksum")|first|default(''))
   with_items:
     - "{{ my_master_certs + all_node_certs }}"
 
@@ -133,7 +133,7 @@
   when: inventory_hostname in groups['kube-node'] and
         inventory_hostname != groups['kube-master'][0] and
         (not item in kubecert_node.files | map(attribute='path') | map("basename") | list or
-        kubecert_node.files | selectattr("path", "equalto", "{{ kube_cert_dir }}/{{ item }}") | map(attribute="checksum")|first|default('') != kubecert_master.files | selectattr("path", "equalto", "{{ kube_cert_dir }}/{{ item }}") | map(attribute="checksum")|first|default(''))
+        kubecert_node.files | selectattr("path", "equalto", '%s/%s'|format(kube_cert_dir, item)) | map(attribute="checksum")|first|default('') != kubecert_master.files | selectattr("path", "equalto", '%s/%s'|format(kube_cert_dir, item)) | map(attribute="checksum")|first|default(''))
   with_items:
     - "{{ my_node_certs }}"
 

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -81,6 +81,7 @@
   shell: mount | grep /var/lib/kubelet/ | awk '{print $3}' | tac
   check_mode: no
   register: mounted_dirs
+  warn: false
   tags:
     - mounts
 
@@ -209,7 +210,9 @@
       networking
       {%- endif %}
     state: restarted
-  when: ansible_os_family not in ["CoreOS", "Container Linux by CoreOS"] and reset_restart_network
+  when:
+    - ansible_os_family not in ["CoreOS", "Container Linux by CoreOS"]
+    - reset_restart_network
   tags:
     - services
     - network

--- a/tests/cloud_playbooks/create-do.yml
+++ b/tests/cloud_playbooks/create-do.yml
@@ -83,15 +83,15 @@
 
     - debug:
         msg: "{{droplets}}, {{inventory_path}}"
-      when: "{{ state == 'present' }}"
+      when: state == 'present'
 
     - name: Template the inventory
       template:
         src: ../templates/inventory-do.j2
         dest: "{{ inventory_path }}"
-      when: "{{ state == 'present' }}"
+      when: state == 'present'
 
     - name: Wait for SSH to come up
       wait_for: host={{item.droplet.ip_address}} port=22 delay=10 timeout=180 state=started
       with_items: "{{droplets.results}}"
-      when: "{{ state == 'present' }}"
+      when: state == 'present'

--- a/tests/testcases/040_check-network-adv.yml
+++ b/tests/testcases/040_check-network-adv.yml
@@ -3,7 +3,9 @@
   tasks:
     - name: Test tunl0 routes
       shell: "! /sbin/ip ro | grep '/26 via' | grep -v tunl0"
-      when: (ipip|default(false) or cloud_provider is defined) and (kube_network_plugin == 'calico')
+      when:
+        - (ipip|default(false) or cloud_provider is defined)
+        - kube_network_plugin == 'calico'
 
 - hosts: k8s-cluster
   vars:
@@ -35,7 +37,7 @@
       run_once: true
       delegate_to: "{{groups['kube-master'][0]}}"
       register: nca_pod
-      until: "{{ nca_pod.stdout_lines|length }} >= {{ groups['kube-node']|intersect(play_hosts)|length * 2 }}"
+      until: nca_pod.stdout_lines|length >= groups['kube-node']|intersect(play_hosts)|length * 2
       retries: 3
       delay: 10
 
@@ -46,9 +48,9 @@
       register: agents
       retries: 18
       delay: "{{ agent_report_interval }}"
-      until: "{{ agents.content|length > 0 and
+      until: agents.content|length > 0 and
         agents.content[0] == '{' and
-        agents.content|from_json|length >= groups['kube-node']|intersect(play_hosts)|length * 2 }}"
+        agents.content|from_json|length >= groups['kube-node']|intersect(play_hosts)|length * 2
       failed_when: false
       no_log: true
 


### PR DESCRIPTION
This PR aims to fix the output of such warnings:
```
[WARNING]: when statements should not include jinja2 templating delimiters such as {{ }} or {% %}
```