### PR TITLE
Use IPv4/IPv6 access_ips generated by terraform dynamic inventory in SSL key SANs

### DIFF
--- a/roles/etcd/templates/openssl.conf.j2
+++ b/roles/etcd/templates/openssl.conf.j2
@@ -37,6 +37,12 @@ DNS.{{ counter["dns"] }} = {{ etcd_alt_name }}{{ increment(counter, 'dns') }}
 {% if hostvars[host]['access_ip'] is defined  %}
 IP.{{ counter["ip"] }} = {{ hostvars[host]['access_ip'] }}{{ increment(counter, 'ip') }}
 {% endif %}
+{% if hostvars[host]['access_ip_v4'] is defined and hostvars[host]['access_ip_v4'] != "" %}
+IP.{{ counter["ip"] }} = {{ hostvars[host]['access_ip_v4'] }}{{ increment(counter, 'ip') }}
+{% endif %}
+{% if hostvars[host]['access_ip_v6'] is defined and hostvars[host]['access_ip_v6'] != "" %}
+IP.{{ counter["ip"] }} = {{ hostvars[host]['access_ip_v6'] }}{{ increment(counter, 'ip') }}
+{% endif %}
 IP.{{ counter["ip"] }} = {{ hostvars[host]['ip'] | default(hostvars[host]['ansible_default_ipv4']['address']) }}{{ increment(counter, 'ip') }}
 {% endfor %}
 {% for cert_alt_ip in etcd_cert_alt_ips %}

--- a/roles/kubernetes/master/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-setup.yml
@@ -52,6 +52,8 @@
       {%- endif %}
       {%- for host in groups['kube-master'] -%}
       {%- if hostvars[host]['access_ip'] is defined %}{{ hostvars[host]['access_ip'] }}{% endif %}
+      {%- if hostvars[host]['access_ip_v4'] is defined and hostvars[host]['access_ip_v4'] != "" %}{{ hostvars[host]['access_ip_v4'] }}{% endif %}
+      {%- if hostvars[host]['access_ip_v6'] is defined and hostvars[host]['access_ip_v6'] != "" %}{{ hostvars[host]['access_ip_v6'] }}{% endif %}
       {{ hostvars[host]['ip'] | default(hostvars[host]['ansible_default_ipv4']['address']) }}
       {%- endfor %}
       {%- if supplementary_addresses_in_ssl_keys is defined %}

--- a/roles/kubernetes/secrets/templates/openssl.conf.j2
+++ b/roles/kubernetes/secrets/templates/openssl.conf.j2
@@ -19,8 +19,14 @@ DNS.{{ counter["dns"] }} = {{ host }}{{ increment(counter, 'dns') }}
 DNS.{{ counter["dns"] }} = {{ apiserver_loadbalancer_domain_name }}{{ increment(counter, 'dns') }}
 {% endif %}
 {% for host in groups['kube-master'] %}
-{% if hostvars[host]['access_ip'] is defined  %}
+{% if hostvars[host]['access_ip'] is defined %}
 IP.{{ counter["ip"] }} = {{ hostvars[host]['access_ip'] }}{{ increment(counter, 'ip') }}
+{% endif %}
+{% if hostvars[host]['access_ip_v4'] is defined and hostvars[host]['access_ip_v4'] != "" %}
+IP.{{ counter["ip"] }} = {{ hostvars[host]['access_ip_v4'] }}{{ increment(counter, 'ip') }}
+{% endif %}
+{% if hostvars[host]['access_ip_v6'] is defined and hostvars[host]['access_ip_v6'] != "" %}
+IP.{{ counter["ip"] }} = {{ hostvars[host]['access_ip_v6'] }}{{ increment(counter, 'ip') }}
 {% endif %}
 IP.{{ counter["ip"] }} = {{ hostvars[host]['ip'] | default(hostvars[host]['ansible_default_ipv4']['address']) }}{{ increment(counter, 'ip') }}
 {% endfor %}


### PR DESCRIPTION
<!-- Thanks for filing an issue! Before hitting the button, please answer these questions.-->

**Is this a BUG REPORT or FEATURE REQUEST?** (choose one): Feature Request

Currently, [contrib/terraform/terraform.py](`contrib/terraform/terraform.py`) sets IP version-specific host vars for `access_ip` and does not set `access_ip`, however jinja templates and the kubeadm setup task only uses `access_ip`. This changes that to additionally use `access_ip_v(4|6)` when available

**Environment**:
- **Cloud provider or hardware configuration:**
OpenStack

- **OS (`printf "$(uname -srm)\n$(cat /etc/os-release)\n"`):**
```Linux 4.15.0-20-generic x86_64
NAME="Ubuntu"
VERSION="18.04.1 LTS (Bionic Beaver)"
ID=ubuntu
ID_LIKE=debian
PRETTY_NAME="Ubuntu 18.04.1 LTS"
VERSION_ID="18.04"
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
VERSION_CODENAME=bionic
UBUNTU_CODENAME=bionic
```

- **Version of Ansible** (`ansible --version`):
```ansible 2.6.5
  config file = /home/twexler/dev/kubespray/ansible.cfg
  configured module search path = [u'/home/twexler/dev/kubespray/library']
  ansible python module location = /home/twexler/dev/kubespray/env/local/lib/python2.7/site-packages/ansible
  executable location = /home/twexler/dev/kubespray/env/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.```

**Kubespray version (commit) (`git rev-parse --short HEAD`):**
7e84de2a

**Network plugin used**:
calico

**Copy of your inventory file:**
It's dynamic, generated by [contrib/terraform/terraform.py](`contrib/terraform/terraform.py`)

**Command used to invoke ansible**:
`ansible-playbook --become -i inventory/kubespray-test/hosts cluster.yml`

**Output of ansible run**:

I can't provide this due to company policy.

**Anything else do we need to know**:
Nope