### PR TITLE
kube_override_hostname must be in kubernetes/master role defaults

### DIFF
--- a/roles/kubernetes/master/defaults/main.yml
+++ b/roles/kubernetes/master/defaults/main.yml
@@ -137,3 +137,10 @@ kube_encryption_algorithm: "aescbc"
 
 # You may want to use ca.pem depending on your situation
 kube_front_proxy_ca: "front-proxy-ca.pem"
+
+# If non-empty, will use this string as identification instead of the actual hostname
+kube_override_hostname: >-
+  {%- if cloud_provider is defined and cloud_provider in [ 'aws' ] -%}
+  {%- else -%}
+  {{ inventory_hostname }}
+  {%- endif -%}


### PR DESCRIPTION
`kube_override_hostname` variable is not set in `roles/kubernetes/master/defaults/main.yml`.
Thus the node name used for kubeadm registration is deducted from hostname which is not the same as the effective node name (especially when `override_system_hostname` is false).
It results in the failure of the "kubeadm | Initialize first master" task