### PR TITLE
Fix work yum in Install packages requirements for bootstrap

### DIFF
--- a/roles/bootstrap-os/tasks/bootstrap-centos.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-centos.yml
@@ -14,6 +14,14 @@
     state: present
   when: fastestmirror.stat.exists
 
+- name: Add proxy to /etc/yum.conf if http_proxy is defined
+  lineinfile:
+    path: "/etc/yum.conf"
+    line: "proxy={{http_proxy}}"
+    create: yes
+    state: present
+  when: http_proxy is defined
+
 - name: Install packages requirements for bootstrap
   yum:
     name: "{{ packages }}"
@@ -22,10 +30,8 @@
     packages:
       - libselinux-python
       - epel-release
-  environment: "{{proxy_env}}"
 
 - name: Install pip for bootstrap
   yum:
     name: python-pip
     state: present
-  environment: "{{proxy_env}}"

--- a/roles/bootstrap-os/tasks/bootstrap-centos.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-centos.yml
@@ -22,6 +22,7 @@
     packages:
       - libselinux-python
       - epel-release
+  environment: "{{proxy_env}}"
 
 - name: Install pip for bootstrap
   yum:


### PR DESCRIPTION
I try install kubespray using proxy
Set
```
## Set these proxy values in order to update package manager and docker daemon to use proxies
http_proxy: "http://172.16.149.1:3128"
https_proxy: "http://172.16.149.1:3128"
```


If run kubespray without  **environment: "{{proxy_env}}"** in Install packages requirements for bootstrap - get error

```
TASK [bootstrap-os : Install packages requirements for bootstrap] *******************************************************************************
Sunday 04 November 2018  15:13:57 +0600 (0:00:01.957)       0:00:09.016 ******* 
fatal: [kuber1]: FAILED! => {
    "ansible_facts": {
        "pkg_mgr": "yum"
    }, 
    "changed": false, 
    "rc": 1, 
    "results": [
        "libselinux-python-2.5-12.el7.x86_64 providing libselinux-python is already installed", 
        "Resolving Dependencies\n--> Running transaction check\n---> Package epel-release.noarch 0:7-11 will be installed\n--> Finished Dependency Resolution\n\nDependencies Resolved\n\n================================================================================\n Package                Arch             Version         Repository        Size\n================================================================================\nInstalling:\n epel-release           noarch           7-11            extras            15 k\n\nTransaction Summary\n================================================================================\nInstall  1 Package\n\nTotal download size: 15 k\nInstalled size: 24 k\nDownloading packages:\nDelta RPMs disabled because /usr/bin/applydeltarpm not installed.\n"
    ]
}

MSG:

http://dedic.sh/centos/7.5.1804/extras/x86_64/Packages/epel-release-7-11.noarch.rpm: [Errno 12] Timeout on http://dedic.sh/centos/7.5.1804/extras/x86_64/Packages/epel-release-7-11.noarch.rpm: (28, 'Connection timed out after 30002 milliseconds')
Trying other mirror.
http://mirror.sale-dedic.com/centos/7.5.1804/extras/x86_64/Packages/epel-release-7-11.noarch.rpm: [Errno 12] Timeout on http://mirror.sale-dedic.com/centos/7.5.1804/extras/x86_64/Packages/epel-release-7-11.noarch.rpm: (28, 'Connection timed out after 30002 milliseconds')
Trying other mirror.
http://mirror.logol.ru/centos/7.5.1804/extras/x86_64/Packages/epel-release-7-11.noarch.rpm: [Errno 12] Timeout on http://mirror.logol.ru/centos/7.5.1804/extras/x86_64/Packages/epel-release-7-11.noarch.rpm: (28, 'Connection timed out after 30002 milliseconds')
Trying other mirror.
http://mirror.reconn.ru/centos/7.5.1804/extras/x86_64/Packages/epel-release-7-11.noarch.rpm: [Errno 14] curl#7 - "Failed to connect to 2a00:1f70:0:10::74: Network is unreachable"
Trying other mirror.
http://mirrors.powernet.com.ru/centos/7.5.1804/extras/x86_64/Packages/epel-release-7-11.noarch.rpm: [Errno 12] Timeout on http://mirrors.powernet.com.ru/centos/7.5.1804/extras/x86_64/Packages/epel-release-7-11.noarch.rpm: (28, 'Connection timed out after 30006 milliseconds')
Trying other mirror.
http://mirror.corbina.net/pub/Linux/centos/7.5.1804/extras/x86_64/Packages/epel-release-7-11.noarch.rpm: [Errno 14] curl#7 - "Failed to connect to 2a00:18c0:1:1::4: Network is unreachable"
Trying other mirror.
http://ftp.nsc.ru/pub/centos/7.5.1804/extras/x86_64/Packages/epel-release-7-11.noarch.rpm: [Errno 14] curl#7 - "Failed to connect to 2a00:bf00:0:3::3: Network is unreachable"
Trying other mirror.
http://mirror.awanti.com/centos/7.5.1804/extras/x86_64/Packages/epel-release-7-11.noarch.rpm: [Errno 12] Timeout on http://mirror.awanti.com/centos/7.5.1804/extras/x86_64/Packages/epel-release-7-11.noarch.rpm: (28, 'Connection timed out after 30007 milliseconds')
Trying other mirror.
http://mirror.yandex.ru/centos/7.5.1804/extras/x86_64/Packages/epel-release-7-11.noarch.rpm: [Errno 14] curl#7 - "Failed to connect to 2a02:6b8::183: Network is unreachable"
Trying other mirror.
http://mirror.vilkam.ru/centos/7.5.1804/extras/x86_64/Packages/epel-release-7-11.noarch.rpm: [Errno 12] Timeout on http://mirror.vilkam.ru/centos/7.5.1804/extras/x86_64/Packages/epel-release-7-11.noarch.rpm: (28, 'Connection timed out after 30005 milliseconds')
Trying other mirror.

Error downloading packages:
  epel-release-7-11.noarch: [Errno 256] No more mirrors to try.
```

Task **Install packages requirements for bootstrap** dont work with proxy

This PR added **environment: "{{proxy_env}}"** to Install packages requirements for bootstrap