### PR TITLE
Fix Sync Container Permission

### DIFF
--- a/roles/download/tasks/sync_container.yml
+++ b/roles/download/tasks/sync_container.yml
@@ -97,7 +97,7 @@
     mode: push
   delegate_to: localhost
   delegate_facts: no
-  become: false
+  become: true
   register: get_task
   until: get_task is succeeded
   retries: 4


### PR DESCRIPTION
When `ansible_user` is not root, using `-b` option.
And with `download_run_once` and `download_localhost` set `true`.

Ansible will executes `container_download | upload container images to nodes` task.

It uses rsync to upload images to `/tmp/release/container/`, but the
`container` directory owned by `root` that make installation abort with permission problem.