### PR TITLE
Add an 'access_ip' for openstack resources to the terraform inventory builder script

### DIFF
--- a/contrib/terraform/openstack/README.md
+++ b/contrib/terraform/openstack/README.md
@@ -436,14 +436,6 @@ $ kubectl config use-context default-system
 kubectl version
 ```
 
-If you are using floating ip addresses then you may get this error:
-```
-Unable to connect to the server: x509: certificate is valid for 10.0.0.6, 10.233.0.1, 127.0.0.1, not 132.249.238.25
-```
-
-You can tell kubectl to ignore this condition by adding the
-`--insecure-skip-tls-verify` option.
-
 ## GlusterFS
 GlusterFS is not deployed by the standard`cluster.yml` playbook, see the
 [GlusterFS playbook documentation](../../network-storage/glusterfs/README.md)

--- a/contrib/terraform/terraform.py
+++ b/contrib/terraform/terraform.py
@@ -328,6 +328,9 @@ def openstack_host(resource, module_name):
     attrs = {
         'access_ip_v4': raw_attrs['access_ip_v4'],
         'access_ip_v6': raw_attrs['access_ip_v6'],
+        'access_ip': (
+            raw_attrs['access_ip_v6'] if raw_attrs['access_ip_v6']
+            else raw_attrs['access_ip_v4']),
         'ip': raw_attrs['network.0.fixed_ip_v4'],
         'flavor': parse_dict(raw_attrs, 'flavor',
                              sep='_'),

--- a/contrib/terraform/terraform.py
+++ b/contrib/terraform/terraform.py
@@ -686,6 +686,7 @@ def iter_host_ips(hosts, ips):
             ip = ips[host_id]
             host[1].update({
                 'access_ip_v4': ip,
+                'access_ip': ip,
                 'public_ipv4': ip,
                 'ansible_ssh_host': ip,
             })

--- a/contrib/terraform/terraform.py
+++ b/contrib/terraform/terraform.py
@@ -328,9 +328,7 @@ def openstack_host(resource, module_name):
     attrs = {
         'access_ip_v4': raw_attrs['access_ip_v4'],
         'access_ip_v6': raw_attrs['access_ip_v6'],
-        'access_ip': (
-            raw_attrs['access_ip_v6'] if raw_attrs['access_ip_v6']
-            else raw_attrs['access_ip_v4']),
+        'access_ip': raw_attrs['access_ip_v4'],
         'ip': raw_attrs['network.0.fixed_ip_v4'],
         'flavor': parse_dict(raw_attrs, 'flavor',
                              sep='_'),


### PR DESCRIPTION
<!-- Thanks for filing an issue! Before hitting the button, please answer these questions.-->

**Is this a BUG REPORT or FEATURE REQUEST?** (choose one): Bug Report

The OpenStack [`README.md`](contrib/openstack/README.md) recommends to ignore invalid TLS certificates, which is a security issue. This recommendation stems from the fact that the terraform dynamic inventory script does not provide `access_ip` for OpenStack resources. This resolves that issue, and removes the offending section in the README.

**Environment**:
- **Cloud provider or hardware configuration:**
OpenStack

- **OS (`printf "$(uname -srm)\n$(cat /etc/os-release)\n"`):**
```Linux 4.15.0-20-generic x86_64
NAME="Ubuntu"
VERSION="18.04.1 LTS (Bionic Beaver)"
ID=ubuntu
ID_LIKE=debian
PRETTY_NAME="Ubuntu 18.04.1 LTS"
VERSION_ID="18.04"
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
VERSION_CODENAME=bionic
UBUNTU_CODENAME=bionic
```

- **Version of Ansible** (`ansible --version`):
```ansible 2.6.5
  config file = /home/twexler/dev/kubespray/ansible.cfg
  configured module search path = [u'/home/twexler/dev/kubespray/library']
  ansible python module location = /home/twexler/dev/kubespray/env/local/lib/python2.7/site-packages/ansible
  executable location = /home/twexler/dev/kubespray/env/bin/ansible
  python version = 2.7.15rc1 (default, Apr 15 2018, 21:51:34) [GCC 7.3.0]
```

**Kubespray version (commit) (`git rev-parse --short HEAD`):**
90d8f7aa


**Network plugin used**:
Calico

**Copy of your inventory file:**
It's dynamic, generated by the aforementioned inventory script

**Command used to invoke ansible**:
`ansible-playbook --become -i inventory/kubespray-test/hosts cluster.yml`

**Output of ansible run**:
It's not something I can post publicly due to company policy.

**Anything else do we need to know**:
This stems from the discussion in #3588 