### PR TITLE
Bump CoreDNS to 1.2.6

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -172,7 +172,7 @@ kubedns_version: 1.14.13
 kubedns_image_repo: "gcr.io/google_containers/k8s-dns-kube-dns-{{ image_arch }}"
 kubedns_image_tag: "{{ kubedns_version }}"
 
-coredns_version: "1.2.5"
+coredns_version: "1.2.6"
 coredns_image_repo: "coredns/coredns"
 coredns_image_tag: "{{ coredns_version }}{%- if image_arch != 'amd64' -%}__{{ image_arch}}_linux{%- endif -%}"
 


### PR DESCRIPTION
As the title states, the 1.2.6 tag got published yesterday. 

[Release tracking issue](https://github.com/coredns/coredns/issues/2266)
[Release notes](https://github.com/coredns/coredns/wiki/CoreDNS-1.2.6-Release-Notes)

In my humble opinion no breaking changes. Might hold off merging until the official release notes are released. Don't know the policy about that :)