### PR TITLE
fix modify the way of the command 'yum remove xxx', e.g. docker-selin…

### DIFF
--- a/roles/container-engine/docker/tasks/pre-upgrade.yml
+++ b/roles/container-engine/docker/tasks/pre-upgrade.yml
@@ -19,13 +19,13 @@
     - docker
     - docker-common
     - docker-engine
-    - docker-selinux
+    - docker-selinux.noarch
     - docker-client
     - docker-client-latest
     - docker-latest
     - docker-latest-logrotate
     - docker-logrotate
-    - docker-engine-selinux
+    - docker-engine-selinux.noarch
   when:
     - ansible_os_family == 'RedHat'
     - (docker_versioned_pkg[docker_version | string] | search('docker-ce'))


### PR DESCRIPTION
…ux and docker-engine-selinux packages
Dear,
When we run the command "yum remove docker-selinux", container-selinux pakcage will be removed. Because container-selinux is the next version of docker-selinux.
Now problem is comming.
In roles/container-engine/docker/tasks/pre-upgrade.yml, docker-selinux and docker-engine-selinux are checked to decide whether to delete the old packages. Packages module runs the command "yum remove xxx" in CentOS.
When we run kubespray again, although docker-selinux is not installed, container-selinux will be removed. This leads to unnecessary deletion and affects the subsequent execution speed, for example, restart docker.
So, we should modify docker-selinux to docker-selinux.noarch, then container-selinux will not be removed when checking docker-selinux.
So does docker-engine-selinux.
Maybe this is a little improvement.
Thanks! 
/assign @ant31 