### PR TITLE
Fix DNS Autoscaler for coredns_dual deployment

### DIFF
--- a/roles/kubernetes-apps/ansible/templates/dns-autoscaler.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/dns-autoscaler.yml.j2
@@ -16,20 +16,20 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: dns-autoscaler{%- if dns_mode in ['coredns', 'coredns_dual'] -%}{{ coredns_ordinal_suffix | default('') }}{%- endif -%}
+  name: dns-autoscaler{{ coredns_ordinal_suffix | default('') }}
   namespace: kube-system
   labels:
-    k8s-app: dns-autoscaler{%- if dns_mode in ['coredns', 'coredns_dual'] -%}{{ coredns_ordinal_suffix | default('') }}{%- endif -%}
+    k8s-app: dns-autoscaler{{ coredns_ordinal_suffix | default('') }}
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   selector:
     matchLabels:
-      k8s-app: dns-autoscaler{%- if dns_mode in ['coredns', 'coredns_dual'] -%}{{ coredns_ordinal_suffix | default('') }}{%- endif -%}
+      k8s-app: dns-autoscaler{{ coredns_ordinal_suffix | default('') }}
   template:
     metadata:
       labels:
-        k8s-app: dns-autoscaler{%- if dns_mode in ['coredns', 'coredns_dual'] -%}{{ coredns_ordinal_suffix | default('') }}{%- endif -%}
+        k8s-app: dns-autoscaler{{ coredns_ordinal_suffix | default('') }}
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
@@ -49,7 +49,7 @@ spec:
           - topologyKey: "kubernetes.io/hostname"
             labelSelector:
               matchLabels:
-                k8s-app: dns-autoscaler{%- if dns_mode in ['coredns', 'coredns_dual'] -%}{{ coredns_ordinal_suffix | default('') }}{%- endif -%}
+                k8s-app: dns-autoscaler{{ coredns_ordinal_suffix | default('') }}
         nodeAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 100
@@ -72,7 +72,7 @@ spec:
         - --default-params={"linear":{"preventSinglePointFailure":{{ dns_prevent_single_point_failure }},"coresPerReplica":{{ dns_cores_per_replica }},"nodesPerReplica":{{ dns_nodes_per_replica }},"min":{{ dns_min_replicas }}}}
         - --logtostderr=true
         - --v=2
-        - --configmap=dns-autoscaler{%- if dns_mode in ['coredns', 'coredns_dual'] -%}{{ coredns_ordinal_suffix | default('') }}{%- endif -%}
+        - --configmap=dns-autoscaler{{ coredns_ordinal_suffix | default('') }}
 {% if dns_mode in ['coredns', 'coredns_dual'] %}
         - --target=Deployment/coredns{{ coredns_ordinal_suffix | default('') }}
 {% endif %}

--- a/roles/kubernetes-apps/ansible/templates/dns-autoscaler.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/dns-autoscaler.yml.j2
@@ -16,20 +16,20 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: dns-autoscaler
+  name: dns-autoscaler{% if dns_mode in ['coredns', 'coredns_dual'] coredns_ordinal_suffix | default('') endif %}
   namespace: kube-system
   labels:
-    k8s-app: dns-autoscaler
+    k8s-app: dns-autoscaler{% if dns_mode in ['coredns', 'coredns_dual'] coredns_ordinal_suffix | default('') endif %}
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   selector:
     matchLabels:
-      k8s-app: dns-autoscaler
+      k8s-app: dns-autoscaler{% if dns_mode in ['coredns', 'coredns_dual'] coredns_ordinal_suffix | default('') endif %}
   template:
     metadata:
       labels:
-        k8s-app: dns-autoscaler
+        k8s-app: dns-autoscaler{% if dns_mode in ['coredns', 'coredns_dual'] coredns_ordinal_suffix | default('') endif %}
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
@@ -49,7 +49,7 @@ spec:
           - topologyKey: "kubernetes.io/hostname"
             labelSelector:
               matchLabels:
-                k8s-app: dns-autoscaler
+                k8s-app: dns-autoscaler{% if dns_mode in ['coredns', 'coredns_dual'] coredns_ordinal_suffix | default('') endif %}
         nodeAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 100
@@ -72,7 +72,7 @@ spec:
         - --default-params={"linear":{"preventSinglePointFailure":{{ dns_prevent_single_point_failure }},"coresPerReplica":{{ dns_cores_per_replica }},"nodesPerReplica":{{ dns_nodes_per_replica }},"min":{{ dns_min_replicas }}}}
         - --logtostderr=true
         - --v=2
-        - --configmap=dns-autoscaler
+        - --configmap=dns-autoscaler{% if dns_mode in ['coredns', 'coredns_dual'] coredns_ordinal_suffix | default('') endif %}
 {% if dns_mode in ['coredns', 'coredns_dual'] %}
         - --target=Deployment/coredns{{ coredns_ordinal_suffix | default('') }}
 {% endif %}

--- a/roles/kubernetes-apps/ansible/templates/dns-autoscaler.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/dns-autoscaler.yml.j2
@@ -16,20 +16,20 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: dns-autoscaler{% if dns_mode in ['coredns', 'coredns_dual'] coredns_ordinal_suffix | default('') endif %}
+  name: dns-autoscaler{%- if dns_mode in ['coredns', 'coredns_dual'] -%}{{ coredns_ordinal_suffix | default('') }}{%- endif -%}
   namespace: kube-system
   labels:
-    k8s-app: dns-autoscaler{% if dns_mode in ['coredns', 'coredns_dual'] coredns_ordinal_suffix | default('') endif %}
+    k8s-app: dns-autoscaler{%- if dns_mode in ['coredns', 'coredns_dual'] -%}{{ coredns_ordinal_suffix | default('') }}{%- endif -%}
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   selector:
     matchLabels:
-      k8s-app: dns-autoscaler{% if dns_mode in ['coredns', 'coredns_dual'] coredns_ordinal_suffix | default('') endif %}
+      k8s-app: dns-autoscaler{%- if dns_mode in ['coredns', 'coredns_dual'] -%}{{ coredns_ordinal_suffix | default('') }}{%- endif -%}
   template:
     metadata:
       labels:
-        k8s-app: dns-autoscaler{% if dns_mode in ['coredns', 'coredns_dual'] coredns_ordinal_suffix | default('') endif %}
+        k8s-app: dns-autoscaler{%- if dns_mode in ['coredns', 'coredns_dual'] -%}{{ coredns_ordinal_suffix | default('') }}{%- endif -%}
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
@@ -49,7 +49,7 @@ spec:
           - topologyKey: "kubernetes.io/hostname"
             labelSelector:
               matchLabels:
-                k8s-app: dns-autoscaler{% if dns_mode in ['coredns', 'coredns_dual'] coredns_ordinal_suffix | default('') endif %}
+                k8s-app: dns-autoscaler{%- if dns_mode in ['coredns', 'coredns_dual'] -%}{{ coredns_ordinal_suffix | default('') }}{%- endif -%}
         nodeAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 100
@@ -72,7 +72,7 @@ spec:
         - --default-params={"linear":{"preventSinglePointFailure":{{ dns_prevent_single_point_failure }},"coresPerReplica":{{ dns_cores_per_replica }},"nodesPerReplica":{{ dns_nodes_per_replica }},"min":{{ dns_min_replicas }}}}
         - --logtostderr=true
         - --v=2
-        - --configmap=dns-autoscaler{% if dns_mode in ['coredns', 'coredns_dual'] coredns_ordinal_suffix | default('') endif %}
+        - --configmap=dns-autoscaler{%- if dns_mode in ['coredns', 'coredns_dual'] -%}{{ coredns_ordinal_suffix | default('') }}{%- endif -%}
 {% if dns_mode in ['coredns', 'coredns_dual'] %}
         - --target=Deployment/coredns{{ coredns_ordinal_suffix | default('') }}
 {% endif %}


### PR DESCRIPTION
When using `coredns_dual` the dns autoscale deployment is overwritten.