### PR TITLE
Checking new CA key presence is not relevant to determine if kubeadm has already run

### DIFF
--- a/roles/kubernetes/master/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-setup.yml
@@ -15,14 +15,14 @@
 
 - name: kubeadm | Check if kubeadm has already run
   stat:
-    path: "{{ kube_cert_dir }}/ca.key"
-  register: kubeadm_ca
+    path: "/var/lib/kubelet/config.yaml"
+  register: kubeadm_already_run
 
 - name: kubeadm | Delete old admin.conf
   file:
     path: "{{ kube_config_dir }}/admin.conf"
     state: absent
-  when: not kubeadm_ca.stat.exists
+  when: not kubeadm_already_run.stat.exists
 
 - name: kubeadm | Delete old static pods
   file:
@@ -115,7 +115,7 @@
   register: kubeadm_init
   # Retry is because upload config sometimes fails
   retries: 3
-  when: inventory_hostname == groups['kube-master']|first and not kubeadm_ca.stat.exists
+  when: inventory_hostname == groups['kube-master']|first and not kubeadm_already_run.stat.exists
   failed_when: kubeadm_init.rc != 0 and "field is immutable" not in kubeadm_init.stderr
   notify: Master | restart kubelet
 
@@ -132,7 +132,7 @@
   register: kubeadm_upgrade
   # Retry is because upload config sometimes fails
   retries: 3
-  when: inventory_hostname == groups['kube-master']|first and (kubeadm_config.changed and kubeadm_ca.stat.exists)
+  when: inventory_hostname == groups['kube-master']|first and (kubeadm_config.changed and kubeadm_already_run.stat.exists)
   failed_when: kubeadm_upgrade.rc != 0 and "field is immutable" not in kubeadm_upgrade.stderr
   notify: Master | restart kubelet
 
@@ -177,7 +177,7 @@
 - name: kubeadm | Init other uninitialized masters
   command: timeout -k 600s 600s {{ bin_dir }}/kubeadm init --config={{ kube_config_dir }}/kubeadm-config.{{ kubeadmConfig_api_version }}.yaml --ignore-preflight-errors=all
   register: kubeadm_init
-  when: inventory_hostname != groups['kube-master']|first and not kubeadm_ca.stat.exists
+  when: inventory_hostname != groups['kube-master']|first and not kubeadm_already_run.stat.exists
   failed_when: kubeadm_init.rc != 0 and "field is immutable" not in kubeadm_init.stderr
   notify: Master | restart kubelet
 
@@ -191,7 +191,7 @@
     --allow-experimental-upgrades
     --allow-release-candidate-upgrades
   register: kubeadm_upgrade
-  when: inventory_hostname != groups['kube-master']|first and (kubeadm_config.changed and kubeadm_ca.stat.exists)
+  when: inventory_hostname != groups['kube-master']|first and (kubeadm_config.changed and kubeadm_already_run.stat.exists)
   failed_when: kubeadm_upgrade.rc != 0 and "field is immutable" not in kubeadm_upgrade.stderr
   notify: Master | restart kubelet
 


### PR DESCRIPTION
This PR makes the "kubeadm | Check if kubeadm has already run" applies on `/var/lib/kubelet/config.yaml` generated by kubeadm instead of `{{ kube_cert_dir }}/ca.key` which can be present before using custom certificates