### PR TITLE
fix: CoreDNS arch tag wasn't updated in #3619

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -171,8 +171,7 @@ kubedns_image_tag: "{{ kubedns_version }}"
 
 coredns_version: "1.2.5"
 coredns_image_repo: "coredns/coredns"
-coredns_image_tag: "{{ coredns_version }}{%- if image_arch != 'amd64' -%}__{{ image_arch}}_linux{%- endif -%}"
-
+coredns_image_tag: "{{ coredns_version }}"
 
 dnsmasq_nanny_image_repo: "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-{{ image_arch }}"
 dnsmasq_nanny_image_tag: "{{ kubedns_version }}"


### PR DESCRIPTION
The tags on Docker Hub are different then the previous GCR.

If I read the [Makefile.release](https://github.com/coredns/coredns/blob/master/Makefile.release#L134) of CoreDNS correct it uses the [manifest-tool](https://github.com/estesp/manifest-tool#createpush) to push multi arch tags to Docker Hub.

I am in the process of testing this and fixing the master to work with arm64/aarch64 :)

Related: #3619 