### PR TITLE
fix remove repeatition etcd directory in gen_certs_script.yml

### DIFF
--- a/roles/etcd/tasks/gen_certs_script.yml
+++ b/roles/etcd/tasks/gen_certs_script.yml
@@ -18,18 +18,6 @@
   when: inventory_hostname == groups['etcd'][0]
   delegate_to: "{{groups['etcd'][0]}}"
 
-- name: "Gen_certs | create etcd cert dir (on {{groups['etcd'][0]}})"
-  file:
-    path: "{{ etcd_cert_dir }}"
-    group: "{{ etcd_cert_group }}"
-    state: directory
-    owner: kube
-    recurse: yes
-    mode: 0700
-  run_once: yes
-  when: inventory_hostname == groups['etcd'][0]
-  delegate_to: "{{groups['etcd'][0]}}"
-
 - name: Gen_certs | write openssl config
   template:
     src: "openssl.conf.j2"


### PR DESCRIPTION
Dear,
The etcd cert directory is created repeatly in roles/etcd/task/gen_certs_script.yml.
So we can delete the last one.
Thanks!
/assign @ant31 
/assign @riverzhang 