### PR TITLE
Fix OpenSuse set hostname

### DIFF
--- a/roles/bootstrap-os/tasks/main.yml
+++ b/roles/bootstrap-os/tasks/main.yml
@@ -58,15 +58,14 @@
     name: "{{inventory_hostname}}"
   when:
     - override_system_hostname
-    - ansible_distribution not in ['openSUSE Tumbleweed']
-    - ansible_os_family not in ['CoreOS', 'Container Linux by CoreOS']
+    - ansible_os_family not in ['Suse', 'CoreOS', 'Container Linux by CoreOS']
 
 - name: Assign inventory name to unconfigured hostnames (CoreOS and Tumbleweed only)
   command: "hostnamectl set-hostname  {{inventory_hostname}}"
   register: hostname_changed
   when:
-    - ansible_distribution in ['openSUSE Tumbleweed'] or ansible_os_family in ['CoreOS', 'Container Linux by CoreOS']
     - override_system_hostname
+    - ansible_os_family in ['Suse', 'CoreOS', 'Container Linux by CoreOS']
 
 - name: Update hostname fact (CoreOS and Tumbleweed only)
   setup:


### PR DESCRIPTION
fatal: [k8s-36833764-121764291-1]: FAILED! => {"changed": false, "msg": "hostname module cannot be used on platform Linux ()"}
fatal: [k8s-36833764-121764291-2]: FAILED! => {"changed": false, "msg": "hostname module cannot be used on platform Linux ()"}