### PR TITLE
Calico: Fix peering with router(s)

### DIFF
--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -221,7 +221,7 @@
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
   with_items:
-    - "{{ peers|rejectattr('scope','equalto', 'global')|default([]) }}"
+    - "{{ peers|selectattr('scope','undefined')|list|default([]) | union(peers|selectattr('scope','defined')|selectattr('scope','equalto', 'node')|list|default([])) }}"
   when:
     - calico_version is version('v3.0.0', '>=')
     - peer_with_router|default(false)
@@ -238,7 +238,7 @@
    | {{ bin_dir }}/calicoctl create --skip-exists -f -
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
-  with_items: "{{ peers|rejectattr('scope','equalto', 'global')|default([]) }}"
+  with_items: "{{ peers|selectattr('scope','undefined')|list|default([]) | union(peers|selectattr('scope','defined')|selectattr('scope','equalto', 'node')|list|default([])) }}"
   when:
     - calico_version | version_compare('v3.0.0', '<')
     - peer_with_router|default(false)
@@ -259,7 +259,7 @@
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
   with_items:
-    - "{{ peers|selectattr('scope','equalto', 'global')|default([]) }}"
+    - "{{ peers|selectattr('scope','defined')|selectattr('scope','equalto', 'global')|list|default([]) }}"
   run_once: true
   when:
     - calico_version | version_compare('v3.0.0', '>=')
@@ -277,7 +277,7 @@
    | {{ bin_dir }}/calicoctl create --skip-exists -f -
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
-  with_items: "{{ peers|selectattr('scope','equalto', 'global')|default([]) }}"
+  with_items: "{{ peers|selectattr('scope','defined')|selectattr('scope','equalto', 'global')|default([]) }}"
   run_once: true
   when:
     - calico_version is version('v3.0.0', '<')


### PR DESCRIPTION
This PR should fix this:
`rejectattr` and `selectattr` jinja filters expect the tested attribute to exist when applying the function ('equalto' in this case). When the peering occurs at node scope (which is the default and backward compatible behaviour before introducing peering at global scope), it fails.