### PR TITLE
Add PriorityClasses on the last master.

### DIFF
--- a/roles/kubernetes-apps/cluster_roles/tasks/main.yml
+++ b/roles/kubernetes-apps/cluster_roles/tasks/main.yml
@@ -179,7 +179,7 @@
   copy: src=k8s-cluster-critical-pc.yml dest={{ kube_config_dir }}/k8s-cluster-critical-pc.yml
   when:
     - kube_version is version('v1.11.1', '>=')
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == groups['kube-master']|last
 
 - name: PriorityClass | Create k8s-cluster-critical
   kube:
@@ -190,4 +190,4 @@
     state: latest
   when:
     - kube_version is version('v1.11.1', '>=')
-    - inventory_hostname == groups['kube-master'][0]
+    - inventory_hostname == groups['kube-master']|last


### PR DESCRIPTION
When upgrading a cluster from a former version of 1.11.1 where PriorityClasses is not supported, the following error happens:

`error: unable to recognize "/etc/kubernetes/k8s-cluster-critical-pc.yml": no matches for kind "PriorityClass" in version "scheduling.k8s.io/v1beta1"`

Adding the PriorityClasses on the last master resolves the issue according to @Atoms 