### PR TITLE
fix readme.md sample/*

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To deploy the cluster you can use :
     sudo pip install -r requirements.txt
 
     # Copy ``inventory/sample`` as ``inventory/mycluster``
-    cp -rfp inventory/sample/* inventory/mycluster
+    cp -rfp inventory/sample inventory/mycluster
 
     # Update Ansible inventory file with inventory builder
     declare -a IPS=(10.10.1.3 10.10.1.4 10.10.1.5)


### PR DESCRIPTION
Dear,
This bug fix is about copy sample files in README.md.
If you run the command "cp -rfp inventory/sample/* inventory/mycluster", the output is:
     cp: target ‘inventory/mycluster’ is not a directory
So, we should remove "/*" behind sample.