### PR TITLE
Fixes network restart for Ubuntu Bionic Beaver

### DIFF
--- a/roles/kubernetes/preinstall/handlers/main.yml
+++ b/roles/kubernetes/preinstall/handlers/main.yml
@@ -16,6 +16,8 @@
     name: >-
       {% if ansible_os_family == "RedHat" -%}
       network
+      {%- elif ansible_distribution == "Ubuntu" and ansible_distribution_release == "bionic" -%}
+      systemd-networkd
       {%- elif ansible_os_family == "Debian" -%}
       networking
       {%- endif %}


### PR DESCRIPTION
As Ubuntu Bionic Beaver uses systemd-networkd the step fails
if it tries to restart networking, as it is nonexistent.