### PR TITLE
Update CoreDNS, KubeDNS and Autoscaler to newest templates

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -181,7 +181,7 @@ dnsmasq_sidecar_image_tag: "{{ kubedns_version }}"
 dnsmasqautoscaler_version: 1.1.2
 dnsmasqautoscaler_image_repo: "gcr.io/google_containers/cluster-proportional-autoscaler-{{ image_arch }}"
 dnsmasqautoscaler_image_tag: "{{ dnsmasqautoscaler_version }}"
-dnsautoscaler_version: 1.2.0
+dnsautoscaler_version: 1.3.0
 dnsautoscaler_image_repo: "gcr.io/google_containers/cluster-proportional-autoscaler-{{ image_arch }}"
 dnsautoscaler_image_tag: "{{ dnsautoscaler_version }}"
 test_image_repo: busybox

--- a/roles/kubernetes-apps/ansible/defaults/main.yml
+++ b/roles/kubernetes-apps/ansible/defaults/main.yml
@@ -9,6 +9,8 @@ dns_cpu_requests: 100m
 dns_memory_requests: 70Mi
 dns_min_replicas: 2
 dns_nodes_per_replica: 10
+dns_cores_per_replica: 20
+dns_prevent_single_point_failure: "{{ 'true' if dns_min_replicas > '1' else 'false' }}"
 
 # Images
 image_arch: "{{host_architecture}}"

--- a/roles/kubernetes-apps/ansible/tasks/kubedns.yml
+++ b/roles/kubernetes-apps/ansible/tasks/kubedns.yml
@@ -6,7 +6,7 @@
     dest: "{{ kube_config_dir }}/{{ item.file }}"
   with_items:
     - { name: kube-dns, file: kubedns-sa.yml, type: sa }
-    - { name: kube-dns, file: kubedns-config.yml.j2, type: configmap }
+    - { name: kube-dns, file: kubedns-config.yml, type: configmap }
     - { name: kube-dns, file: kubedns-deploy.yml, type: deployment }
     - { name: kube-dns, file: kubedns-svc.yml, type: svc }
     - { name: dns-autoscaler, file: dns-autoscaler-sa.yml, type: sa }

--- a/roles/kubernetes-apps/ansible/tasks/kubedns.yml
+++ b/roles/kubernetes-apps/ansible/tasks/kubedns.yml
@@ -6,6 +6,7 @@
     dest: "{{ kube_config_dir }}/{{ item.file }}"
   with_items:
     - { name: kube-dns, file: kubedns-sa.yml, type: sa }
+    - { name: kube-dns, file: kubedns-config.yml.j2, type: configmap }
     - { name: kube-dns, file: kubedns-deploy.yml, type: deployment }
     - { name: kube-dns, file: kubedns-svc.yml, type: svc }
     - { name: dns-autoscaler, file: dns-autoscaler-sa.yml, type: sa }

--- a/roles/kubernetes-apps/ansible/templates/coredns-clusterrole.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-clusterrole.yml.j2
@@ -1,9 +1,10 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
     kubernetes.io/bootstrapping: rbac-defaults
+    addonmanager.kubernetes.io/mode: Reconcile
   name: system:coredns
 rules:
 - apiGroups:
@@ -16,3 +17,9 @@ rules:
   verbs:
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get

--- a/roles/kubernetes-apps/ansible/templates/coredns-clusterrolebinding.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-clusterrolebinding.yml.j2
@@ -1,11 +1,12 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   annotations:
     rbac.authorization.kubernetes.io/autoupdate: "true"
   labels:
     kubernetes.io/bootstrapping: rbac-defaults
+    addonmanager.kubernetes.io/mode: EnsureExists
   name: system:coredns
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
@@ -4,6 +4,8 @@ kind: ConfigMap
 metadata:
   name: coredns
   namespace: kube-system
+  labels:
+      addonmanager.kubernetes.io/mode: EnsureExists
 data:
   Corefile: |
     .:53 {

--- a/roles/kubernetes-apps/ansible/templates/coredns-deployment.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-deployment.yml.j2
@@ -2,10 +2,12 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: coredns{{ coredns_ordinal_suffix | default('') }}
+  name: "coredns{{ coredns_ordinal_suffix | default('') }}"
   namespace: kube-system
   labels:
-    k8s-app: coredns{{ coredns_ordinal_suffix | default('') }}
+    k8s-app: "coredns{{ coredns_ordinal_suffix | default('') }}"
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
     kubernetes.io/name: "coredns{{ coredns_ordinal_suffix | default('') }}"
 spec:
   strategy:
@@ -21,7 +23,7 @@ spec:
       labels:
         k8s-app: coredns{{ coredns_ordinal_suffix | default('') }}
       annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
+        seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
 {% if kube_version is version('v1.11.1', '>=') %}
       priorityClassName: system-cluster-critical

--- a/roles/kubernetes-apps/ansible/templates/coredns-sa.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-sa.yml.j2
@@ -4,3 +4,6 @@ kind: ServiceAccount
 metadata:
   name: coredns
   namespace: kube-system
+  labels:
+      kubernetes.io/cluster-service: "true"
+      addonmanager.kubernetes.io/mode: Reconcile

--- a/roles/kubernetes-apps/ansible/templates/coredns-svc.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-svc.yml.j2
@@ -8,6 +8,7 @@ metadata:
     k8s-app: coredns{{ coredns_ordinal_suffix | default('') }}
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "coredns{{ coredns_ordinal_suffix | default('') }}"
+    addonmanager.kubernetes.io/mode: Reconcile
   annotations:
     prometheus.io/path: /metrics
     prometheus.io/port: "9153"

--- a/roles/kubernetes-apps/ansible/templates/dns-autoscaler-clusterrole.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/dns-autoscaler-clusterrole.yml.j2
@@ -14,10 +14,11 @@
 # limitations under the License.
 
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: cluster-proportional-autoscaler
-  namespace: kube-system
+  name: system:dns-autoscaler
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
 rules:
   - apiGroups: [""]
     resources: ["nodes"]

--- a/roles/kubernetes-apps/ansible/templates/dns-autoscaler-clusterrolebinding.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/dns-autoscaler-clusterrolebinding.yml.j2
@@ -14,15 +14,16 @@
 # limitations under the License.
 
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: cluster-proportional-autoscaler
-  namespace: kube-system
+  name: system:dns-autoscaler
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
 subjects:
   - kind: ServiceAccount
-    name: cluster-proportional-autoscaler
+    name: dns-autoscaler
     namespace: kube-system
 roleRef:
   kind: ClusterRole
-  name: cluster-proportional-autoscaler
+  name: system:dns-autoscaler
   apiGroup: rbac.authorization.k8s.io

--- a/roles/kubernetes-apps/ansible/templates/dns-autoscaler-sa.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/dns-autoscaler-sa.yml.j2
@@ -16,5 +16,7 @@
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: cluster-proportional-autoscaler
+  name: dns-autoscaler
   namespace: kube-system
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile

--- a/roles/kubernetes-apps/ansible/templates/dns-autoscaler.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/dns-autoscaler.yml.j2
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: dns-autoscaler
@@ -27,6 +27,9 @@ spec:
     metadata:
       labels:
         k8s-app: dns-autoscaler
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
 {% if kube_version is version('v1.11.1', '>=') %}
       priorityClassName: system-cluster-critical
@@ -63,7 +66,7 @@ spec:
         command:
         - /cluster-proportional-autoscaler
         - --namespace=kube-system
-        - --default-params={"linear":{"nodesPerReplica":{{ dns_nodes_per_replica }},"min":{{ dns_min_replicas }}}}
+        - --default-params={"linear":{"preventSinglePointFailure":{{ dns_prevent_single_point_failure }},"coresPerReplica":{{ dns_cores_per_replica }},"nodesPerReplica":{{ dns_nodes_per_replica }},"min":{{ dns_min_replicas }}}}
         - --logtostderr=true
         - --v=2
         - --configmap=dns-autoscaler
@@ -73,4 +76,4 @@ spec:
 {% if dns_mode in ['kubedns', 'dnsmasq_kubedns'] %}
         - --target=Deployment/kube-dns
 {% endif %}
-      serviceAccountName: cluster-proportional-autoscaler
+      serviceAccountName: dns-autoscaler

--- a/roles/kubernetes-apps/ansible/templates/dns-autoscaler.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/dns-autoscaler.yml.j2
@@ -23,6 +23,9 @@ metadata:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
+  selector:
+    matchLabels:
+      k8s-app: dns-autoscaler
   template:
     metadata:
       labels:

--- a/roles/kubernetes-apps/ansible/templates/dns-autoscaler.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/dns-autoscaler.yml.j2
@@ -79,4 +79,7 @@ spec:
 {% if dns_mode in ['kubedns', 'dnsmasq_kubedns'] %}
         - --target=Deployment/kube-dns
 {% endif %}
+      tolerations:
+      - key: "CriticalAddonsOnly"
+        operator: "Exists"
       serviceAccountName: dns-autoscaler

--- a/roles/kubernetes-apps/ansible/templates/kubedns-config.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/kubedns-config.yml.j2
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-dns
+  namespace: kube-system
+  labels:
+    addonmanager.kubernetes.io/mode: EnsureExists

--- a/roles/kubernetes-apps/ansible/templates/kubedns-deploy.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/kubedns-deploy.yml.j2
@@ -26,6 +26,7 @@ spec:
         k8s-app: kube-dns
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
+        seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
 {% if kube_version is version('v1.11.1', '>=') %}
       priorityClassName: system-cluster-critical
@@ -135,6 +136,7 @@ spec:
         - --
         - -k
         - --cache-size=1000
+        - --no-negcache
         - --dns-loop-detect
         - --log-facility=-
         - --server=/{{ dns_domain }}/127.0.0.1#10053
@@ -169,8 +171,8 @@ spec:
         args:
         - --v={{ kube_log_level }}
         - --logtostderr
-        - --probe=kubedns,127.0.0.1:10053,kubernetes.default.svc.{{ dns_domain }},5,A
-        - --probe=dnsmasq,127.0.0.1:53,kubernetes.default.svc.{{ dns_domain }},5,A
+        - --probe=kubedns,127.0.0.1:10053,kubernetes.default.svc.{{ dns_domain }},5,SRV
+        - --probe=dnsmasq,127.0.0.1:53,kubernetes.default.svc.{{ dns_domain }},5,SRV
         ports:
         - containerPort: 10054
           name: metrics

--- a/roles/kubernetes-apps/ansible/templates/kubedns-sa.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/kubedns-sa.yml.j2
@@ -6,3 +6,4 @@ metadata:
   namespace: kube-system
   labels:
     kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile


### PR DESCRIPTION
Update all templates for KubeDNS, CoreDNS and Autoscaler to newest version from https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/dns