### PR TITLE
Skip most of kubernetes/preinstall role during late DNS config

### DIFF
--- a/cluster.yml
+++ b/cluster.yml
@@ -126,7 +126,7 @@
   roles:
     - { role: kubespray-defaults}
     - { role: dnsmasq, when: "dns_mode == 'dnsmasq_kubedns'", tags: dnsmasq }
-    - { role: kubernetes/preinstall, when: "dns_mode != 'none' and resolvconf_mode == 'host_resolvconf'", tags: resolvconf }
+    - { role: kubernetes/preinstall, when: "dns_mode != 'none' and resolvconf_mode == 'host_resolvconf'", tags: resolvconf, dns_late: true }
   environment: "{{proxy_env}}"
 
 - hosts: kube-master

--- a/roles/kubernetes/preinstall/defaults/main.yml
+++ b/roles/kubernetes/preinstall/defaults/main.yml
@@ -5,6 +5,7 @@ run_gitinfos: false
 ignore_assert_errors: false
 
 epel_enabled: false
+dns_late: false
 
 common_required_pkgs:
   - python-httplib2

--- a/roles/kubernetes/preinstall/tasks/main.yml
+++ b/roles/kubernetes/preinstall/tasks/main.yml
@@ -1,24 +1,34 @@
 ---
 # Disable swap
 - import_tasks: 0010-swapoff.yml
-  when: disable_swap
+  when:
+    - not dns_late
+    - disable_swap
 
 - import_tasks: 0020-verify-settings.yml
+  when:
+    - not dns_late
   tags:
     - asserts
 
 # This is run before bin_dir is pinned because these tasks are run on localhost
 - import_tasks: 0030-pre_upgrade.yml
   run_once: true
+  when:
+    - not dns_late
   tags:
     - upgrade
 
 - import_tasks: 0040-set_facts.yml
+  when:
+    - not dns_late
   tags:
     - resolvconf
     - facts
 
 - import_tasks: 0050-create_directories.yml
+  when:
+    - not dns_late
 
 - import_tasks: 0060-resolvconf.yml
   when:
@@ -29,14 +39,20 @@
     - resolvconf
 
 - import_tasks: 0070-system-packages.yml
+  when:
+    - not dns_late
   tags:
     - bootstrap-os
 
 - import_tasks: 0080-system-configurations.yml
+  when:
+    - not dns_late
   tags:
     - bootstrap-os
 
 - import_tasks: 0090-etchosts.yml
+  when:
+    - not dns_late
   tags:
     - bootstrap-os
     - etchosts
@@ -67,11 +83,14 @@
   stat:
     path: /var/lib/waagent/
   register: azure_check
+  when:
+    - not dns_late
   tags:
     - bootstrap-os
 
 - import_tasks: 0120-growpart-azure-centos-7.yml
   when:
+    - not dns_late
     - azure_check.stat.exists
     - ansible_distribution in ["CentOS","RedHat"]
   tags:


### PR DESCRIPTION
When using resolvconf_mode host_resolvconf, there is an early DNS
config stage where Kubernetes cluster DNS is not injected for host
DNS intially. Later, the cluster DNS is enabled, but we do not
need to run every task from the kubernetes/preinstall role.