### PR TITLE
Fix version check in node removal script

### DIFF
--- a/remove-node.yml
+++ b/remove-node.yml
@@ -5,7 +5,7 @@
       assert:
         msg: "Ansible V2.7.0 can't be used until: https://github.com/ansible/ansible/issues/46600 is fixed"
         that:
-          - ansible_version.string is version("2.7.0", "<")
+          - ansible_version.string is version("2.7.0", "!=")
           - ansible_version.string is version("2.5.0", ">=")
       tags:
         - check


### PR DESCRIPTION
Looks like when the Ansible version was updated to 2.7.1 in #3618 all the checks were updated except in this script. This PR just modifies the one check from < 2.7.0 to != 2.7.0 in `remove_node.yml`.