### PR TITLE
Fix AWS Node Labels Error

### DIFF
--- a/contrib/aws_inventory/kubespray-aws-inventory.py
+++ b/contrib/aws_inventory/kubespray-aws-inventory.py
@@ -45,24 +45,28 @@ class SearchEC2Tags(object):
 
       instances = ec2.instances.filter(Filters=[{'Name': 'tag:'+tag_key, 'Values': tag_value}, {'Name': 'instance-state-name', 'Values': ['running']}])
       for instance in instances:
-        node_labels_tag = list(filter(lambda t: t['Key'] == 'kubespray-node-labels', instance.tags))
-        node_labels = ''
-        if node_labels_tag:
-          node_labels = dict([ label.strip().split('=') for label in node_labels_tag[0]['Value'].split(',') ])
 
+        ##Suppose default vpc_visibility is private
+        dns_name = instance.private_dns_name
+        ansible_host = {
+          'ansible_ssh_host': instance.private_ip_address
+        }
+
+        ##Override when vpc_visibility actually is public
         if self.vpc_visibility == "public":
-          hosts[group].append(instance.public_dns_name)
-          hosts['_meta']['hostvars'][instance.public_dns_name] = {
-             'ansible_ssh_host': instance.public_ip_address,
-             'node_labels': node_labels
-          }
-        else:
-          hosts[group].append(instance.private_dns_name)
-          hosts['_meta']['hostvars'][instance.private_dns_name] = {
-             'ansible_ssh_host': instance.private_ip_address,
-             'node_labels': node_labels
+          dns_name = instance.public_dns_name
+          ansible_host = {
+            'ansible_ssh_host': instance.public_ip_address
           }
 
+        ##Set when instance actually has node_labels
+        node_labels_tag = list(filter(lambda t: t['Key'] == 'kubespray-node-labels', instance.tags))
+        if node_labels_tag:
+          ansible_host['node_labels'] = dict([ label.strip().split('=') for label in node_labels_tag[0]['Value'].split(',') ])
+
+        hosts[group].append(dns_name)
+        hosts['_meta']['hostvars'][dns_name] = ansible_host
+        
     hosts['k8s-cluster'] = {'children':['kube-master', 'kube-node']}
     print(json.dumps(hosts, sort_keys=True, indent=2))
 

--- a/roles/kubernetes/node/templates/kubelet.kubeadm.env.j2
+++ b/roles/kubernetes/node/templates/kubelet.kubeadm.env.j2
@@ -89,7 +89,7 @@ KUBELET_HOSTNAME="--hostname-override={{ kube_override_hostname }}"
 {%   set dummy = role_node_labels.append("node-role.kubernetes.io/node=''") %}
 {% endif %}
 {% set inventory_node_labels = [] %}
-{% if node_labels is defined %}
+{% if node_labels is defined and node_labels is mapping %}
 {%   for labelname, labelvalue in node_labels.items() %}
 {%     set dummy = inventory_node_labels.append('%s=%s'|format(labelname, labelvalue)) %}
 {%   endfor %}

--- a/roles/kubernetes/node/templates/kubelet.standard.env.j2
+++ b/roles/kubernetes/node/templates/kubelet.standard.env.j2
@@ -108,7 +108,7 @@ KUBELET_HOSTNAME="--hostname-override={{ kube_override_hostname }}"
 {%   endif %}
 {% endif %}
 {% set inventory_node_labels = [] %}
-{% if node_labels is defined %}
+{% if node_labels is defined and node_labels is mapping %}
 {%   for labelname, labelvalue in node_labels.items() %}
 {%     set dummy = inventory_node_labels.append('%s=%s'|format(labelname, labelvalue)) %}
 {%   endfor %}


### PR DESCRIPTION
Now the `kubespray-aws-inventory.py` script always set a node_labels key
to ansible_host.

When AWS instance did not set property labels, it would be an empty
string.

The TASK `Write kubelet config file (kubeadm or non-kubeadm)` will
failed with a msg:

`AnsibleUndefinedVariable: 'unicode object' has no attribute 'items'`.

This may fix #3739 