### PR TITLE
Avoid gather_facts on scale.yml

### DIFF
--- a/scale.yml
+++ b/scale.yml
@@ -1,5 +1,6 @@
 ---
 - hosts: localhost
+  gather_facts: False
   tasks:
     - name: "Check ansible version !=2.7.0"
       assert:


### PR DESCRIPTION
Use case is when kubespray runs from unprivileged user without sudo permission.