### PR TITLE
Fix kube-router annotations: add conditions

### DIFF
--- a/roles/network_plugin/kube-router/tasks/annotate.yml
+++ b/roles/network_plugin/kube-router/tasks/annotate.yml
@@ -4,18 +4,18 @@
   with_items:
   - "{{ kube_router_annotations_master }}"
   delegate_to: "{{groups['kube-master'][0]}}"
-  when: kube_router_annotations_master is defined
+  when: kube_router_annotations_master is defined and inventory_hostname in groups['kube-master']
 
 - name: kube-router | Add annotations on kube-node
   command: "{{bin_dir}}/kubectl annotate --overwrite node {{ ansible_hostname }} {{ item }}"
   with_items:
   - "{{ kube_router_annotations_node }}"
   delegate_to: "{{groups['kube-master'][0]}}"
-  when: kube_router_annotations_node is defined
+  when: kube_router_annotations_node is defined and inventory_hostname in groups['kube-node']
 
 - name: kube-router | Add common annotations on all servers
   command: "{{bin_dir}}/kubectl annotate --overwrite node {{ ansible_hostname }} {{ item }}"
   with_items:
   - "{{ kube_router_annotations_all }}"
   delegate_to: "{{groups['kube-master'][0]}}"
-  when: kube_router_annotations_all is defined
+  when: kube_router_annotations_all is defined and inventory_hostname in groups['all']


### PR DESCRIPTION
This commit is a small fix for kube-router annotations. Annotations should depend on node group.