### PR TITLE
fix `dns_prevent_single_point_failure` variable

### DIFF
--- a/roles/kubernetes-apps/ansible/defaults/main.yml
+++ b/roles/kubernetes-apps/ansible/defaults/main.yml
@@ -10,7 +10,7 @@ dns_memory_requests: 70Mi
 dns_min_replicas: 2
 dns_nodes_per_replica: 10
 dns_cores_per_replica: 20
-dns_prevent_single_point_failure: "{{ 'true' if dns_min_replicas > '1' else 'false' }}"
+dns_prevent_single_point_failure: "{{ 'true' if dns_min_replicas > 1 else 'false' }}"
 
 # Images
 image_arch: "{{host_architecture}}"


### PR DESCRIPTION
comparison that happens during `TASK [kubernetes-apps/ansible : Kubernetes Apps | Lay Down CoreDNS Template]` where the `dns-autoscaler` template is deployed causes coredns to fail deployment.  The error is caused by the variable `dns_prevent_single_point_failure` where an integer is being compared with a string. The resulting error:

```bash
'>' not supported between instances of 'int' and 'str'
```

prevents successful deployment of CoreDNS.  

The change makes the comparison happen between integers and allows CoreDNS to succeed.
Fixes: https://github.com/kubernetes-incubator/kubespray/pull/3728