### PR TITLE
Install ipvsadm when kube_proxy_mode is ipvs

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0070-system-packages.yml
+++ b/roles/kubernetes/preinstall/tasks/0070-system-packages.yml
@@ -80,6 +80,11 @@
   tags:
     - bootstrap-os
 
+- name: Update common_required_pkgs with ipvsadm when kube_proxy_mode is ipvs
+  set_fact:
+    common_required_pkgs: "{{ common_required_pkgs|default([]) + ['ipvsadm'] }}"
+  when: kube_proxy_mode == 'ipvs'
+
 - name: Install packages requirements
   action:
     module: "{{ ansible_pkg_mgr }}"


### PR DESCRIPTION
ipvsadm is used in roles/reset/tasks/main.yml but is never installed