### PR TITLE
Add the option to create a DNS record for bastion deployed to Azure

### DIFF
--- a/contrib/azurerm/group_vars/all
+++ b/contrib/azurerm/group_vars/all
@@ -1,11 +1,15 @@
 
-# Due to some Azure limitations (ex:- Storage Account's name must be unique), 
+# Due to some Azure limitations (ex:- Storage Account's name must be unique),
 # this name must be globally unique - it will be used as a prefix for azure components
 cluster_name: example
 
 # Set this to true if you do not want to have public IPs for your masters and minions. This will provision a bastion
 # node that can be used to access the masters and minions
 use_bastion: false
+
+# Set this to a prefered name that will be used as the first part of the dns name for your bastotion host. For example: k8s-bastion.<azureregion>.cloudapp.azure.com.
+# This is convenient when exceptions have to be configured on a firewall to allow ssh to the given bastion host.
+# bastion_domain_prefix: k8s-bastion
 
 number_of_k8s_masters: 3
 number_of_k8s_nodes: 3

--- a/contrib/azurerm/roles/generate-templates/templates/bastion.json
+++ b/contrib/azurerm/roles/generate-templates/templates/bastion.json
@@ -15,7 +15,12 @@
       "name": "{{bastionIPAddressName}}",
       "location": "[resourceGroup().location]",
       "properties": {
-        "publicIPAllocationMethod": "Static"
+        "publicIPAllocationMethod": "Static",
+        "dnsSettings": {
+          {% if bastion_domain_prefix %}
+          "domainNameLabel": "{{ bastion_domain_prefix }}"
+          {% endif %}
+        }
       }
     },
     {


### PR DESCRIPTION
This is rather convenient if you want to configure exceptions on a
company firewall.