### PR TITLE
Fix patch type in kubectl patch for hostnameOverride

### DIFF
--- a/roles/win_nodes/kubernetes_patch/tasks/main.yml
+++ b/roles/win_nodes/kubernetes_patch/tasks/main.yml
@@ -19,7 +19,7 @@
       register: current_kube_proxy_command
 
     - name: Apply hostnameOverride patch for kube-proxy daemonset
-      shell: "{{bin_dir}}/kubectl patch ds kube-proxy --namespace=kube-system --type=strategic -p \"$(cat hostnameOverride-patch.json)\""
+      shell: "{{bin_dir}}/kubectl patch ds kube-proxy --namespace=kube-system --type=json -p \"$(cat hostnameOverride-patch.json)\""
       args:
         chdir: "{{ kubernetes_user_manifests_path }}"
       register: patch_kube_proxy_command


### PR DESCRIPTION
Fix type to json (I should have read https://kubernetes.io/docs/setup/independent/troubleshooting-kubeadm/#services-with-externaltrafficpolicy-local-are-not-reachable more carefully)