### PR TITLE
Update pre-install verify settings with network checks and etc.

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -202,10 +202,3 @@
     msg: "resolvconf_mode can only be 'docker_dns', 'host_resolvconf' or 'none'"
   when: resolvconf_mode is defined
   run_once: true
-
-- name: Stop if upstream_dns_servers is defined with no dns servers
-  assert:
-    that: upstream_dns_servers|length > 0
-    msg: "You need to define dns servers for upstream_dns_servers"
-  when: upstream_dns_servers is defined
-  run_once: true

--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -153,3 +153,59 @@
     - 'calico_version_on_server.stdout != ""'
     - inventory_hostname == groups['kube-master'][0]
   run_once: yes
+
+- name: "Check that kube_service_addresses is a network range"
+  assert:
+    that:
+      - kube_service_addresses | ipaddr
+    msg: "kube_service_addresses is not a valid network range"
+  run_once: yes
+
+- name: "Check that kube_pods_subnet is a network range"
+  assert:
+    that:
+      - kube_pods_subnet | ipaddr
+    msg: "kube_pods_subnet is not a valid network range"
+  run_once: yes
+
+- name: "Check that kube_pods_subnet does not collide with kube_service_addresses"
+  assert:
+    that:
+      - kube_pods_subnet | ipaddr(kube_service_addresses) | string == 'None'
+    msg: "kube_pods_subnet cannot be the same network segment as kube_service_addresses"
+  run_once: yes
+
+- name: Stop if unknown dns mode
+  assert:
+    that: dns_mode in ['dnsmasq_kubedns', 'kubedns', 'coredns', 'coredns_dual', 'manual', 'none']
+    msg: "dns_mode can only be 'dnsmasq_kubedns', 'kubedns', 'coredns', 'coredns_dual', 'manual' or 'none'"
+  when: dns_mode is defined
+  run_once: true
+
+- name: Stop if unknown kube proxy mode
+  assert:
+    that: kube_proxy_mode in ['iptables', 'ipvs']
+    msg: "kube_proxy_mode can only be 'iptables' or 'ipvs'"
+  when: kube_proxy_mode is defined
+  run_once: true
+
+- name: Stop if unknown cert_management
+  assert:
+    that: cert_management in ['script', 'vault']
+    msg: "cert_management can only be 'script' or 'vault'"
+  when: cert_management is defined
+  run_once: true
+
+- name: Stop if unknown resolvconf_mode
+  assert:
+    that: resolvconf_mode in ['docker_dns', 'host_resolvconf', 'none']
+    msg: "resolvconf_mode can only be 'docker_dns', 'host_resolvconf' or 'none'"
+  when: resolvconf_mode is defined
+  run_once: true
+
+- name: Stop if upstream_dns_servers is defined with no dns servers
+  assert:
+    that: upstream_dns_servers|length > 0
+    msg: "You need to define dns servers for upstream_dns_servers"
+  when: upstream_dns_servers is defined
+  run_once: true


### PR DESCRIPTION
In #3501 the first issue was, that the user had configured `kube_pods_subnet` and `kube_service_addresses` to be the same network segment:

```
kube_service_addresses: 172.17.0.1/24
kube_pods_subnet: 172.17.0.1/24
```

This PR adds some pre-checks to verify settings, that `kube_pods_subnet` and `kube_service_addresses` first of all is valid networks and that they do not overlap to prevent IP collision.

Also, add some more basic checks to make sure Kubespray is configured properly.