### PR TITLE
fix modify deprecated --graph flag

### DIFF
--- a/inventory/sample/group_vars/all/docker.yml
+++ b/inventory/sample/group_vars/all/docker.yml
@@ -57,7 +57,11 @@ docker_options: >-
   {% if docker_registry_mirrors is defined -%}
   {{ docker_registry_mirrors | map('regex_replace', '^(.*)$', '--registry-mirror=\1' ) | list | join(' ') }}
   {%- endif %}
+  {%- if docker_version is version('17.05', '<') -%}
   --graph={{ docker_daemon_graph }} {{ docker_log_opts }}
+  {%- else -%}
+  --data-root={{ docker_daemon_graph }} {{ docker_log_opts }}
+  {%- endif %}
   {%- if ansible_architecture == "aarch64" and ansible_os_family == "RedHat" %}
   --add-runtime docker-runc=/usr/libexec/docker/docker-runc-current
   --default-runtime=docker-runc --exec-opt native.cgroupdriver=systemd

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -213,7 +213,11 @@ docker_options: >-
   {% if docker_registry_mirrors is defined -%}
   {{ docker_registry_mirrors | map('regex_replace', '^(.*)$', '--registry-mirror=\1' ) | list | join(' ') }}
   {%- endif %}
+  {%- if docker_version is version('17.05', '<') -%}
   --graph={{ docker_daemon_graph }} {{ docker_log_opts }}
+  {%- else -%}
+  --data-root={{ docker_daemon_graph }} {{ docker_log_opts }}
+  {%- endif %}
   {%- if ansible_architecture == "aarch64" and ansible_os_family == "RedHat" %}
   --add-runtime docker-runc=/usr/libexec/docker/docker-runc-current
   --default-runtime=docker-runc --exec-opt native.cgroupdriver=systemd


### PR DESCRIPTION
Dear,
The '-g' or '--graph' flag for the dockerd or docker daemon command was used to indicate the directory in which to store persistent data and resource configuration and has been replaced with the more descriptive --data-root flag. They are deprecated in release: v17.05.0.
These flags were added before Docker 1.0, so will not be removed, only hidden, to discourage their use.
When we run the command: dockerd -h，we can see '--data-root' instead of '--graph'.
So, we should modify it.
Thanks! 