### PR TITLE
fixed ansible include/import inheritance issue

### DIFF
--- a/roles/network_plugin/calico/tasks/main.yml
+++ b/roles/network_plugin/calico/tasks/main.yml
@@ -3,7 +3,7 @@
 
 - include_tasks: pre.yml
 
-- include_tasks: upgrade.yml
+- import_tasks: upgrade.yml
   when:
     - calico_upgrade_enabled
     - calico_upgrade_needed


### PR DESCRIPTION
Replaced 'include' and 'include_task' with 'import_task'. In ansible 2.4 'include' behaviour changed and properties (like delegate and become) are not propagated to the included task. Using import_task fixes this issue. See https://github.com/ansible/ansible/issues/37995.