### PR TITLE
remove deprecated parameters of blockinfile module

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0060-resolvconf.yml
+++ b/roles/kubernetes/preinstall/tasks/0060-resolvconf.yml
@@ -5,7 +5,7 @@
 
 - name: Add domain/search/nameservers/options to resolv.conf
   blockinfile:
-    dest: "{{resolvconffile}}"
+    path: "{{resolvconffile}}"
     block: |-
       {% for item in [domainentry] + [searchentries] + nameserverentries.split(',') -%}
       {{ item }}
@@ -17,7 +17,6 @@
     insertbefore: BOF
     create: yes
     backup: yes
-    follow: yes
     marker: "# Ansible entries {mark}"
   notify: Preinstall | restart network
 

--- a/roles/kubernetes/preinstall/tasks/0090-etchosts.yml
+++ b/roles/kubernetes/preinstall/tasks/0090-etchosts.yml
@@ -1,7 +1,7 @@
 ---
 - name: Hosts | populate inventory into hosts file
   blockinfile:
-    dest: /etc/hosts
+    path: /etc/hosts
     block: |-
       {% for item in (groups['k8s-cluster'] + groups['etcd'] + groups['calico-rr']|default([]))|unique -%}{{ hostvars[item]['access_ip'] | default(hostvars[item]['ip'] | default(hostvars[item]['ansible_default_ipv4']['address'])) }}{% if (item != hostvars[item]['ansible_hostname']) %} {{ hostvars[item]['ansible_hostname'] }}.{{ dns_domain }} {{ hostvars[item]['ansible_hostname'] }}{% endif %} {{ item }} {{ item }}.{{ dns_domain }}
       {% endfor %}

--- a/roles/kubernetes/preinstall/tasks/0100-dhclient-hooks.yml
+++ b/roles/kubernetes/preinstall/tasks/0100-dhclient-hooks.yml
@@ -5,12 +5,11 @@
       {% for item in [ supersede_domain, supersede_search, supersede_nameserver ] -%}
       {{ item }}
       {% endfor %}
-    dest: "{{dhclientconffile}}"
+    path: "{{dhclientconffile}}"
     create: yes
     state: present
     insertbefore: BOF
     backup: yes
-    follow: yes
     marker: "# Ansible entries {mark}"
   notify: Preinstall | restart network
   when: dhclientconffile is defined

--- a/roles/kubernetes/preinstall/tasks/0110-dhclient-hooks-undo.yml
+++ b/roles/kubernetes/preinstall/tasks/0110-dhclient-hooks-undo.yml
@@ -5,10 +5,9 @@
 
 - name: Remove kubespray specific config from dhclient config
   blockinfile:
-    dest: "{{dhclientconffile}}"
+    path: "{{dhclientconffile}}"
     state: absent
     backup: yes
-    follow: yes
     marker: "# Ansible entries {mark}"
   when: dhclientconffile is defined
   notify: Preinstall | restart network

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -177,9 +177,8 @@
 
 - name: reset | remove dns settings from dhclient.conf
   blockinfile:
-    dest: "{{ item }}"
+    path: "{{ item }}"
     state: absent
-    follow: yes
     marker: "# Ansible entries {mark}"
   failed_when: false
   with_items:
@@ -191,9 +190,8 @@
 
 - name: reset | remove host entries from /etc/hosts
   blockinfile:
-    dest: "/etc/hosts"
+    path: "/etc/hosts"
     state: absent
-    follow: yes
     marker: "# Ansible inventory hosts {mark}"
   tags:
     - files


### PR DESCRIPTION
blockinfile module:

- As of Ansible 2.3, the dest option has been changed to path as default, but dest still works as well.
- Option follow has been removed in version 2.5, because this module modifies the contents of the file so follow=no doesn’t make sense.