### PR TITLE
Add the option to add multiple ssh public keys for Azure infrastructure

### DIFF
--- a/contrib/azurerm/group_vars/all
+++ b/contrib/azurerm/group_vars/all
@@ -1,5 +1,5 @@
 
-# Due to some Azure limitations (ex:- Storage Account's name must be unique), 
+# Due to some Azure limitations (ex:- Storage Account's name must be unique),
 # this name must be globally unique - it will be used as a prefix for azure components
 cluster_name: example
 
@@ -20,7 +20,8 @@ admin_username: devops
 admin_password: changeme
 
 # MAKE SURE TO CHANGE THIS TO YOUR PUBLIC KEY to access your azure machines
-ssh_public_key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDLRzcxbsFDdEibiyXCSdIFh7bKbXso1NqlKjEyPTptf3aBXHEhVil0lJRjGpTlpfTy7PHvXFbXIOCdv9tOmeH1uxWDDeZawgPFV6VSZ1QneCL+8bxzhjiCn8133wBSPZkN8rbFKd9eEUUBfx8ipCblYblF9FcidylwtMt5TeEmXk8yRVkPiCuEYuDplhc2H0f4PsK3pFb5aDVdaDT3VeIypnOQZZoUxHWqm6ThyHrzLJd3SrZf+RROFWW1uInIDf/SZlXojczUYoffxgT1lERfOJCHJXsqbZWugbxQBwqsVsX59+KPxFFo6nV88h3UQr63wbFx52/MXkX4WrCkAHzN ablock-vwfs@dell-lappy"
+ssh_public_keys:
+ - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDLRzcxbsFDdEibiyXCSdIFh7bKbXso1NqlKjEyPTptf3aBXHEhVil0lJRjGpTlpfTy7PHvXFbXIOCdv9tOmeH1uxWDDeZawgPFV6VSZ1QneCL+8bxzhjiCn8133wBSPZkN8rbFKd9eEUUBfx8ipCblYblF9FcidylwtMt5TeEmXk8yRVkPiCuEYuDplhc2H0f4PsK3pFb5aDVdaDT3VeIypnOQZZoUxHWqm6ThyHrzLJd3SrZf+RROFWW1uInIDf/SZlXojczUYoffxgT1lERfOJCHJXsqbZWugbxQBwqsVsX59+KPxFFo6nV88h3UQr63wbFx52/MXkX4WrCkAHzN ablock-vwfs@dell-lappy"
 
 # Disable using ssh using password. Change it to false to allow to connect to ssh by password
 disablePasswordAuthentication: true

--- a/contrib/azurerm/roles/generate-templates/templates/bastion.json
+++ b/contrib/azurerm/roles/generate-templates/templates/bastion.json
@@ -66,10 +66,12 @@
             "disablePasswordAuthentication": "true",
             "ssh": {
               "publicKeys": [
+                {% for key in ssh_public_keys %}
                 {
                   "path": "{{sshKeyPath}}",
-                  "keyData": "{{ssh_public_key}}"
-                }
+                  "keyData": "{{key}}"
+                }{% if loop.index < ssh_public_keys | length %},{% endif %}
+                {% endfor %}
               ]
             }
           }

--- a/contrib/azurerm/roles/generate-templates/templates/masters.json
+++ b/contrib/azurerm/roles/generate-templates/templates/masters.json
@@ -162,10 +162,12 @@
             "disablePasswordAuthentication": "{{disablePasswordAuthentication}}",
             "ssh": {
               "publicKeys": [
+                {% for key in ssh_public_keys %}
                 {
                   "path": "{{sshKeyPath}}",
-                  "keyData": "{{ssh_public_key}}"
-                }
+                  "keyData": "{{key}}"
+                }{% if loop.index < ssh_public_keys | length %},{% endif %}
+                {% endfor %}
               ]
             }
           }

--- a/contrib/azurerm/roles/generate-templates/templates/minions.json
+++ b/contrib/azurerm/roles/generate-templates/templates/minions.json
@@ -79,10 +79,12 @@
             "disablePasswordAuthentication": "{{disablePasswordAuthentication}}",
             "ssh": {
               "publicKeys": [
+                {% for key in ssh_public_keys %}
                 {
                   "path": "{{sshKeyPath}}",
-                  "keyData": "{{ssh_public_key}}"
-                }
+                  "keyData": "{{key}}"
+                }{% if loop.index < ssh_public_keys | length %},{% endif %}
+                {% endfor %}
               ]
             }
           }


### PR DESCRIPTION
This give users the option to define multiple ssh public keys when
deploying the base infrastructure on Azure.