### PR TITLE
calico CALICO_IPV4POOL_IPIP overriding variable

### DIFF
--- a/roles/network_plugin/calico/defaults/main.yml
+++ b/roles/network_plugin/calico/defaults/main.yml
@@ -4,6 +4,7 @@ nat_outgoing: true
 
 # add default ippool name
 calico_pool_name: "default-pool"
+calico_ipv4pool_ipip: "Always"
 
 # Use IP-over-IP encapsulation across hosts
 ipip: true

--- a/roles/network_plugin/calico/templates/calico-node.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-node.yml.j2
@@ -77,8 +77,8 @@ spec:
 #            # Configure the IP Pool from which Pod IPs will be chosen.
 #            - name: CALICO_IPV4POOL_CIDR
 #              value: "192.168.0.0/16"
-#            - name: CALICO_IPV4POOL_IPIP
-#              value: "always"
+            - name: CALICO_IPV4POOL_IPIP
+              value: "{{ calico_ipv4pool_ipip }}"
             # Disable IPv6 on Kubernetes.
             - name: FELIX_IPV6SUPPORT
               value: "false"


### PR DESCRIPTION
not able to override CALICO_IPV4POOL_IPIP, so creating "calico_ipv4pool_ipip" 