### PR TITLE
Update defaults to match k8s 1.12 suggestions

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s-cluster/k8s-cluster.yml
@@ -89,13 +89,13 @@ kube_network_node_prefix: 24
 # The port the API Server will be listening on.
 kube_apiserver_ip: "{{ kube_service_addresses|ipaddr('net')|ipaddr(1)|ipaddr('address') }}"
 kube_apiserver_port: 6443 # (https)
-kube_apiserver_insecure_port: 8080 # (http)
+#kube_apiserver_insecure_port: 8080 # (http)
 # Set to 0 to disable insecure port - Requires RBAC in authorization_modes and kube_api_anonymous_auth: true
-#kube_apiserver_insecure_port: 0 # (disabled)
+kube_apiserver_insecure_port: 0 # (disabled)
 
 # Kube-proxy proxyMode configuration.
 # Can be ipvs, iptables
-kube_proxy_mode: iptables
+kube_proxy_mode: ipvs
 
 # Kube-proxy nodeport address.
 # cidr to bind nodeport services. Flag --nodeport-addresses on kube-proxy manifest
@@ -111,7 +111,7 @@ cluster_name: cluster.local
 # Subdomains of DNS domain to be resolved via /etc/resolv.conf for hostnet pods
 ndots: 2
 # Can be dnsmasq_kubedns, kubedns, coredns, coredns_dual, manual or none
-dns_mode: kubedns
+dns_mode: coredns
 # Set manual server if using a custom cluster DNS server
 #manual_dns_server: 10.x.x.x
 

--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -18,7 +18,7 @@ kube_resolv_conf: "/etc/resolv.conf"
 kube_proxy_healthz_bind_address: "127.0.0.1"
 
 # Can be ipvs, iptables
-kube_proxy_mode: iptables
+kube_proxy_mode: ipvs
 
 # If using the pure iptables proxy, SNAT everything. Note that it breaks any
 # policy engine.

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -142,7 +142,7 @@ kube_apiserver_bind_address: 0.0.0.0
 kube_apiserver_port: 6443
 # http
 kube_apiserver_insecure_bind_address: 127.0.0.1
-kube_apiserver_insecure_port: 8080
+kube_apiserver_insecure_port: 0
 
 # dynamic kubelet configuration
 dynamic_kubelet_configuration: false

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -44,7 +44,7 @@ cluster_name: cluster.local
 # Subdomains of DNS domain to be resolved via /etc/resolv.conf for hostnet pods
 ndots: 2
 # Can be dnsmasq_kubedns, kubedns, manual or none
-dns_mode: kubedns
+dns_mode: coredns
 
 # Should be set to a cluster IP if using a custom cluster DNS
 # manual_dns_server: 10.x.x.x

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -15,7 +15,7 @@ disable_swap: true
 kube_version: v1.12.2
 
 ## Kube Proxy mode One of ['iptables','ipvs']
-kube_proxy_mode: iptables
+kube_proxy_mode: ipvs
 
 # Kube-proxy nodeport address.
 # cidr to bind nodeport services. Flag --nodeport-addresses on kube-proxy manifest

--- a/tests/testcases/040_check-network-adv.yml
+++ b/tests/testcases/040_check-network-adv.yml
@@ -42,7 +42,7 @@
       delay: 10
 
     - name: Get netchecker agents
-      uri: url=http://localhost:{{netchecker_port}}/api/v1/agents/ return_content=yes
+      uri: url=http://{{ ansible_default_ipv4.address }}:{{netchecker_port}}/api/v1/agents/ return_content=yes
       run_once: true
       delegate_to: "{{groups['kube-master'][0]}}"
       register: agents
@@ -59,7 +59,7 @@
       run_once: true
 
     - name: Check netchecker status
-      uri: url=http://localhost:{{netchecker_port}}/api/v1/connectivity_check status_code=200 return_content=yes
+      uri: url=http://{{ ansible_default_ipv4.address }}:{{netchecker_port}}/api/v1/connectivity_check status_code=200 return_content=yes
       delegate_to: "{{groups['kube-master'][0]}}"
       run_once: true
       register: result


### PR DESCRIPTION
With k8s 1.12 as default now, let's update several defaults as well.

Possible fixes #3465 too