### PR TITLE
fix bootstrap os_family error in multi-plantform

### DIFF
--- a/roles/bootstrap-os/tasks/main.yml
+++ b/roles/bootstrap-os/tasks/main.yml
@@ -20,7 +20,7 @@
       centos
       {%- elif 'OpenSUSE' in os_release.stdout -%}
       opensuse
-      {% endif %}
+      {%- endif -%}
 
 - include_tasks: bootstrap-ubuntu.yml
   when: os_family == "ubuntu"


### PR DESCRIPTION
Dear,
There is an error in roles/bootstrap-os/tasks/main.yml.
- name: Set bootstrap_os
  set_fact:
    os_family: >-
      {%- if 'Ubuntu' in os_release.stdout -%}
      ubuntu
      ...
      {%- elif 'OpenSUSE' in os_release.stdout -%}
      opensuse
      **{% endif %}**

We must add **'-'** in  '**{% endif %}**', otherwise there will be more space behind opensuse. We will get error result(**os_family: "opensuse "**, note the space bedind opensuse), and this will affect judgement conditions later.

Test: 
We can test it by debug module, e.g.
- name: debug
  debug: msg={{ os_family }}

If we don't have OpenSUSE Operating System, we can use CentOS instead of OpenSUSE to test the last value.

/assign @mattymo 

Thanks.