### PR TITLE
Add support to set tolerations for ingress-nginx

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster/addons.yml
+++ b/inventory/sample/group_vars/k8s-cluster/addons.yml
@@ -45,6 +45,11 @@ ingress_nginx_enabled: false
 # ingress_nginx_host_network: false
 # ingress_nginx_nodeselector:
 #   node-role.kubernetes.io/master: ""
+# ingress_nginx_tolerations:
+#   - key: "key"
+#     operator: "Equal"
+#     value: "value"
+#     effect: "NoSchedule"
 # ingress_nginx_namespace: "ingress-nginx"
 # ingress_nginx_insecure_port: 80
 # ingress_nginx_secure_port: 443

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/defaults/main.yml
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/defaults/main.yml
@@ -3,6 +3,7 @@ ingress_nginx_namespace: "ingress-nginx"
 ingress_nginx_host_network: false
 ingress_nginx_nodeselector:
   node-role.kubernetes.io/master: ""
+ingress_nginx_tolerations: []
 ingress_nginx_insecure_port: 80
 ingress_nginx_secure_port: 443
 ingress_nginx_configmap: {}

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ds-ingress-nginx-controller.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ds-ingress-nginx-controller.yml.j2
@@ -29,6 +29,10 @@ spec:
       nodeSelector:
         {{ ingress_nginx_nodeselector | to_nice_yaml }}
 {%- endif %}
+{% if ingress_nginx_tolerations %}
+      tolerations:
+        {{ ingress_nginx_tolerations | to_nice_yaml(indent=2) | indent(width=8) }}
+{%- endif %}
 {% if kube_version is version('v1.11.1', '>=') %}
       priorityClassName: {% if ingress_nginx_namespace == 'kube-system' %}system-node-critical{% else %}k8s-cluster-critical{% endif %}{{''}}
 {% endif %}


### PR DESCRIPTION
Introduced variable `ingress_nginx_tolerations` to set custom tolerations for Ingress nginx daemonset, to be able to schedule ingress-nginx on dedicated nodes with taints.