### PR TITLE
sysctl related PodSecurityPolicy spec since 1.12

### DIFF
--- a/roles/kubernetes-apps/cluster_roles/templates/psp.yml.j2
+++ b/roles/kubernetes-apps/cluster_roles/templates/psp.yml.j2
@@ -43,6 +43,10 @@ spec:
       - min: 1
         max: 65535
   readOnlyRootFilesystem: false
+{% if kube_version is version('v1.12.1', '>=') %}
+  forbiddenSysctls:
+  - '*'
+{% endif %}
 ---
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
@@ -75,3 +79,8 @@ spec:
   fsGroup:
     rule: 'RunAsAny'
   readOnlyRootFilesystem: false
+{% if kube_version is version('v1.12.1', '>=') %}
+  # This will fail if allowed-unsafe-sysctls is not set accordingly in kubelet flags
+  allowedUnsafeSysctls:
+  - '*'
+{% endif %}


### PR DESCRIPTION
Addition of `forbiddenSysctls` and `allowedUnsafeSysctls` to respectively restricted and privileged psp (both of them set to "*" i.e. no sysctl allowed in NS other than kube-system, unsafe sysctls allowed in kube-system - if allowed-unsafe-sysctls is passed to kubelet).
