### PR TITLE
Fix kubeadm-config: add kube_network_node_prefix

### DIFF
--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha1.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha1.yaml.j2
@@ -20,6 +20,7 @@ networking:
   dnsDomain: {{ dns_domain }}
   serviceSubnet: {{ kube_service_addresses }}
   podSubnet: {{ kube_pods_subnet }}
+  podNetworkCidr: "{{ kube_network_node_prefix }}"
 kubernetesVersion: {{ kube_version }}
 {% if cloud_provider is defined and cloud_provider not in ["gce", "oci"] %}
 cloudProvider: {{ cloud_provider }}

--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha2.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha2.yaml.j2
@@ -21,6 +21,7 @@ networking:
   dnsDomain: {{ dns_domain }}
   serviceSubnet: {{ kube_service_addresses }}
   podSubnet: {{ kube_pods_subnet }}
+  podNetworkCidr: "{{ kube_network_node_prefix }}"
 kubernetesVersion: {{ kube_version }}
 {% if cloud_provider is defined and cloud_provider != "gce" %}
 cloudProvider: {{ cloud_provider }}

--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha3.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha3.yaml.j2
@@ -36,6 +36,7 @@ networking:
   dnsDomain: {{ dns_domain }}
   serviceSubnet: {{ kube_service_addresses }}
   podSubnet: {{ kube_pods_subnet }}
+  podNetworkCidr: "{{ kube_network_node_prefix }}"
 kubernetesVersion: {{ kube_version }}
 {% if groups['kube-master'] | length > 1 and kubeadm_config_api_fqdn is defined %}
 controlPlaneEndpoint: {{ kubeadm_config_api_fqdn }}:{{ loadbalancer_apiserver.port | default(kube_apiserver_port) }}


### PR DESCRIPTION
Option kube_network_node_prefix should be added in network section of kubeadm-config. It will be passed to kube-controller-manager as node-cidr-mask-size option.