### PR TITLE
cluster_name is to be set in ClusterConfiguration too

### DIFF
--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha3.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha3.yaml.j2
@@ -18,6 +18,7 @@ nodeRegistration:
 ---
 apiVersion: kubeadm.k8s.io/v1alpha3
 kind: ClusterConfiguration
+clusterName: {{ cluster_name }}
 etcd:
   external:
       endpoints:


### PR DESCRIPTION
Currently, `cluster_name` is only used in the Joinconfiguration section of kubeadm-client.conf.v1alpha3.j2 and not in the ClusterConfiguration section  of kubeadm-config.v1alpha3.yaml.j2 which seems to determine the cluster name