### PR TITLE
Merge aci-master changes to latest Kubespray

### DIFF
--- a/cluster.yml
+++ b/cluster.yml
@@ -115,11 +115,11 @@
     - { role: kubernetes-apps/ingress_controller, tags: ingress-controller }
     - { role: kubernetes-apps/external_provisioner, tags: external-provisioner }
 
-- hosts: calico-rr
-  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
-  roles:
-    - { role: kubespray-defaults}
-    - { role: network_plugin/calico/rr, tags: network }
+#- hosts: calico-rr
+#  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+#  roles:
+#    - { role: kubespray-defaults}
+#    - { role: network_plugin/calico/rr, tags: network }
 
 - hosts: k8s-cluster
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"

--- a/inventory/sample/group_vars/k8s-cluster/addons.yml
+++ b/inventory/sample/group_vars/k8s-cluster/addons.yml
@@ -1,6 +1,6 @@
 # Kubernetes dashboard
 # RBAC required. see docs/getting-started.md for access details.
-dashboard_enabled: true
+dashboard_enabled: false
 
 # Helm deployment
 helm_enabled: false

--- a/inventory/sample/group_vars/k8s-cluster/all.yml.template
+++ b/inventory/sample/group_vars/k8s-cluster/all.yml.template
@@ -1,0 +1,99 @@
+# Valid bootstrap options (required): ubuntu, coreos, centos, none
+bootstrap_os: none
+
+#Directory where etcd data stored
+etcd_data_dir: /var/lib/etcd
+
+# Directory where the binaries will be installed
+bin_dir: /usr/local/bin
+
+## The access_ip variable is used to define how other nodes should access
+## the node.  This is used in flannel to allow other flannel nodes to see
+## this node for example.  The access_ip is really useful AWS and Google
+## environments where the nodes are accessed remotely by the "public" ip,
+## but don't know about that address themselves.
+#access_ip: 1.1.1.1
+
+### LOADBALANCING AND ACCESS MODES
+## Enable multiaccess to configure etcd clients to access all of the etcd members directly
+## as the "http://hostX:port, http://hostY:port, ..." and ignore the proxy loadbalancers.
+## This may be the case if clients support and loadbalance multiple etcd servers  natively.
+#etcd_multiaccess: true
+
+## External LB example config
+## apiserver_loadbalancer_domain_name: "elb.some.domain"
+#loadbalancer_apiserver:
+#  address: 1.2.3.4
+#  port: 1234
+
+## Internal loadbalancers for apiservers
+#loadbalancer_apiserver_localhost: true
+
+## Local loadbalancer should use this port instead, if defined.
+## Defaults to kube_apiserver_port (6443)
+#nginx_kube_apiserver_port: 8443
+
+### OTHER OPTIONAL VARIABLES
+## For some things, kubelet needs to load kernel modules.  For example, dynamic kernel services are needed
+## for mounting persistent volumes into containers.  These may not be loaded by preinstall kubernetes
+## processes.  For example, ceph and rbd backed volumes.  Set to true to allow kubelet to load kernel
+## modules.
+# kubelet_load_modules: false
+
+## Internal network total size. This is the prefix of the
+## entire network. Must be unused in your environment.
+#kube_network_prefix: 18
+
+## With calico it is possible to distributed routes with border routers of the datacenter.
+## Warning : enabling router peering will disable calico's default behavior ('node mesh').
+## The subnets of each nodes will be distributed by the datacenter router
+#peer_with_router: false
+
+## Upstream dns servers used by dnsmasq
+#upstream_dns_servers:
+#  - 8.8.8.8
+#  - 8.8.4.4
+
+## There are some changes specific to the cloud providers
+## for instance we need to encapsulate packets with some network plugins
+## If set the possible values are either 'gce', 'aws', 'azure', 'openstack', or 'vsphere'
+## When openstack is used make sure to source in the openstack credentials
+## like you would do when using nova-client before starting the playbook.
+#cloud_provider:
+
+## When azure is used, you need to also set the following variables.
+## see docs/azure.md for details on how to get these values
+#azure_tenant_id:
+#azure_subscription_id:
+#azure_aad_client_id:
+#azure_aad_client_secret:
+#azure_resource_group:
+#azure_location:
+#azure_subnet_name:
+#azure_security_group_name:
+#azure_vnet_name:
+#azure_route_table_name:
+
+## Set these proxy values in order to update docker daemon to use proxies
+#http_proxy: ""
+#https_proxy: ""
+#no_proxy: ""
+
+## Uncomment this if you want to force overlay/overlay2 as docker storage driver
+## Please note that overlay2 is only supported on newer kernels
+#docker_storage_options: -s overlay2
+
+## Default packages to install within the cluster, f.e:
+#kpm_packages:
+#  - name: kube-system/grafana
+
+## Certificate Management
+## This setting determines whether certs are generated via scripts or whether a
+## cluster of Hashicorp's Vault is started to issue certificates (using etcd
+## as a backend). Options are "script" or "vault"
+#cert_management: script
+
+## Please specify true if you want to perform a kernel upgrade
+kernel_upgrade: false
+
+k8s_version: {{ k8s_version }}

--- a/inventory/sample/group_vars/k8s-cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s-cluster/k8s-cluster.yml
@@ -71,7 +71,7 @@ kube_users:
 
 # Choose network plugin (cilium, calico, contiv, weave or flannel)
 # Can also be set to 'cloud', which lets the cloud provider setup appropriate routing
-kube_network_plugin: calico
+kube_network_plugin: aci
 
 # Kubernetes internal network for services, unused block of space.
 kube_service_addresses: 10.233.0.0/18
@@ -179,6 +179,7 @@ podsecuritypolicy_enabled: false
 volume_cross_zone_attachment: false
 # Add Persistent Volumes Storage Class for corresponding cloud provider ( OpenStack is only supported now )
 persistent_volumes_enabled: false
+kubelet_fail_swap_on: false
 
 ## Container Engine Acceleration
 ## Enable container acceleration feature, for example use gpu acceleration in containers

--- a/reset.yml
+++ b/reset.yml
@@ -15,19 +15,19 @@
 - hosts: all
   gather_facts: true
 
-- hosts: etcd:k8s-cluster:vault:calico-rr
-  vars_prompt:
-    name: "reset_confirmation"
-    prompt: "Are you sure you want to reset cluster state? Type 'yes' to reset your cluster."
-    default: "no"
-    private: no
-
-  pre_tasks:
-    - name: check confirmation
-      fail:
-        msg: "Reset confirmation failed"
-      when: reset_confirmation != "yes"
-
+#- hosts: etcd:k8s-cluster:vault:calico-rr
+#  vars_prompt:
+#    name: "reset_confirmation"
+#    prompt: "Are you sure you want to reset cluster state? Type 'yes' to reset your cluster."
+#    default: "no"
+#    private: no
+#
+#  pre_tasks:
+#    - name: check confirmation
+#      fail:
+#        msg: "Reset confirmation failed"
+#      when: reset_confirmation != "yes"
+#
   roles:
     - { role: kubespray-defaults}
     - { role: reset, tags: reset }

--- a/roles/container-engine/docker/tasks/main.yml
+++ b/roles/container-engine/docker/tasks/main.yml
@@ -55,7 +55,8 @@
   action: "{{ docker_repo_key_info.pkg_key }}"
   args:
     id: "{{item}}"
-    url: "{{docker_repo_key_info.url}}"
+    #url: "{{docker_repo_key_info.url}}"
+    keyserver: "{{docker_repo_key_info.keyserver}}"
     state: present
   register: keyserver_task_result
   until: keyserver_task_result is succeeded
@@ -76,7 +77,8 @@
   action: "{{ dockerproject_repo_key_info.pkg_key }}"
   args:
     id: "{{item}}"
-    url: "{{dockerproject_repo_key_info.url}}"
+    #url: "{{dockerproject_repo_key_info.url}}"
+    keyserver: "{{docker_repo_key_info.keyserver}}"
     state: present
   register: keyserver_task_result
   until: keyserver_task_result is succeeded

--- a/roles/container-engine/docker/vars/ubuntu-amd64.yml
+++ b/roles/container-engine/docker/vars/ubuntu-amd64.yml
@@ -23,6 +23,7 @@ docker_package_info:
 docker_repo_key_info:
   pkg_key: apt_key
   url: '{{ docker_ubuntu_repo_gpgkey }}'
+  keyserver: hkp://p80.pool.sks-keyservers.net:80
   repo_keys:
     - 9DC858229FC7DD38854AE2D88D81803C0EBFCD88
 

--- a/roles/container-engine/docker/vars/ubuntu-bionic.yml
+++ b/roles/container-engine/docker/vars/ubuntu-bionic.yml
@@ -19,6 +19,7 @@ docker_package_info:
 docker_repo_key_info:
   pkg_key: apt_key
   url: '{{ docker_ubuntu_repo_gpgkey }}'
+  keyserver: hkp://p80.pool.sks-keyservers.net:80
   repo_keys:
     - 9DC858229FC7DD38854AE2D88D81803C0EBFCD88
 

--- a/roles/dnsmasq/tasks/main.yml
+++ b/roles/dnsmasq/tasks/main.yml
@@ -77,7 +77,7 @@
   with_items:
     - {name: dnsmasq, file: dnsmasq-deploy.yml, type: deployment}
     - {name: dnsmasq, file: dnsmasq-svc.yml, type: svc}
-    - {name: dnsmasq-autoscaler, file: dnsmasq-autoscaler.yml, type: deployment}
+#    - {name: dnsmasq-autoscaler, file: dnsmasq-autoscaler.yml, type: deployment}
   register: manifests
   delegate_to: "{{ groups['kube-master'][0] }}"
   run_once: true

--- a/roles/kubernetes-apps/network_plugin/aci/tasks/main.yml
+++ b/roles/kubernetes-apps/network_plugin/aci/tasks/main.yml
@@ -1,0 +1,18 @@
+- name: copy over private repo yaml
+  template: src=noiro-docker-registry-credentials.yaml dest={{kube_manifest_dir}}/noiro-docker-registry-credentials.yaml
+  when: inventory_hostname == groups['kube-master'][0]
+ 
+- name: create private repo secret
+  command: "{{ bin_dir }}/kubectl create -f {{kube_manifest_dir}}/noiro-docker-registry-credentials.yaml"
+  run_once: true
+  when: inventory_hostname == groups['kube-master'][0]
+ 
+#- name: Create aci manifest
+#  template: src=aci-containers.j2 dest={{kube_manifest_dir}}/aci-containers.yml
+#  when: inventory_hostname == groups['kube-master'][0]
+ 
+- name: Create ACI containers
+  command: "{{ bin_dir }}/kubectl create -f /home/noiro/noiro/aci_deployment.yaml"
+  run_once: true
+  when: inventory_hostname == groups['kube-master'][0]
+

--- a/roles/kubernetes-apps/network_plugin/aci/templates/aci-containers.j2
+++ b/roles/kubernetes-apps/network_plugin/aci/templates/aci-containers.j2
@@ -1,0 +1,346 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: apic-user-pass
+  namespace: kube-system
+data:
+  username: YWRtaW4=
+  password: bm9pcjAxMjM=
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aci-containers-config
+  namespace: kube-system
+  labels:
+    k8s-app: aci-containers
+data:
+  encap-type: "vxlan"
+  uplink-iface: "eth2"
+  infra-vlan: "4093"
+  apic-hosts: "10.30.120.140"
+  controller-config: |-
+    {
+        "log-level": "debug",
+        "aci-tenant": "common",
+        "default-endpoint-group": {
+            "policy-space": "common",
+            "name": "inb-mgmt-app|kube-system-pods"
+        },
+        "service-ip-pool": [
+            {"start": "10.4.1.1", "end": "10.4.255.254"}
+        ],
+        "static-service-ip-pool": [
+            {"start": "10.4.0.1", "end": "10.4.0.255"}
+        ],
+        "pod-ip-pool": [
+            {"start": "10.1.0.2", "end": "10.1.255.254"}
+        ],
+        "node-service-ip-pool": [
+            {"start": "10.6.1.1", "end": "10.6.1.254"}
+        ]
+    }
+  host-agent-config: |-
+    {
+        "log-level": "debug",
+        "aci-vrf": "kubernetes-vrf",
+        "aci-vrf-tenant": "common",
+        "service-iface": "eth2",
+        "service-iface-vlan": 4003,
+        "cni-netconfig": [
+            {
+                "subnet": "10.1.0.0/16",
+                "gateway": "10.1.0.1",
+                "routes": [
+                    { "dst": "0.0.0.0/0", "gw": "10.1.0.1" }
+                ]
+            }
+        ]
+    }
+  opflex-agent-config: |-
+    {
+        "opflex": {
+            "domain": "comp/prov-OpenStack/ctrlr-[ostack]-ostack/sw-InsiemeLSOid"
+        }
+    }
+  aim-config: |-
+    [DEFAULT]
+    debug = True
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: aci-containers-host
+  namespace: kube-system
+  labels:
+    k8s-app: aci-containers
+spec:
+  template:
+    metadata:
+      labels:
+        name: aci-containers-host
+    spec:
+      hostNetwork: true
+      hostPID: true
+      hostIPC: true
+      imagePullSecrets:
+        - name: noiro-docker-registry-secret
+      containers:
+        - name: aci-containers-host
+          image: 10.30.120.20/noiro/aci-containers-host
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true
+          env:
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: cni-bin
+              mountPath: /mnt/cni-bin
+            - name: cni-conf
+              mountPath: /mnt/cni-conf
+            - name: hostvar
+              mountPath: /usr/local/var
+            - name: hostrun
+              mountPath: /run
+            - name: kubeconfig
+              mountPath: /usr/local/etc/kubeconfig
+            - name: host-config-volume
+              mountPath: /usr/local/etc/aci-containers/
+          livenessProbe:
+            httpGet:
+              path: /status
+              port: 8090
+        - name: opflex-agent
+          image: 10.30.120.20/noiro/opflex
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true
+          env:
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: ACI_ENCAP_TYPE
+              valueFrom:
+                configMapKeyRef:
+                  name: aci-containers-config
+                  key: encap-type
+            - name: ACI_UPLINK_IFACE
+              valueFrom:
+                configMapKeyRef:
+                  name: aci-containers-config
+                  key: uplink-iface
+            - name: ACI_INFRA_VLAN
+              valueFrom:
+                configMapKeyRef:
+                  name: aci-containers-config
+                  key: infra-vlan
+          volumeMounts:
+            - name: hostvar
+              mountPath: /usr/local/var
+            - name: hostrun
+              mountPath: /run
+            - name: opflex-config-volume
+              mountPath: /usr/local/etc/opflex-agent-ovs/conf.d
+        - name: mcast-daemon
+          image: 10.30.120.20/noiro/opflex
+          command: ["/bin/sh"]
+          args: ["/usr/local/bin/launch-mcastdaemon.sh"]
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: hostvar
+              mountPath: /usr/local/var
+            - name: hostrun
+              mountPath: /run
+      restartPolicy: Always
+      volumes:
+        - name: cni-bin
+          hostPath:
+            path: /opt
+        - name: cni-conf
+          hostPath:
+            path: /etc
+        - name: hostvar
+          hostPath:
+            path: /var
+        - name: hostrun
+          hostPath:
+            path: /run
+        - name: kubeconfig
+          hostPath:
+            path: /etc/kubernetes/kubelet.conf
+        - name: host-config-volume
+          configMap:
+            name: aci-containers-config
+            items:
+              - key: host-agent-config
+                path: host-agent.conf
+        - name: opflex-config-volume
+          configMap:
+            name: aci-containers-config
+            items:
+              - key: opflex-agent-config
+                path: local.conf
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: aci-containers-openvswitch
+  namespace: kube-system
+  labels:
+    k8s-app: aci-containers
+spec:
+  template:
+    metadata:
+      labels:
+        name: aci-containers-openvswitch
+    spec:
+      hostNetwork: true
+      hostPID: true
+      hostIPC: true
+      imagePullSecrets:
+        - name: noiro-docker-registry-secret
+      containers:
+        - name: aci-containers-openvswitch
+          image: 10.30.120.20/noiro/openvswitch
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true
+          env:
+            - name: ACI_ENCAP_TYPE
+              valueFrom:
+                configMapKeyRef:
+                  name: aci-containers-config
+                  key: encap-type
+            - name: ACI_UPLINK_IFACE
+              valueFrom:
+                configMapKeyRef:
+                  name: aci-containers-config
+                  key: uplink-iface
+            - name: ACI_INFRA_VLAN
+              valueFrom:
+                configMapKeyRef:
+                  name: aci-containers-config
+                  key: infra-vlan
+            - name: OVS_RUNDIR
+              value: /usr/local/var/run/openvswitch
+            - name: OVS_DBDIR
+              value: /usr/local/var/lib/aci-containers/ovsdb
+          volumeMounts:
+            - name: hostvar
+              mountPath: /usr/local/var
+            - name: hostrun
+              mountPath: /run
+            - name: hostetc
+              mountPath: /usr/local/etc
+            - name: hostmodules
+              mountPath: /lib/modules
+          livenessProbe:
+            exec:
+              command:
+                - /usr/share/openvswitch/scripts/ovs-ctl
+                - status
+      restartPolicy: Always
+      volumes:
+        - name: hostetc
+          hostPath:
+            path: /etc
+        - name: hostvar
+          hostPath:
+            path: /var
+        - name: hostrun
+          hostPath:
+            path: /run
+        - name: hostmodules
+          hostPath:
+            path: /lib/modules
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: aci-containers-controller
+  namespace: kube-system
+  labels:
+    k8s-app: aci-containers
+  annotations:
+    scheduler.alpha.kubernetes.io/critical-pod: ''
+    scheduler.alpha.kubernetes.io/tolerations: |
+      [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
+       {"key":"CriticalAddonsOnly", "operator":"Exists"}]
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      name: aci-containers-controller
+      namespace: kube-system
+      labels:
+        k8s-app: aci-containers
+    spec:
+      hostNetwork: true
+      imagePullSecrets:
+        - name: noiro-docker-registry-secret
+      containers:
+        - name: aci-containers-controller
+          image: 10.30.120.20/noiro/aci-containers-controller
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: controller-config-volume
+              mountPath: /usr/local/etc/aci-containers/
+            - name: kubeconfig
+              mountPath: /usr/local/etc/kubeconfig
+          livenessProbe:
+            httpGet:
+              path: /status
+              port: 8091
+        - name: aci-integration-module
+          image: 10.30.120.20/noiro/aci-integration-module
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: APIC_HOSTS
+              valueFrom:
+                configMapKeyRef:
+                  name: aci-containers-config
+                  key: apic-hosts
+            - name: APIC_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: apic-user-pass
+                  key: username
+            - name: APIC_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: apic-user-pass
+                  key: password
+          volumeMounts:
+            - name: aim-config-volume
+              mountPath: /usr/local/etc/aim-local
+            - name: kubeconfig
+              mountPath: /usr/local/etc/kubeconfig
+            - name: kubessl
+              mountPath: /etc/kubernetes/ssl
+      volumes:
+        - name: controller-config-volume
+          configMap:
+            name: aci-containers-config
+            items:
+              - key: controller-config
+                path: controller.conf
+        - name: aim-config-volume
+          configMap:
+            name: aci-containers-config
+            items:
+              - key: aim-config
+                path: aim-local.conf
+        - name: kubeconfig
+          hostPath:
+            path: /etc/kubernetes/node-kubeconfig.yaml
+        - name: kubessl
+          hostPath:
+            path: /etc/kubernetes/ssl

--- a/roles/kubernetes-apps/network_plugin/aci/templates/noiro-docker-registry-credentials.yaml
+++ b/roles/kubernetes-apps/network_plugin/aci/templates/noiro-docker-registry-credentials.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+data:
+  .dockercfg: eyIxMC4zMC4xMjAuMjAiOnsidXNlcm5hbWUiOiJub2lybyIsInBhc3N3b3JkIjoibm9pcjAxMjMiLCJlbWFpbCI6InJrb2xsaUBub2lyb25ldHdvcmtzLmNvbSIsImF1dGgiOiJibTlwY204NmJtOXBjakF4TWpNPSJ9fQ==
+kind: Secret
+metadata:
+  creationTimestamp: null
+  name: noiro-docker-registry-secret
+  namespace: kube-system
+type: kubernetes.io/dockercfg

--- a/roles/kubernetes-apps/network_plugin/meta/main.yml
+++ b/roles/kubernetes-apps/network_plugin/meta/main.yml
@@ -39,3 +39,8 @@ dependencies:
     when: kube_network_plugin_multus
     tags:
       - multus
+
+  - role: kubernetes-apps/network_plugin/aci
+    when: kube_network_plugin == 'aci'
+    tags:
+      - aci

--- a/roles/kubernetes/master/defaults/main.yml
+++ b/roles/kubernetes/master/defaults/main.yml
@@ -4,7 +4,7 @@
 kube_hostpath_dynamic_provisioner: "false"
 
 # change to 0.0.0.0 to enable insecure access from anywhere (not recommended)
-kube_apiserver_insecure_bind_address: 127.0.0.1
+kube_apiserver_insecure_bind_address: 0.0.0.0
 
 # By default the external API listens on all interfaces, this can be changed to
 # listen on a specific address/interface.

--- a/roles/kubernetes/node/templates/kubelet.standard.env.j2
+++ b/roles/kubernetes/node/templates/kubelet.standard.env.j2
@@ -124,7 +124,7 @@ KUBELET_HOSTNAME="--hostname-override={{ kube_override_hostname }}"
 
 KUBELET_ARGS="{{ kubelet_args_base }} {{ kubelet_args_dns }} {{ kubelet_args_kubeconfig }} {{ kube_reserved }} --node-labels={{ all_node_labels | join(',') }} {% if kube_feature_gates %} --feature-gates={{ kube_feature_gates|join(',') }} {% endif %} {% if kubelet_custom_flags is string %} {{kubelet_custom_flags}} {% else %}{% for flag in kubelet_custom_flags %} {{flag}} {% endfor %}{% endif %}{% if inventory_hostname in groups['kube-node'] %}{% if kubelet_node_custom_flags is string %} {{kubelet_node_custom_flags}} {% else %}{% for flag in kubelet_node_custom_flags %} {{flag}} {% endfor %}{% endif %}{% endif %}"
 
-{% if kube_network_plugin is defined and kube_network_plugin in ["calico", "canal", "flannel", "weave", "contiv", "cilium", "kube-router"] %}
+{% if kube_network_plugin is defined and kube_network_plugin in ["calico", "canal", "flannel", "weave", "contiv", "cilium", "kube-router", "aci"] %}
 KUBELET_NETWORK_PLUGIN="--network-plugin=cni --cni-conf-dir=/etc/cni/net.d --cni-bin-dir=/opt/cni/bin"
 {% elif kube_network_plugin is defined and kube_network_plugin == "weave" %}
 DOCKER_SOCKET="--docker-endpoint=unix:/var/run/weave/weave.sock"

--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -26,7 +26,7 @@
 
 - name: Stop if unknown network plugin
   assert:
-    that: kube_network_plugin in ['calico', 'canal', 'flannel', 'weave', 'cloud', 'cilium', 'contiv', 'kube-router']
+    that: kube_network_plugin in ['calico', 'canal', 'flannel', 'weave', 'cloud', 'cilium', 'contiv', 'kube-router', 'aci']
   when: kube_network_plugin is defined
   ignore_errors: "{{ ignore_assert_errors }}"
 

--- a/roles/kubernetes/preinstall/tasks/0050-create_directories.yml
+++ b/roles/kubernetes/preinstall/tasks/0050-create_directories.yml
@@ -33,7 +33,7 @@
     - "/opt/cni/bin"
     - "/var/lib/calico"
   when:
-    - kube_network_plugin in ["calico", "weave", "canal", "flannel", "contiv", "cilium", "kube-router"]
+    - kube_network_plugin in ["calico", "weave", "canal", "flannel", "contiv", "cilium", "kube-router", "aci"]
     - inventory_hostname in groups['k8s-cluster']
   tags:
     - network

--- a/roles/network_plugin/aci/tasks/main.yml
+++ b/roles/network_plugin/aci/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+- name: Cloud | Copy cni plugins from hyperkube
+  command: "{{ docker_bin_dir }}/docker run --rm -v /opt/cni/bin:/cnibindir {{ hyperkube_image_repo }}:{{ hyperkube_image_tag }} /bin/cp -r /opt/cni/bin/. /cnibindir/"
+  register: cni_task_result
+  until: cni_task_result.rc == 0
+  retries: 4
+  delay: "{{ retry_stagger | random + 3 }}"
+  changed_when: false
+
+- name: Cloud | Set cni directory permissions
+  file:
+    path: /opt/cni/bin
+    state: directory
+    owner: kube
+    recurse: true
+    mode: "u=rwX,g-rwx,o-rwx"

--- a/roles/network_plugin/meta/main.yml
+++ b/roles/network_plugin/meta/main.yml
@@ -42,3 +42,6 @@ dependencies:
     when: kube_network_plugin_multus
     tags:
       - multus
+
+  - role: network_plugin/aci
+    when: kube_network_plugin == 'aci'

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -136,6 +136,8 @@
     - /opt/cni
     - /etc/dhcp/dhclient.d/zdnsupdate.sh
     - /etc/dhcp/dhclient-exit-hooks.d/zdnsupdate
+    - /var/lib/opflex-agent-ovs
+    - /var/run/openvswitch
     - /run/flannel
     - /etc/flannel
     - /run/kubernetes


### PR DESCRIPTION
Work Pending: 

1. update packages on noiro-ctrl-svr .
noiro@noiro-ctrl-srvr:~/kubespray-mchalla$ cat requirements.txt
ansible>=2.5.0,!=2.7.0
jinja2>=2.9.6
netaddr
pbr>=1.6
ansible-modules-hashivault>=3.9.4
hvac
noiro@noiro-ctrl-srvr:~/kubespray-mchalla$

2. update sauto to account for the directory structure refactor in latest kubespray. Diffs at 
noiro@noiro-ctrl-srvr:~/sauto-mchalla$ pwd
/home/noiro/sauto-mchalla