### PR TITLE
Fix company name capitalisation

### DIFF
--- a/contrib/terraform/openstack/README.md
+++ b/contrib/terraform/openstack/README.md
@@ -13,7 +13,7 @@ most modern installs of OpenStack that support the basic services.
 - [BetaCloud](https://www.betacloud.io/)
 - [CityCloud](https://www.citycloud.com/)
 - [DreamHost](https://www.dreamhost.com/cloud/computing/)
-- [ElastX](https://elastx.se/)
+- [ELASTX](https://elastx.se/)
 - [EnterCloudSuite](https://www.entercloudsuite.com/)
 - [FugaCloud](https://fuga.cloud/)
 - [OVH](https://www.ovh.com/)


### PR DESCRIPTION
ELASTX company name is written in only capital letters. This PR fixes a capitalisation error of the company name.