### PR TITLE
Add clear ipvs virtual server table when reset k8s

### DIFF
--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -107,6 +107,11 @@
   tags:
     - iptables
 
+- name: Clear IPVS virtual server table
+  shell: "ipvsadm -C"
+  when:
+    - kube_proxy_mode == 'ipvs'
+
 - name: reset | delete some files and directories
   file:
     path: "{{ item }}"


### PR DESCRIPTION
I used kube-proxy ipvs mode, after I reset the cluster, I found the virtual server table of ipvsadm still there.
So I want to improve the reset part for clear ipvs virtual server table.
Thank you.
cc #3465, #3416