### PR TITLE
use force umount when reset cluster

### DIFF
--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -87,7 +87,7 @@
     - mounts
 
 - name: reset | unmount kubelet dirs
-  command: umount {{item}}
+  command: umount -f {{item}}
   with_items: '{{ mounted_dirs.stdout_lines }}'
   register: umount_dir
   retries: 4


### PR DESCRIPTION
 reset role hang and can't umount PersistenceVolume (ceph cluster)