### PR TITLE
Fix tasks to avoid ansible warning about raw module environment

### DIFF
--- a/roles/bootstrap-os/tasks/bootstrap-coreos.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-coreos.yml
@@ -2,6 +2,7 @@
 - name: Bootstrap | Check if bootstrap is needed
   raw: stat /opt/bin/.bootstrapped
   register: need_bootstrap
+  environment: {}
   failed_when: false
   changed_when: false
   tags:

--- a/roles/bootstrap-os/tasks/bootstrap-debian.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-debian.yml
@@ -10,12 +10,14 @@
     - python
     - pip
     - dbus-daemon
+  environment: {}
   tags: facts
 
 - name: Bootstrap | Install python 2.x, pip, and dbus
   raw:
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y python-minimal python-pip dbus
+  environment: {}
   when:
     need_bootstrap.results | map(attribute='rc') | sort | last | bool
 

--- a/roles/bootstrap-os/tasks/bootstrap-fedora.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-fedora.yml
@@ -7,10 +7,12 @@
   changed_when: false
   with_items:
     - python
+  environment: {}
   tags: facts
 
 - name: Install python on fedora
   raw: "dnf install --assumeyes --quiet python"
+  environment: {}
   when: need_bootstrap.results | map(attribute='rc') | sort | last | bool
 
 - name: Install required python packages

--- a/roles/bootstrap-os/tasks/bootstrap-ubuntu.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-ubuntu.yml
@@ -15,7 +15,7 @@
   failed_when: false
   changed_when: false
   with_items: "{{ubuntu_packages}}"
-
+  environment: {}
   tags:
     - facts
 
@@ -23,6 +23,7 @@
   raw:
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y {{ubuntu_packages | join(" ")}}
+  environment: {}
   when:
     - need_bootstrap.results | map(attribute='rc') | sort | last | bool
 

--- a/roles/bootstrap-os/tasks/main.yml
+++ b/roles/bootstrap-os/tasks/main.yml
@@ -3,6 +3,7 @@
   raw: cat /etc/os-release
   register: os_release
   changed_when: false
+  environment: {}
 
 - name: Set bootstrap_os
   set_fact:

--- a/roles/download/tasks/download_prep.yml
+++ b/roles/download/tasks/download_prep.yml
@@ -7,6 +7,7 @@
   failed_when: false
   changed_when: false
   check_mode: no
+  environment: {}
   when: download_container
 
 - name: container_download | Create dest directory for saved/loaded container images

--- a/roles/download/tasks/set_docker_image_facts.yml
+++ b/roles/download/tasks/set_docker_image_facts.yml
@@ -15,6 +15,7 @@
   failed_when: false
   changed_when: false
   check_mode: no
+  environment: {}
   when: not download_always_pull
 
 - set_fact:


### PR DESCRIPTION
This PR just sets the environment attribute to an empty dict for tasks using the `raw` module which "does not support the environment keyword"
```
 [WARNING]: raw module does not support the environment keyword
```