### PR TITLE
Fix ansible syntax to avoid ansible warnings (again)

### DIFF
--- a/roles/etcd/tasks/check_certs.yml
+++ b/roles/etcd/tasks/check_certs.yml
@@ -57,12 +57,8 @@
 - name: "Check_certs | Set 'sync_certs' to true"
   set_fact:
     sync_certs: true
-  when: |-
-      {%- set certs = {'sync': False} -%}
-      {% if gen_node_certs[inventory_hostname] or
-        (not etcdcert_node.results[0].stat.exists|default(False)) or
-          (not etcdcert_node.results[1].stat.exists|default(False)) or
-            (etcdcert_node.results[1].stat.checksum|default('') != etcdcert_master.files|selectattr("path", "equalto", etcdcert_node.results[1].stat.path)|map(attribute="checksum")|first|default('')) -%}
-              {%- set _ = certs.update({'sync': True}) -%}
-      {% endif %}
-      {{ certs.sync }}
+  when:
+    - gen_node_certs[inventory_hostname] or
+      (not etcdcert_node.results[0].stat.exists|default(false)) or
+      (not etcdcert_node.results[1].stat.exists|default(false)) or
+      (etcdcert_node.results[1].stat.checksum|default('') != etcdcert_master.files|selectattr("path", "equalto", etcdcert_node.results[1].stat.path)|map(attribute="checksum")|first|default(''))

--- a/roles/kubernetes/secrets/tasks/check-tokens.yml
+++ b/roles/kubernetes/secrets/tasks/check-tokens.yml
@@ -24,8 +24,7 @@
 
 - name: "Check_tokens | Set 'sync_tokens' to true"
   set_fact:
-    sync_tokens: true
-  when: >-
+    sync_tokens: >-
       {%- set tokens = {'sync': False} -%}
       {%- for server in groups['kube-master'] | intersect(ansible_play_batch)
          if (not hostvars[server].known_tokens.stat.exists) or

--- a/roles/kubernetes/secrets/tasks/gen_tokens.yml
+++ b/roles/kubernetes/secrets/tasks/gen_tokens.yml
@@ -50,6 +50,7 @@
   check_mode: no
   delegate_to: "{{groups['kube-master'][0]}}"
   run_once: true
+  warn: false
   when: sync_tokens|default(false)
 
 - name: Gen_tokens | Copy tokens on masters

--- a/roles/kubernetes/secrets/tasks/gen_tokens.yml
+++ b/roles/kubernetes/secrets/tasks/gen_tokens.yml
@@ -46,11 +46,12 @@
 
 - name: Gen_tokens | Gather tokens
   shell: "tar cfz - {{ tokens_list.stdout_lines | join(' ') }} | base64 --wrap=0"
+  args:
+    warn: false
   register: tokens_data
   check_mode: no
   delegate_to: "{{groups['kube-master'][0]}}"
   run_once: true
-  warn: false
   when: sync_tokens|default(false)
 
 - name: Gen_tokens | Copy tokens on masters

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -79,9 +79,10 @@
 
 - name: reset | gather mounted kubelet dirs
   shell: mount | grep /var/lib/kubelet/ | awk '{print $3}' | tac
+  args:
+    warn: false
   check_mode: no
   register: mounted_dirs
-  warn: false
   tags:
     - mounts
 


### PR DESCRIPTION
This PR aims to fix the output of such warnings:
```
[WARNING]: when statements should not include jinja2 templating delimiters such as {{ }} or {% %}
```