### PR TITLE
[contrib/terraform/openstack] Allow user defined port ranges for worker security group

### DIFF
--- a/contrib/terraform/openstack/README.md
+++ b/contrib/terraform/openstack/README.md
@@ -242,6 +242,7 @@ For your cluster, edit `inventory/$CLUSTER/cluster.tf`.
 |`supplementary_master_groups` | To add ansible groups to the masters, such as `kube-node` for tainting them as nodes, empty by default. |
 |`supplementary_node_groups` | To add ansible groups to the nodes, such as `kube-ingress` for running ingress controller pods, empty by default. |
 |`bastion_allowed_remote_ips` | List of CIDR allowed to initiate a SSH connection, `["0.0.0.0/0"]` by default |
+|`worker_allowed_ports` | List of ports to open on worker nodes, `[{ "protocol" = "tcp", "port_range_min" = 30000, "port_range_max" = 32767, "remote_ip_prefix" = "0.0.0.0/0"}]` by default |
 
 #### Terraform state files
 

--- a/contrib/terraform/openstack/kubespray.tf
+++ b/contrib/terraform/openstack/kubespray.tf
@@ -54,6 +54,7 @@ module "compute" {
   bastion_allowed_remote_ips                   = "${var.bastion_allowed_remote_ips}"
   supplementary_master_groups                  = "${var.supplementary_master_groups}"
   supplementary_node_groups                    = "${var.supplementary_node_groups}"
+  worker_allowed_ports                         = "${var.worker_allowed_ports}"
 
   network_id = "${module.network.router_id}"
 }

--- a/contrib/terraform/openstack/modules/compute/main.tf
+++ b/contrib/terraform/openstack/modules/compute/main.tf
@@ -52,12 +52,13 @@ resource "openstack_networking_secgroup_v2" "worker" {
 }
 
 resource "openstack_networking_secgroup_rule_v2" "worker" {
+  count = "${length(var.worker_allowed_ports)}"
   direction = "ingress"
   ethertype = "IPv4"
-  protocol = "tcp"
-  port_range_min = "30000"
-  port_range_max = "32767"
-  remote_ip_prefix = "0.0.0.0/0"
+  protocol = "${lookup(var.worker_allowed_ports[count.index], "protocol", "tcp")}"
+  port_range_min = "${lookup(var.worker_allowed_ports[count.index], "port_range_min")}"
+  port_range_max = "${lookup(var.worker_allowed_ports[count.index], "port_range_max")}"
+  remote_ip_prefix = "${lookup(var.worker_allowed_ports[count.index], "remote_ip_prefix", "0.0.0.0/0")}"
   security_group_id = "${openstack_networking_secgroup_v2.worker.id}"
 }
 

--- a/contrib/terraform/openstack/modules/compute/variables.tf
+++ b/contrib/terraform/openstack/modules/compute/variables.tf
@@ -73,3 +73,7 @@ variable "supplementary_master_groups" {
 variable "supplementary_node_groups" {
   default = ""
 }
+
+variable "worker_allowed_ports" {
+  type = "list"
+}

--- a/contrib/terraform/openstack/variables.tf
+++ b/contrib/terraform/openstack/variables.tf
@@ -144,3 +144,15 @@ variable "bastion_allowed_remote_ips" {
   type = "list"
   default = ["0.0.0.0/0"]
 }
+
+variable "worker_allowed_ports" {
+  type = "list"
+  default = [
+    {
+      "protocol" = "tcp"
+      "port_range_min" = 30000
+      "port_range_max" = 32767
+      "remote_ip_prefix" = "0.0.0.0/0"
+    }
+  ]
+}


### PR DESCRIPTION
Allow user to define in terraform template which ports and remote IPs that are allowed to access worker nodes. This is useful when you don't want to open up whole NodePort range to the outside world, or ports outside of NodePort range.