### PR TITLE
Fix untaint master with kubeadm when disable insecure port

### DIFF
--- a/roles/kubernetes/master/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-setup.yml
@@ -212,7 +212,7 @@
   when: old_apiserver_cert.stat.exists
 
 - name: kubeadm | Remove taint for master with node role
-  command: "{{ bin_dir }}/kubectl taint node {{ inventory_hostname }} node-role.kubernetes.io/master:NoSchedule-"
+  command: "{{ bin_dir }}/kubectl --kubeconfig={{ kube_config_dir }}/admin.conf taint node {{ inventory_hostname }} node-role.kubernetes.io/master:NoSchedule-"
   delegate_to: "{{groups['kube-master']|first}}"
   when: inventory_hostname in groups['kube-node']
   failed_when: false


### PR DESCRIPTION
When disable insecure port,  kubectl needs kube config.

This PR will fix #3563 problem.