### PR TITLE
Align node-role value for kubeadm compatibility

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster/addons.yml
+++ b/inventory/sample/group_vars/k8s-cluster/addons.yml
@@ -44,7 +44,7 @@ cephfs_provisioner_enabled: false
 ingress_nginx_enabled: false
 # ingress_nginx_host_network: false
 # ingress_nginx_nodeselector:
-#   node-role.kubernetes.io/master: "true"
+#   node-role.kubernetes.io/master: ""
 # ingress_nginx_namespace: "ingress-nginx"
 # ingress_nginx_insecure_port: 80
 # ingress_nginx_secure_port: 443

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/defaults/main.yml
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/defaults/main.yml
@@ -2,7 +2,7 @@
 ingress_nginx_namespace: "ingress-nginx"
 ingress_nginx_host_network: false
 ingress_nginx_nodeselector:
-  node-role.kubernetes.io/master: "true"
+  node-role.kubernetes.io/master: ""
 ingress_nginx_insecure_port: 80
 ingress_nginx_secure_port: 443
 ingress_nginx_configmap: {}

--- a/roles/kubernetes/node/templates/kubelet.kubeadm.env.j2
+++ b/roles/kubernetes/node/templates/kubelet.kubeadm.env.j2
@@ -81,12 +81,12 @@ KUBELET_HOSTNAME="--hostname-override={{ kube_override_hostname }}"
 {# Kubelet node labels #}
 {% set role_node_labels = [] %}
 {% if inventory_hostname in groups['kube-master'] %}
-{%   set dummy = role_node_labels.append('node-role.kubernetes.io/master=true') %}
+{%   set dummy = role_node_labels.append("node-role.kubernetes.io/master=''") %}
 {%   if not standalone_kubelet|bool %}
-{%     set dummy = role_node_labels.append('node-role.kubernetes.io/node=true') %}
+{%     set dummy = role_node_labels.append("node-role.kubernetes.io/node=''") %}
 {%   endif %}
 {% else %}
-{%   set dummy = role_node_labels.append('node-role.kubernetes.io/node=true') %}
+{%   set dummy = role_node_labels.append("node-role.kubernetes.io/node=''") %}
 {% endif %}
 {% set inventory_node_labels = [] %}
 {% if node_labels is defined %}

--- a/roles/kubernetes/node/templates/kubelet.standard.env.j2
+++ b/roles/kubernetes/node/templates/kubelet.standard.env.j2
@@ -95,12 +95,12 @@ KUBELET_HOSTNAME="--hostname-override={{ kube_override_hostname }}"
 {# Kubelet node labels #}
 {% set role_node_labels = [] %}
 {% if inventory_hostname in groups['kube-master'] %}
-{%   set dummy = role_node_labels.append('node-role.kubernetes.io/master=true') %}
+{%   set dummy = role_node_labels.append("node-role.kubernetes.io/master=''") %}
 {%   if not standalone_kubelet|bool %}
-{%     set dummy = role_node_labels.append('node-role.kubernetes.io/node=true') %}
+{%     set dummy = role_node_labels.append("node-role.kubernetes.io/node=''") %}
 {%   endif %}
 {% else %}
-{%   set dummy = role_node_labels.append('node-role.kubernetes.io/node=true') %}
+{%   set dummy = role_node_labels.append("node-role.kubernetes.io/node=''") %}
 {% endif %}
 {% if nvidia_gpu_nodes is defined and nvidia_accelerator_enabled|bool %}
 {%   if inventory_hostname in nvidia_gpu_nodes %}

--- a/roles/network_plugin/contiv/templates/contiv-api-proxy.yml.j2
+++ b/roles/network_plugin/contiv/templates/contiv-api-proxy.yml.j2
@@ -27,7 +27,7 @@ spec:
       hostNetwork: true
       hostPID: true
       nodeSelector:
-        node-role.kubernetes.io/master: "true"
+        node-role.kubernetes.io/master: ""
       tolerations:
         - operator: Exists
         # Mark pod as critical for rescheduling (Will have no effect starting with kubernetes 1.12)

--- a/roles/network_plugin/contiv/templates/contiv-etcd.yml.j2
+++ b/roles/network_plugin/contiv/templates/contiv-etcd.yml.j2
@@ -23,7 +23,7 @@ spec:
       hostNetwork: true
       hostPID: true
       nodeSelector:
-        node-role.kubernetes.io/master: "true"
+        node-role.kubernetes.io/master: ""
       tolerations:
         - operator: Exists
         # Mark pod as critical for rescheduling (Will have no effect starting with kubernetes 1.12)

--- a/roles/network_plugin/contiv/templates/contiv-netmaster.yml.j2
+++ b/roles/network_plugin/contiv/templates/contiv-netmaster.yml.j2
@@ -27,7 +27,7 @@ spec:
       hostNetwork: true
       hostPID: true
       nodeSelector:
-        node-role.kubernetes.io/master: "true"
+        node-role.kubernetes.io/master: ""
       tolerations:
         - operator: Exists
         # Mark pod as critical for rescheduling (Will have no effect starting with kubernetes 1.12)


### PR DESCRIPTION
kubeadm sets node label node-role.kubernetes.io/master=''
and this is not configurable. We should use it everywhere.