### PR TITLE
Fix dns-autoscaler nodeAffinity: set to empty

### DIFF
--- a/roles/kubernetes-apps/ansible/templates/dns-autoscaler.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/dns-autoscaler.yml.j2
@@ -58,7 +58,7 @@ spec:
               - key: node-role.kubernetes.io/master
                 operator: In
                 values:
-                - "true"
+                - ""
       containers:
       - name: autoscaler
         image: "{{ dnsautoscaler_image_repo }}:{{ dnsautoscaler_image_tag }}"


### PR DESCRIPTION
Found error with nodeAffinity for dns-autoscaler deployment. This fix will run it on master node.