### PR TITLE
[contrib/terraform/openstack] Add support for router less deployments

### DIFF
--- a/contrib/terraform/openstack/README.md
+++ b/contrib/terraform/openstack/README.md
@@ -16,13 +16,13 @@ most modern installs of OpenStack that support the basic services.
 - [ElastX](https://elastx.se/)
 - [EnterCloudSuite](https://www.entercloudsuite.com/)
 - [FugaCloud](https://fuga.cloud/)
+- [OVH](https://www.ovh.com/)
+- [Rackspace](https://www.rackspace.com/)
 - [Ultimum](https://ultimum.io/)
 - [VexxHost](https://vexxhost.com/)
 - [Zetta](https://www.zetta.io/)
 
 ### Known incompatible public clouds
-- OVH: No router support
-- Rackspace: No router support
 - T-Systems / Open Telekom Cloud: requires `wait_until_associated`
 
 ## Approach

--- a/contrib/terraform/openstack/kubespray.tf
+++ b/contrib/terraform/openstack/kubespray.tf
@@ -6,6 +6,7 @@ module "network" {
   subnet_cidr     = "${var.subnet_cidr}"
   cluster_name    = "${var.cluster_name}"
   dns_nameservers = "${var.dns_nameservers}"
+  use_neutron     = "${var.use_neutron}"
 }
 
 module "ips" {

--- a/contrib/terraform/openstack/modules/compute/variables.tf
+++ b/contrib/terraform/openstack/modules/compute/variables.tf
@@ -46,7 +46,9 @@ variable "network_name" {}
 
 variable "flavor_bastion" {}
 
-variable "network_id" {}
+variable "network_id" {
+  default = ""
+}
 
 variable "k8s_master_fips" {
   type = "list"

--- a/contrib/terraform/openstack/modules/ips/variables.tf
+++ b/contrib/terraform/openstack/modules/ips/variables.tf
@@ -12,4 +12,6 @@ variable "external_net" {}
 
 variable "network_name" {}
 
-variable "router_id" {}
+variable "router_id" {
+  default = ""
+}

--- a/contrib/terraform/openstack/modules/network/main.tf
+++ b/contrib/terraform/openstack/modules/network/main.tf
@@ -1,16 +1,19 @@
 resource "openstack_networking_router_v2" "k8s" {
   name                = "${var.cluster_name}-router"
+  count               = "${var.use_neutron}"
   admin_state_up      = "true"
   external_network_id = "${var.external_net}"
 }
 
 resource "openstack_networking_network_v2" "k8s" {
   name           = "${var.network_name}"
+  count          = "${var.use_neutron}"
   admin_state_up = "true"
 }
 
 resource "openstack_networking_subnet_v2" "k8s" {
   name            = "${var.cluster_name}-internal-network"
+  count           = "${var.use_neutron}"
   network_id      = "${openstack_networking_network_v2.k8s.id}"
   cidr            = "${var.subnet_cidr}"
   ip_version      = 4
@@ -18,6 +21,7 @@ resource "openstack_networking_subnet_v2" "k8s" {
 }
 
 resource "openstack_networking_router_interface_v2" "k8s" {
+  count     = "${var.use_neutron}"
   router_id = "${openstack_networking_router_v2.k8s.id}"
   subnet_id = "${openstack_networking_subnet_v2.k8s.id}"
 }

--- a/contrib/terraform/openstack/modules/network/outputs.tf
+++ b/contrib/terraform/openstack/modules/network/outputs.tf
@@ -1,11 +1,12 @@
 output "router_id" {
-  value = "${openstack_networking_router_v2.k8s.id}"
+  value = "${element(concat(openstack_networking_router_v2.k8s.*.id, list("")), 0)}"
 }
 
 output "router_internal_port_id" {
-  value = "${openstack_networking_router_interface_v2.k8s.id}"
+  value = "${element(concat(openstack_networking_router_interface_v2.k8s.*.id, list("")), 0)}"
+
 }
 
 output "subnet_id" {
-  value = "${openstack_networking_subnet_v2.k8s.id}"
+  value = "${element(concat(openstack_networking_subnet_v2.k8s.*.id, list("")), 0)}"
 }

--- a/contrib/terraform/openstack/modules/network/variables.tf
+++ b/contrib/terraform/openstack/modules/network/variables.tf
@@ -9,3 +9,5 @@ variable "dns_nameservers" {
 }
 
 variable "subnet_cidr" {}
+
+variable "use_neutron" {}

--- a/contrib/terraform/openstack/variables.tf
+++ b/contrib/terraform/openstack/variables.tf
@@ -103,6 +103,11 @@ variable "network_name" {
   default     = "internal"
 }
 
+variable "use_neutron" {
+  description = "Use neutron"
+  default     = 1
+}
+
 variable "subnet_cidr" {
   description = "Subnet CIDR block."
   type = "string"


### PR DESCRIPTION
Some OpenStack cloud providers do not allow Neutron routers. This PR adds a variable to enable/disable the creation of neutron routers (enabled by default for backwards compatibility).

Tested with OVH public cloud.