### PR TITLE
Fixup #3595: coredns: Upgrade to v1.2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Supported Components
 -   Application
     -   [cephfs-provisioner](https://github.com/kubernetes-incubator/external-storage) v2.1.0-k8s1.11
     -   [cert-manager](https://github.com/jetstack/cert-manager) v0.5.0
-    -   [coredns](https://github.com/coredns/coredns) v1.2.2
+    -   [coredns](https://github.com/coredns/coredns) v1.2.5
     -   [ingress-nginx](https://github.com/kubernetes/ingress-nginx) v0.20.0
 
 Note: The list of validated [docker versions](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.12.md) was updated to 1.11.1, 1.12.1, 1.13.1, 17.03, 17.06, 17.09, 18.06. The kubelet might break on docker's non-standard version numbering (it no longer uses semantic versioning). To ensure auto-updates don't break your cluster look into e.g. yum versionlock plugin or apt pin).

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -169,8 +169,8 @@ kubedns_version: 1.14.13
 kubedns_image_repo: "gcr.io/google_containers/k8s-dns-kube-dns-{{ image_arch }}"
 kubedns_image_tag: "{{ kubedns_version }}"
 
-coredns_version: "1.2.2"
-coredns_image_repo: "gcr.io/google-containers/coredns"
+coredns_version: "1.2.5"
+coredns_image_repo: "coredns/coredns"
 coredns_image_tag: "{{ coredns_version }}{%- if image_arch != 'amd64' -%}__{{ image_arch}}_linux{%- endif -%}"
 
 


### PR DESCRIPTION
Upstream Changes:

   - coredns v1.2.5 (https://github.com/coredns/coredns/releases/tag/v1.2.5)

NOTE:

   - Switch image repo to https://hub.docker.com/r/coredns/coredns/ (https://github.com/kubernetes-incubator/kubespray/pull/3595#issuecomment-433962973)