### PR TITLE
Replace shell with command in order to allow the task to fail when openssl x509 does not return zero

### DIFF
--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -14,7 +14,7 @@
     - etcd-secrets
 
 - name: "Gen_certs | Get etcd certificate serials"
-  shell: "openssl x509 -in {{ etcd_cert_dir }}/node-{{ inventory_hostname }}.pem -noout -serial | cut -d= -f2"
+  command: "openssl x509 -in {{ etcd_cert_dir }}/node-{{ inventory_hostname }}.pem -noout -serial"
   register: "etcd_client_cert_serial_result"
   changed_when: false
   when: inventory_hostname in groups['k8s-cluster']|union(groups['etcd'])|union(groups['calico-rr']|default([]))|unique|sort
@@ -24,7 +24,7 @@
 
 - name: Set etcd_client_cert_serial
   set_fact:
-    etcd_client_cert_serial: "{{ etcd_client_cert_serial_result.stdout }}"
+    etcd_client_cert_serial: "{{ etcd_client_cert_serial_result.stdout.split('=')[1] }}"
   when: inventory_hostname in groups['k8s-cluster']|union(groups['etcd'])|union(groups['calico-rr']|default([]))|unique|sort
   tags:
     - master


### PR DESCRIPTION
Regarding the #3464 , the "Gen_certs | Get etcd certificate serials" task should have failed.