### PR TITLE
calico-node: add prometheus annotations

### DIFF
--- a/roles/network_plugin/calico/templates/calico-node.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-node.yml.j2
@@ -21,6 +21,10 @@ spec:
         # Mark pod as critical for rescheduling (Will have no effect starting with kubernetes 1.12)
         scheduler.alpha.kubernetes.io/critical-pod: ''
         kubespray.etcd-cert/serial: "{{ etcd_client_cert_serial }}"
+{% if calico_felix_prometheusmetricsenabled %}
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: "{{ calico_felix_prometheusmetricsport }}"
+{% endif %}
     spec:
 {% if kube_version is version('v1.11.1', '>=') %}
       priorityClassName: system-node-critical


### PR DESCRIPTION
add prometheus annotations to calico-node if
calico_felix_prometheusmetricsenabled is enabled.

This will allow a kubernetes_sd to automatically find the pods and start
scraping.