### PR TITLE
remove-node: fix assert for ansible_version

### DIFF
--- a/remove-node.yml
+++ b/remove-node.yml
@@ -5,7 +5,7 @@
       assert:
         msg: "Ansible V2.7.0 can't be used until: https://github.com/ansible/ansible/issues/46600 is fixed"
         that:
-          - ansible_version.string is version("2.7.0", "<")
+          - ansible_version.string is version("2.7.0", "!=")
           - ansible_version.string is version("2.5.0", ">=")
       tags:
         - check


### PR DESCRIPTION
A small fix for those who use Ansible >2.7.0. Should use same logic as other asserts.