### PR TITLE
Added the missing environment for proxy for get_url

### DIFF
--- a/roles/network_plugin/calico/tasks/upgrade.yml
+++ b/roles/network_plugin/calico/tasks/upgrade.yml
@@ -7,7 +7,8 @@
     owner: root
     group: root
     force: yes
-
+  environment: "{{proxy_env}}"
+  
 - name: "Create etcdv2 and etcdv3 calicoApiConfig"
   template:
     src: "{{ item }}-store.yml.j2"

--- a/roles/network_plugin/calico/tasks/upgrade.yml
+++ b/roles/network_plugin/calico/tasks/upgrade.yml
@@ -7,8 +7,7 @@
     owner: root
     group: root
     force: yes
-  environment: "{{proxy_env}}"
-  
+  environment: "{{proxy_env}}"  
 - name: "Create etcdv2 and etcdv3 calicoApiConfig"
   template:
     src: "{{ item }}-store.yml.j2"
@@ -25,4 +24,3 @@
 - name: "If test migration is success continue with calico data real migration"
   shell: "{{ bin_dir }}/calico-upgrade start --no-prompts --apiconfigv1 /etc/calico/etcdv2.yml --apiconfigv3 /etc/calico/etcdv3.yml --output-dir=/tmp/calico_upgrade"
   register: calico_upgrade_migration_data
-  

--- a/roles/network_plugin/calico/tasks/upgrade.yml
+++ b/roles/network_plugin/calico/tasks/upgrade.yml
@@ -7,7 +7,7 @@
     owner: root
     group: root
     force: yes
-  environment: "{{proxy_env}}"  
+  environment: "{{proxy_env}}"
 - name: "Create etcdv2 and etcdv3 calicoApiConfig"
   template:
     src: "{{ item }}-store.yml.j2"

--- a/roles/network_plugin/calico/tasks/upgrade.yml
+++ b/roles/network_plugin/calico/tasks/upgrade.yml
@@ -25,3 +25,4 @@
 - name: "If test migration is success continue with calico data real migration"
   shell: "{{ bin_dir }}/calico-upgrade start --no-prompts --apiconfigv1 /etc/calico/etcdv2.yml --apiconfigv3 /etc/calico/etcdv3.yml --output-dir=/tmp/calico_upgrade"
   register: calico_upgrade_migration_data
+  


### PR DESCRIPTION
While executing kubespray in a proxy environment get_url timed out for the calico upgrade.  I added the missing environment statement