### PR TITLE
Tag win_nodes roles with master

### DIFF
--- a/cluster.yml
+++ b/cluster.yml
@@ -90,7 +90,7 @@
   roles:
     - { role: kubespray-defaults}
     - { role: kubernetes-apps/rotate_tokens, tags: rotate_tokens, when: "secret_changed|default(false)" }
-    - { role: win_nodes/kubernetes_patch, tags: win_nodes, when: "kubeadm_enabled" }
+    - { role: win_nodes/kubernetes_patch, tags: ["win_nodes", "master"], when: "kubeadm_enabled" }
 
 - hosts: kube-master
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"

--- a/cluster.yml
+++ b/cluster.yml
@@ -90,7 +90,7 @@
   roles:
     - { role: kubespray-defaults}
     - { role: kubernetes-apps/rotate_tokens, tags: rotate_tokens, when: "secret_changed|default(false)" }
-    - { role: win_nodes/kubernetes_patch, tags: ["win_nodes", "master"], when: "kubeadm_enabled" }
+    - { role: win_nodes/kubernetes_patch, tags: ["master", "win_nodes"], when: "kubeadm_enabled" }
 
 - hosts: kube-master
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"


### PR DESCRIPTION

[kube-proxy setup](https://github.com/kubernetes-incubator/kubespray/blob/master/roles/kubernetes/master/tasks/kubeadm-setup.yml#L140) in the kubernetes master role will remove any node selectors applied to the kube-proxy daemonset.   For hybrid clusters, running just the master role may result in kube-proxy pods being scheduled on windows node.  Therefore, the linux node selector patch for kube-proxy should be reapplied anytime the master role runs. 