### PR TITLE
Replace raw module with shell to avoid warning

### DIFF
--- a/roles/download/tasks/download_prep.yml
+++ b/roles/download/tasks/download_prep.yml
@@ -1,13 +1,12 @@
 ---
 - name: Register docker images info
-  raw: >-
+  shell: >-
     {{ docker_bin_dir }}/docker images -q | xargs {{ docker_bin_dir }}/docker inspect -f "{{ '{{' }} (index .RepoTags 0) {{ '}}' }},{{ '{{' }} (index .RepoDigests 0) {{ '}}' }}" | tr '\n' ','
   no_log: true
   register: docker_images
   failed_when: false
   changed_when: false
   check_mode: no
-  environment: {}
   when: download_container
 
 - name: container_download | Create dest directory for saved/loaded container images

--- a/roles/download/tasks/set_docker_image_facts.yml
+++ b/roles/download/tasks/set_docker_image_facts.yml
@@ -8,14 +8,13 @@
       {%- if pull_by_digest %}{{download.repo}}@sha256:{{download.sha256}}{%- else -%}{{download.repo}}:{{download.tag}}{%- endif -%}
 
 - name: Register docker images info
-  raw: >-
+  shell: >-
     {{ docker_bin_dir }}/docker images -q | xargs {{ docker_bin_dir }}/docker inspect -f "{{ '{{' }} if .RepoTags {{ '}}' }}{{ '{{' }} (index .RepoTags 0) {{ '}}' }}{{ '{{' }} end {{ '}}' }}{{ '{{' }} if .RepoDigests {{ '}}' }},{{ '{{' }} (index .RepoDigests 0) {{ '}}' }}{{ '{{' }} end {{ '}}' }}" | tr '\n' ','
   no_log: true
   register: docker_images
   failed_when: false
   changed_when: false
   check_mode: no
-  environment: {}
   when: not download_always_pull
 
 - set_fact:


### PR DESCRIPTION
`raw` module can be replaced here with `shell` module. Braces are not an issue with the current yaml notation.
