### PR TITLE
Fix node selector for contiv etcd proxy

### DIFF
--- a/roles/network_plugin/contiv/templates/contiv-etcd-proxy.yml.j2
+++ b/roles/network_plugin/contiv/templates/contiv-etcd-proxy.yml.j2
@@ -23,7 +23,7 @@ spec:
       hostNetwork: true
       hostPID: true
       nodeSelector:
-        node-role.kubernetes.io/node: "true"
+        node-role.kubernetes.io/node: ""
       containers:
         - name: contiv-etcd-proxy
           image: {{ contiv_etcd_image_repo }}:{{ contiv_etcd_image_tag }}


### PR DESCRIPTION
`node-role.kubernetes.io/node` label is not set to true anymore. Contiv-etcd-proxy daemonset uses it and should be modified