### PR TITLE
hostnameOverride on a per-node basis in kube-proxy configuration with kubeadm

### DIFF
--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha2.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha2.yaml.j2
@@ -28,7 +28,6 @@ cloudProvider: {{ cloud_provider }}
 kubeProxy:
   config:
     mode: {{ kube_proxy_mode }}
-    hostnameOverride: {{ inventory_hostname }}
 {% if kube_proxy_nodeport_addresses %}
     nodePortAddresses: [{{ kube_proxy_nodeport_addresses_cidr }}]
 {% endif %}

--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha3.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha3.yaml.j2
@@ -180,7 +180,6 @@ conntrack:
  tcpEstablishedTimeout: 24h0m0s
 enableProfiling: false
 healthzBindAddress: 0.0.0.0:10256
-hostnameOverride: {{ inventory_hostname }}
 iptables:
  masqueradeAll: false
  masqueradeBit: 14

--- a/roles/win_nodes/kubernetes_patch/tasks/main.yml
+++ b/roles/win_nodes/kubernetes_patch/tasks/main.yml
@@ -7,6 +7,33 @@
     recurse: yes
   tags: [init, cni]
 
+- name: Apply kube-proxy hostnameOverride
+  block:
+    - name: Copy kube-proxy daemonset hostnameOverride patch
+      copy:
+        src: hostnameOverride-patch.json
+        dest: "{{ kubernetes_user_manifests_path }}/hostnameOverride-patch.json"
+
+    - name: Check current command for kube-proxy daemonset
+      shell: "{{bin_dir}}/kubectl get ds kube-proxy --namespace=kube-system -o jsonpath='{.spec.template.spec.containers[0].command}'"
+      register: current_kube_proxy_command
+
+    - name: Apply hostnameOverride patch for kube-proxy daemonset
+      shell: "{{bin_dir}}/kubectl patch ds kube-proxy --namespace=kube-system --type=strategic -p \"$(cat hostnameOverride-patch.json)\""
+      args:
+        chdir: "{{ kubernetes_user_manifests_path }}"
+      register: patch_kube_proxy_command
+      when: not current_kube_proxy_command.stdout is search("--hostname-override=${NODE_NAME}")
+
+    - debug: msg={{ patch_kube_proxy_command.stdout_lines }}
+      when: patch_kube_proxy_command is not skipped
+
+    - debug: msg={{ patch_kube_proxy_command.stderr_lines }}
+      when: patch_kube_proxy_command is not skipped
+  tags: init
+  when:
+    - not kube_proxy_remove
+
 - name: Apply kube-proxy nodeselector
   block:
     - name: Copy kube-proxy daemonset nodeselector patch


### PR DESCRIPTION
Supersedes PR #3612 (by addressing the issue described here https://kubernetes.io/docs/setup/independent/troubleshooting-kubeadm/#services-with-externaltrafficpolicy-local-are-not-reachable) and thus fixes #3610.
