### PR TITLE
Revert "CoreDNS v1.2.5 (#3595)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Supported Components
 -   Application
     -   [cephfs-provisioner](https://github.com/kubernetes-incubator/external-storage) v2.1.0-k8s1.11
     -   [cert-manager](https://github.com/jetstack/cert-manager) v0.5.0
-    -   [coredns](https://github.com/coredns/coredns) v1.2.5
+    -   [coredns](https://github.com/coredns/coredns) v1.2.2
     -   [ingress-nginx](https://github.com/kubernetes/ingress-nginx) v0.20.0
 
 Note: The list of validated [docker versions](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.12.md) was updated to 1.11.1, 1.12.1, 1.13.1, 17.03, 17.06, 17.09, 18.06. The kubelet might break on docker's non-standard version numbering (it no longer uses semantic versioning). To ensure auto-updates don't break your cluster look into e.g. yum versionlock plugin or apt pin).

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -169,7 +169,7 @@ kubedns_version: 1.14.13
 kubedns_image_repo: "gcr.io/google_containers/k8s-dns-kube-dns-{{ image_arch }}"
 kubedns_image_tag: "{{ kubedns_version }}"
 
-coredns_version: "1.2.5"
+coredns_version: "1.2.2"
 coredns_image_repo: "gcr.io/google-containers/coredns"
 coredns_image_tag: "{{ coredns_version }}{%- if image_arch != 'amd64' -%}__{{ image_arch}}_linux{%- endif -%}"
 


### PR DESCRIPTION
This reverts commit 8ba6b601b0f2ea5d0e278555f7c47713168ffa80.

Since it break, the tags isn't committed yet:

https://console.cloud.google.com/gcr/images/google-containers/GLOBAL/coredns?gcrImageListsize=30

This results in an error on a run:

```
fatal: [node2]: FAILED! => {"attempts": 4, "changed": true, "cmd": ["/usr/bin/docker", "pull", "gcr.io/google-containers/coredns:1.2.5"], "delta": "0:00:00.497879", "end": "2018-10-29 15:10:41.168956", "msg": "non-zero return code", "rc": 1,"start": "2018-10-29 15:10:40.671077", "stderr": "Error response from daemon: manifest for gcr.io/google-containers/coredns:1.2.5 not found", "stderr_lines": ["Error response from daemon: manifest for gcr.io/google-containers/coredns:1.2.5 not found"], "stdout": "", "stdout_lines": []}
```

See #3595 