### PR TITLE
Fixup #3589: ansible: Upgrade to 2.7.1

### DIFF
--- a/cluster.yml
+++ b/cluster.yml
@@ -1,11 +1,11 @@
 ---
 - hosts: localhost
   tasks:
-    - name: Check ansible version <2.7
+    - name: "Check ansible version !=2.7.0"
       assert:
         msg: "Ansible V2.7.0 can't be used until: https://github.com/ansible/ansible/issues/46600 is fixed"
         that:
-          - ansible_version.string is version("2.7.0", "<")
+          - ansible_version.string is version("2.7.0", "!=")
           - ansible_version.string is version("2.5.0", ">=")
       tags:
         - check

--- a/remove-node.yml
+++ b/remove-node.yml
@@ -1,7 +1,7 @@
 ---
 - hosts: localhost
   tasks:
-    - name: Check ansible version <2.7
+    - name: "Check ansible version !=2.7.0"
       assert:
         msg: "Ansible V2.7.0 can't be used until: https://github.com/ansible/ansible/issues/46600 is fixed"
         that:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ansible>=2.5.0,<2.7
+ansible>=2.5.0,!=2.7.0
 jinja2>=2.9.6
 netaddr
 pbr>=1.6

--- a/reset.yml
+++ b/reset.yml
@@ -1,11 +1,11 @@
 ---
 - hosts: localhost
   tasks:
-    - name: Check ansible version <2.7
+    - name: "Check ansible version !=2.7.0"
       assert:
         msg: "Ansible V2.7.0 can't be used until: https://github.com/ansible/ansible/issues/46600 is fixed"
         that:
-          - ansible_version.string is version("2.7.0", "<")
+          - ansible_version.string is version("2.7.0", "!=")
           - ansible_version.string is version("2.5.0", ">=")
       tags:
         - check

--- a/scale.yml
+++ b/scale.yml
@@ -1,11 +1,11 @@
 ---
 - hosts: localhost
   tasks:
-    - name: Check ansible version <2.7
+    - name: "Check ansible version !=2.7.0"
       assert:
         msg: "Ansible V2.7.0 can't be used until: https://github.com/ansible/ansible/issues/46600 is fixed"
         that:
-          - ansible_version.string is version("2.7.0", "<")
+          - ansible_version.string is version("2.7.0", "!=")
           - ansible_version.string is version("2.5.0", ">=")
       tags:
         - check

--- a/upgrade-cluster.yml
+++ b/upgrade-cluster.yml
@@ -1,11 +1,11 @@
 ---
 - hosts: localhost
   tasks:
-    - name: Check ansible version <2.7
+    - name: "Check ansible version !=2.7.0"
       assert:
         msg: "Ansible V2.7.0 can't be used until: https://github.com/ansible/ansible/issues/46600 is fixed"
         that:
-          - ansible_version.string is version("2.7.0", "<")
+          - ansible_version.string is version("2.7.0", "!=")
           - ansible_version.string is version("2.5.0", ">=")
       tags:
         - check


### PR DESCRIPTION
Only exclude buggy Ansible v2.7.0 (https://github.com/ansible/ansible/issues/46600#issuecomment-433863628)

Fixup #3589