### PR TITLE
Added interpolation for number of subnets given vs number of AZs used

### DIFF
--- a/contrib/terraform/aws/create-infrastructure.tf
+++ b/contrib/terraform/aws/create-infrastructure.tf
@@ -57,7 +57,7 @@ resource "aws_instance" "bastion-server" {
     instance_type = "${var.aws_bastion_size}"
     count = "${length(var.aws_cidr_subnets_public)}"
     associate_public_ip_address = true
-    availability_zone  = "${element(slice(data.aws_availability_zones.available.names,0,2),count.index)}"
+    availability_zone  = "${element(slice(data.aws_availability_zones.available.names,0,length(var.aws_cidr_subnets_private)),count.index)}"
     subnet_id = "${element(module.aws-vpc.aws_subnet_ids_public,count.index)}"
 
 
@@ -85,7 +85,7 @@ resource "aws_instance" "k8s-master" {
     count = "${var.aws_kube_master_num}"
 
 
-    availability_zone  = "${element(slice(data.aws_availability_zones.available.names,0,2),count.index)}"
+    availability_zone  = "${element(slice(data.aws_availability_zones.available.names,0,length(var.aws_cidr_subnets_private)),count.index)}"
     subnet_id = "${element(module.aws-vpc.aws_subnet_ids_private,count.index)}"
 
 

--- a/contrib/terraform/aws/create-infrastructure.tf
+++ b/contrib/terraform/aws/create-infrastructure.tf
@@ -57,7 +57,7 @@ resource "aws_instance" "bastion-server" {
     instance_type = "${var.aws_bastion_size}"
     count = "${length(var.aws_cidr_subnets_public)}"
     associate_public_ip_address = true
-    availability_zone  = "${element(slice(data.aws_availability_zones.available.names,0,length(var.aws_cidr_subnets_private)),count.index)}"
+    availability_zone  = "${element(slice(data.aws_availability_zones.available.names,0,length(var.aws_cidr_subnets_public)),count.index)}"
     subnet_id = "${element(module.aws-vpc.aws_subnet_ids_public,count.index)}"
 
 
@@ -117,7 +117,7 @@ resource "aws_instance" "k8s-etcd" {
     count = "${var.aws_etcd_num}"
 
 
-    availability_zone = "${element(slice(data.aws_availability_zones.available.names,0,2),count.index)}"
+    availability_zone = "${element(slice(data.aws_availability_zones.available.names,0,length(var.aws_cidr_subnets_private)),count.index)}"
     subnet_id = "${element(module.aws-vpc.aws_subnet_ids_private,count.index)}"
 
 


### PR DESCRIPTION
Unless I'm mistaken, this variable interpolation will prevent you from having to manually change the "2" to the number of Availability Zones. 

This falls down when there are more subnets given than AZs. 

Without this, if you specify more subnets than 2 (for using more than 2 AZs) then the Terraform won't run, as it tries to attach a subnet that is already attached to a Route Table to another Route Table. Use case was trying to create a 3 AZ cluster in US-East-1, and I was being limited to 1A and 1B Availability Zones. (You can change this number, but this was more seamless for my use) 