### PR TITLE
[jjo] upgrade kube-router to v0.2.1

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -58,7 +58,7 @@ weave_version: "2.4.1"
 pod_infra_version: 3.1
 contiv_version: 1.2.1
 cilium_version: "v1.2.0"
-kube_router_version: "v0.2.0"
+kube_router_version: "v0.2.1"
 
 # Download URLs
 kubeadm_download_url: "https://storage.googleapis.com/kubernetes-release/release/{{ kubeadm_version }}/bin/linux/{{ image_arch }}/kubeadm"


### PR DESCRIPTION
kube-router v0.2.1 highlights from changelog:
- IPv6 WIP but pretty close to full working functionality
- fully support network policy semantics with addition of support for
  ipblock and except