### PR TITLE
fix provisioning of single node with -l <node_name>

### DIFF
--- a/roles/etcd/tasks/gen_certs_script.yml
+++ b/roles/etcd/tasks/gen_certs_script.yml
@@ -68,7 +68,6 @@
   delegate_to: "{{groups['etcd'][0]}}"
   when:
     - gen_certs|default(false)
-    - inventory_hostname == groups['etcd'][0]
   notify: set etcd_secret_changed
 
 - name: Gen_certs | Gather etcd master certs


### PR DESCRIPTION
I encountered a problem provisioning single nodes that I wanted to add to an existing cluster.
The problem was this condition at the certificate genaration task `inventory_hostname == groups['etcd'][0]`
So the certificates were only generated if the first member of the etcd group is part of the play.

Since this task has also run_once set to true I think that this condition can be removed.