### PR TITLE
Add timeout capability for container image downloading (#3021)

### DIFF
--- a/inventory/sample/group_vars/all/docker.yml
+++ b/inventory/sample/group_vars/all/docker.yml
@@ -59,3 +59,6 @@ docker_options: >-
   --default-runtime=docker-runc --exec-opt native.cgroupdriver=systemd
   --userland-proxy-path=/usr/libexec/docker/docker-proxy-current --signature-verification=false
   {%- endif -%}
+
+## Timeout period in seconds for container image downloading
+#download_timeout: 600

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -31,6 +31,9 @@ download_validate_certs: True
 # Use the first kube-master if download_localhost is not set
 download_delegate: "{% if download_localhost %}localhost{% else %}{{groups['kube-master'][0]}}{% endif %}"
 
+# timeout for a container image download
+download_timeout: 600
+
 # Arch of Docker images and needed packages
 image_arch: "{{host_architecture | default('amd64')}}"
 

--- a/roles/download/tasks/download_container.yml
+++ b/roles/download/tasks/download_container.yml
@@ -13,7 +13,7 @@
 # FIXME(mattymo): In Ansible 2.4 omitting download delegate is broken. Move back
 #                 to one task in the future.
 - name: container_download | Download containers if pull is required or told to always pull (delegate)
-  command: "{{ docker_bin_dir }}/docker pull {{ pull_args }}"
+  command: "timeout {{ download_timeout }} {{ docker_bin_dir }}/docker pull {{ pull_args }}"
   register: pull_task_result
   until: pull_task_result is succeeded
   retries: 4
@@ -28,7 +28,7 @@
   run_once: yes
 
 - name: container_download | Download containers if pull is required or told to always pull (all nodes)
-  command: "{{ docker_bin_dir }}/docker pull {{ pull_args }}"
+  command: "timeout {{ download_timeout }} {{ docker_bin_dir }}/docker pull {{ pull_args }}"
   register: pull_task_result
   until: pull_task_result is succeeded
   retries: 4


### PR DESCRIPTION
This patchset fixes the issue #3021 ; Setup K8S Cluster freezes on "TASK [download : container_download | Download containers if pull is required or told to always pull (all nodes)] "