### PR TITLE
Calculate etcd client cert serial for appropriate groups

### DIFF
--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -17,7 +17,8 @@
   command: "openssl x509 -in {{ etcd_cert_dir }}/node-{{ inventory_hostname }}.pem -noout -serial"
   register: "etcd_client_cert_serial_result"
   changed_when: false
-  when: inventory_hostname in groups['k8s-cluster']|union(groups['etcd'])|union(groups['calico-rr']|default([]))|unique|sort
+  when:
+    - inventory_hostname in groups['k8s-cluster']|union(groups['calico-rr']|default([]))|unique|sort
   tags:
     - master
     - network
@@ -25,7 +26,8 @@
 - name: Set etcd_client_cert_serial
   set_fact:
     etcd_client_cert_serial: "{{ etcd_client_cert_serial_result.stdout.split('=')[1] }}"
-  when: inventory_hostname in groups['k8s-cluster']|union(groups['etcd'])|union(groups['calico-rr']|default([]))|unique|sort
+  when:
+    - inventory_hostname in groups['k8s-cluster']|union(groups['calico-rr']|default([]))|unique|sort
   tags:
     - master
     - network


### PR DESCRIPTION
Standalone etcd nodes do not generate node-$hostname certs and do
not need this serial calculated.