### PR TITLE
Add bin_dir to kubectl version check

### DIFF
--- a/roles/upgrade/pre-upgrade/tasks/main.yml
+++ b/roles/upgrade/pre-upgrade/tasks/main.yml
@@ -33,7 +33,7 @@
   when: needs_cordoning
 
 - name: Check kubectl version
-  command: kubectl version --client --short
+  command: "{{ bin_dir }}/kubectl version --client --short"
   register: kubectl_version
   delegate_to: "{{ groups['kube-master'][0] }}"
   run_once: yes


### PR DESCRIPTION
kubectl binary may not be found if full path not specified.